### PR TITLE
Offline AI Analysis for Grafana Dashboard Exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,3 +276,32 @@ kpi-collection-tool/
 - grafana/datasource → Datasource YAML files
 - grafana/dashboard → Dashboard JSON files
 - Makefile → Automates running Grafana locally
+
+## Grafana AI Analyzer
+
+This tool provides offline AI-based summarization for exported Grafana dashboards. You can generate structured insights using a locally installed AI model.
+
+### Usage
+
+After building or running the `rds-kpi-collector`, use the following command to analyze a Grafana JSON export:
+
+```bash
+go run ./cmd/rds-kpi-collector \
+  --cluster-name=<your-cluster> \
+  --duration=10m \
+  --frequency=30 \
+  --kubeconfig=<path-to-kubeconfig> \
+  --summarize \
+  --grafana-file=<path-to-exported-grafana.json> \
+  --ollama-model=llama3.2:latest
+Flags:
+
+--grafana-file – path to the exported Grafana dashboard JSON.
+
+--summarize – triggers the AI summarization process.
+
+--ollama-model – choose any local Ollama model (default: llama3.2:latest).
+
+The AI summary and metadata will be saved in the out/ directory and printed to stdout.
+
+Note: The selected AI model must be installed locally, support text generation, and be capable enough to produce meaningful summaries.

--- a/cmd/rds-kpi-collector/main.go
+++ b/cmd/rds-kpi-collector/main.go
@@ -12,6 +12,7 @@ import (
 	"rds-kpi-collector/internal/kubernetes"
 	"rds-kpi-collector/internal/logger"
 	"rds-kpi-collector/internal/prometheus"
+	"rds-kpi-collector/internal/grafana_ai"
 )
 
 func main() {
@@ -62,6 +63,16 @@ func main() {
 	runCollectionLoop(kpis, flags)
 
 	fmt.Println("All queries completed successfully!")
+
+	if flags.Summarize && flags.GrafanaFile != "" {
+    log.Println("Starting Grafana AI Analysis...")
+    if err := grafana_ai.Run(flags); err != nil {
+        log.Printf("Grafana AI analysis failed: %v\n", err)
+    } else {
+        log.Println("Grafana AI analysis finished.")
+    }
+}
+
 
 }
 

--- a/internal/config/cli_flags.go
+++ b/internal/config/cli_flags.go
@@ -22,6 +22,11 @@ func SetupFlags() (InputFlags, error) {
 	flag.StringVar(&flags.LogFile, "log", "kpi.log", "log file name")
 	flag.StringVar(&flags.DatabaseType, "db-type", "sqlite", "database type: sqlite or postgres (default: sqlite)")
 	flag.StringVar(&flags.PostgresURL, "postgres-url", "", "PostgreSQL connection string (required if db-type=postgres)")
+	
+	flag.StringVar(&flags.GrafanaFile, "grafana-file", "", "path to exported Grafana dashboard JSON to analyze")
+	flag.BoolVar(&flags.Summarize, "summarize", false, "run Grafana AI summarization after KPI collection")
+	flag.StringVar(&flags.AIModel, "ollama-model", "llama3.2:latest", "local Ollama model to use")
+
 	flag.Parse()
 
 	err := validateFlags(flags)

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -15,6 +15,10 @@ type InputFlags struct {
 	LogFile      string
 	DatabaseType string // "sqlite" or "postgres"
 	PostgresURL  string // PostgreSQL connection string
+	GrafanaFile  string // path to grafana_exported.json
+	Summarize    bool   // whether to run Grafana AI summarization
+	AIModel      string // local Ollama model to use 
+	
 }
 
 // KPIs represents the structure of the kpis.json file containing

--- a/internal/grafana_ai/analyzer.go
+++ b/internal/grafana_ai/analyzer.go
@@ -1,0 +1,70 @@
+package grafana_ai
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"rds-kpi-collector/internal/config"
+)
+
+func Run(flags config.InputFlags) error {
+	// Parse the Grafana dashboard JSON
+	dash, err := ParseGrafanaFile(flags.GrafanaFile)
+	if err != nil {
+		return fmt.Errorf("parse grafana file: %w", err)
+	}
+
+	// Extract basic statistics from the dashboard
+	stats := ExtractBasicStats(dash)
+
+	// Build prompt for Ollama AI
+	prompt := BuildPrompt(dash, stats, nil)
+
+	model := flags.AIModel
+	if model == "" {
+		model = "llama3.2:latest"
+	}
+
+	// Run Ollama locally
+	cmd := exec.Command("ollama", "run", model)
+	cmd.Stdin = bytes.NewBufferString(prompt)
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("ollama run failed: %w (output: %s)", err, string(out))
+	}
+
+	// Ensure output directory exists
+	outDir := "out"
+	_ = os.MkdirAll(outDir, 0755)
+
+	// Save AI summary text file
+	ts := time.Now().Format("20060102_150405")
+	txtPath := filepath.Join(outDir, fmt.Sprintf("summary_%s.txt", ts))
+	_ = os.WriteFile(txtPath, out, 0644)
+
+	// Save meta JSON
+	meta := map[string]interface{}{
+		"generated_at": time.Now().Format(time.RFC3339),
+		"dashboard": map[string]interface{}{
+			"title":   dash.Title,
+			"panels":  stats.PanelCount,
+			"queries": stats.QueryCount,
+		},
+		"ollama_model": model,
+	}
+	if jb, err := json.MarshalIndent(meta, "", "  "); err == nil {
+		_ = os.WriteFile(filepath.Join(outDir, fmt.Sprintf("summary_%s.meta.json", ts)), jb, 0644)
+	}
+
+	fmt.Println("===== Grafana AI Analysis =====")
+	fmt.Println(string(out))
+	fmt.Printf("\nSaved: %s\n", txtPath)
+
+	return nil
+}

--- a/internal/grafana_ai/parser.go
+++ b/internal/grafana_ai/parser.go
@@ -1,0 +1,79 @@
+package grafana_ai
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+type Panel struct {
+	Title      string   `json:"title"`
+	Type       string   `json:"type"`
+	Datasource string   `json:"datasource,omitempty"`
+	RawSQL     []string `json:"raw_sql,omitempty"`
+}
+
+type Dashboard struct {
+	Title   string                 `json:"title"`
+	Panels  []Panel                `json:"panels"`
+	RawJSON map[string]interface{} `json:"-"`
+}
+
+func ParseGrafanaFile(path string) (*Dashboard, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read grafana file: %w", err)
+	}
+
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("unmarshal grafana json: %w", err)
+	}
+
+	d := &Dashboard{
+		Title:   "",
+		RawJSON: raw,
+	}
+
+	if t, ok := raw["title"].(string); ok {
+		d.Title = t
+	}
+
+	if panelsRaw, ok := raw["panels"].([]interface{}); ok {
+		for _, p := range panelsRaw {
+			pm, ok := p.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			panel := Panel{}
+			if v, ok := pm["title"].(string); ok {
+				panel.Title = v
+			}
+			if v, ok := pm["type"].(string); ok {
+				panel.Type = v
+			}
+
+			if targets, ok := pm["targets"].([]interface{}); ok {
+				for _, t := range targets {
+					if tm, ok := t.(map[string]interface{}); ok {
+						if ds, ok := tm["datasource"].(string); ok {
+							panel.Datasource = ds
+						} else if dsObj, ok := tm["datasource"].(map[string]interface{}); ok {
+							if n, ok := dsObj["type"].(string); ok {
+								panel.Datasource = n
+							}
+						}
+						if rawSql, ok := tm["rawSql"].(string); ok {
+							panel.RawSQL = append(panel.RawSQL, rawSql)
+						}
+					}
+				}
+			}
+
+			d.Panels = append(d.Panels, panel)
+		}
+	}
+
+	return d, nil
+}
+

--- a/internal/grafana_ai/stats.go
+++ b/internal/grafana_ai/stats.go
@@ -1,0 +1,30 @@
+package grafana_ai
+
+type DashboardStats struct {
+	PanelCount    int               `json:"panel_count"`
+	QueryCount    int               `json:"query_count"`
+	DatasourceMap map[string]int    `json:"datasource_usage"`
+	KPIsDetected  []string          `json:"kpis_detected,omitempty"`
+	ErrorsPresent bool              `json:"errors_present"`
+	Extra         map[string]interface{} `json:"extra,omitempty"`
+}
+
+func ExtractBasicStats(d *Dashboard) DashboardStats {
+	st := DashboardStats{
+		PanelCount:    len(d.Panels),
+		DatasourceMap: map[string]int{},
+		Extra:         map[string]interface{}{},
+	}
+
+	qc := 0
+	for _, p := range d.Panels {
+		if len(p.RawSQL) > 0 {
+			qc += len(p.RawSQL)
+		}
+		if p.Datasource != "" {
+			st.DatasourceMap[p.Datasource]++
+		}
+	}
+	st.QueryCount = qc
+	return st
+}

--- a/internal/grafana_ai/summarizer.go
+++ b/internal/grafana_ai/summarizer.go
@@ -1,0 +1,53 @@
+package grafana_ai
+
+import (
+	"fmt"
+	"strings"
+)
+
+func BuildPrompt(d *Dashboard, stats DashboardStats, kpiData map[string]interface{}) string {
+	var b strings.Builder
+
+	b.WriteString("You are an offline data analyst specialized in Grafana dashboards for KPI monitoring.\n")
+	b.WriteString("Context: This dashboard uses SQLite datasource with query_results, query_errors, clusters.\n\n")
+
+	b.WriteString("Dashboard metadata:\n")
+	b.WriteString(fmt.Sprintf("- Title: %s\n", d.Title))
+	b.WriteString(fmt.Sprintf("- Panels: %d\n", stats.PanelCount))
+	b.WriteString(fmt.Sprintf("- Queries (estimated): %d\n", stats.QueryCount))
+	b.WriteString(fmt.Sprintf("- Datasources: %v\n\n", stats.DatasourceMap))
+
+	b.WriteString("Panels detail:\n")
+	for i, p := range d.Panels {
+		b.WriteString(fmt.Sprintf("%d) %s [%s] datasource=%s\n", i+1, p.Title, p.Type, p.Datasource))
+		for _, sql := range p.RawSQL {
+			sn := sql
+			if len(sn) > 200 {
+				sn = sn[:200] + "..."
+			}
+			b.WriteString(fmt.Sprintf("  - SQL: %s\n", sn))
+		}
+	}
+
+	if kpiData != nil {
+		b.WriteString("\nProvided sample KPI data (summary):\n")
+		for k, v := range kpiData {
+			switch vv := v.(type) {
+			case []interface{}:
+				b.WriteString(fmt.Sprintf("- %s : %d samples\n", k, len(vv)))
+			default:
+				b.WriteString(fmt.Sprintf("- %s : type=%T\n", k, vv))
+			}
+		}
+		b.WriteString("\n")
+	}
+
+	b.WriteString("\nTasks:\n")
+	b.WriteString("1) Provide a concise high-level summary of what this dashboard monitors.\n")
+	b.WriteString("2) Highlight potential issues suggested by queries or panel types.\n")
+	b.WriteString("3) Identify unstable KPIs or KPIs with high execution time (if KPI data provided).\n")
+	b.WriteString("4) Provide recommended next steps (alerts, aggregation, SQL improvements).\n")
+	b.WriteString("\nResponse format: Summary, Insights, Detected Issues, Suggested Actions.\n")
+
+	return b.String()
+}


### PR DESCRIPTION
This PR introduces an offline AI-based summarization flow that analyzes exported Grafana dashboard JSON files and produces structured insights using a locally installed AI model.

### New Grafana AI Module (internal/grafana_ai/)

A new modular pipeline was added for parsing dashboards, extracting metadata, generating analysis prompts, and running local AI inference.

1. **parser.go**

     Loads exported Grafana dashboard JSON.
     Extracts title, panels, datasources, and SQL queries into normalized structures.

2. **stats.go**

     Computes dashboard statistics: panel count, estimated query count, datasource usage.

3. **summarizer.go**

     Builds a structured prompt for the AI model based on parsed data and statistics.

4. **analyzer.go**

     Manages the analysis workflow: parses the dashboard, collects statistics, builds the AI prompt, runs the local model 
     (ollama run), and saves the summary and metadata to out/.

### CLI Enhancements

Three new flags enable the feature:

--grafana-file – path to exported Grafana JSON

--summarize – triggers AI analysis

--ollama-model – choose any installed local model (default: llama3.2:latest)

main.go now runs the analysis automatically when both --summarize and --grafana-file are provided.

### AI Model Requirements

- The default model is llama3.2:latest, but users may select any local model.

- To ensure high-quality output, the chosen model must:

    1. Be installed locally
    2. Support text generation
    3. Be sufficiently capable (not a tiny or embedding-only model)

**Offline Operation**

The entire workflow—parsing, analysis, and AI inference—runs locally with no internet access, suitable for disconnect enviornaments

