### PR TITLE
Add --insecure-tls flag documentation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,28 @@ Provide Thanos URL and bearer token directly.
   --db-type postgres \
   --postgres-url "postgresql://myuser:mypass@localhost:5432/kpi_metrics?sslmode=disable"
 ```
+## --insecure-tls
+
+Use this flag when running the tool against clusters or Prometheus/Thanos servers with self-signed or untrusted certificates.
+
+```bash
+./kpi-collector \
+  --cluster-name my-cluster \
+  --kubeconfig ~/.kube/config \
+  --insecure-tls
+```  
+### What it does
+- Skips TLS certificate verification for all HTTPS requests:
+- Kubernetes API calls
+- Thanos/Prometheus queries
+- Allows execution in environments where the certificate cannot be validated.
+
+### When to use
+- Self-signed certificates
+- Disconnected / lab / air-gapped clusters
+- kubeconfig without a valid CA
+- TLS errors such as:
+  x509: certificate signed by unknown authority
 
 ### Complete Examples
 


### PR DESCRIPTION
This PR adds a new section to the README explaining the purpose, usage, and
recommended scenarios for the `--insecure-tls flag`. 
The documentation clarifies when the flag should be used (self-signed certificates, disconnected or
lab environments) and what behavior it changes in the collector (skipping TLS
verification for Kubernetes API and Prometheus/Thanos requests).
