### PR TITLE
lint: handle deferred closes

### DIFF
--- a/rds-kpi-collector-poc/flags.go
+++ b/rds-kpi-collector-poc/flags.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 )
 
-// setupFlags parses and validates command line flags, returns InputFlags struct
-func setupFlags() (InputFlags, error) {
+// SetupFlags parses and validates command line flags, returns InputFlags struct
+func SetupFlags() (InputFlags, error) {
 	var flags InputFlags
 
 	flag.StringVar(&flags.BearerToken, "token", "", "bearer token for thanos-queries")

--- a/rds-kpi-collector-poc/main.go
+++ b/rds-kpi-collector-poc/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"os"
 )
 
@@ -10,7 +11,7 @@ func main() {
 	fmt.Println("RDS KPI Collector starting...")
 
 	// Setup flags
-	flags, err := setupFlags()
+	flags, err := SetupFlags()
 	if err != nil {
 		fmt.Printf("Error: %v\n", err)
 		return
@@ -52,7 +53,11 @@ func loadKPIs() (KPIs, error) {
 	if err != nil {
 		return KPIs{}, fmt.Errorf("failed to open kpis.json: %v", err)
 	}
-	defer kpisFile.Close()
+	defer func() {
+		if err := kpisFile.Close(); err != nil {
+			log.Printf("failed to close kpis.json: %v", err)
+		}
+	}()
 
 	var kpis KPIs
 	decoder := json.NewDecoder(kpisFile)

--- a/rds-kpi-collector-poc/prometheus_client.go
+++ b/rds-kpi-collector-poc/prometheus_client.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"database/sql"
 	"fmt"
+	"log"
 	"net/http"
 	"time"
 
@@ -51,7 +52,11 @@ func runQueries(kpisToRun KPIs, flags InputFlags) error {
 	if err != nil {
 		return fmt.Errorf("failed to init database: %v", err)
 	}
-	defer db.Close()
+	defer func() {
+		if err := db.Close(); err != nil {
+			log.Printf("failed to close database: %v", err)
+		}
+	}()
 
 	// Get or create cluster in DB
 	clusterID, err := database.GetOrCreateCluster(db, flags.ClusterName)


### PR DESCRIPTION
- Capitalized SetupFlags to make it accessible outside the package.

-  Wrapped kpisFile.Close() and db.Close() in deferred funcs with error logging.

-  Keeps context cancel defer as-is.

- Ensures lint compliance and proper resource cleanup.
