### PR TITLE
Add new filters (pod, node, container, job) to SQLite dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -583,9 +583,25 @@ kpi-collector grafana --datasource=postgres \
 
 ## Dashboard Features
 
+### Dashboard Filters
+The dashboard includes filters, supported for both SQLite and PostgreSQL datasources:
+
+- **Cluster Name**
+- **Cluster Type**
+- **KPI**
+
+#### The following new filters are available **only when using SQLite:
+
+- **Node**
+- **Pod**
+- **Job**
+- **Container**
+
+All filters default to **All**.
+
 The dashboard includes:
 
-- **Dynamic KPI Selection:** Choose any KPI from the dropdown
+- **Dynamic Metric Selection:** Choose any metric from the dropdown
 - **Time-series Visualization:** View metric values over time
 - **Statistical Summary:** Average, min, max, sample count
 - **Detailed Metrics Table:** All labels and values

--- a/grafana/dashboard/sqlite-dashboard.json
+++ b/grafana/dashboard/sqlite-dashboard.json
@@ -23,15 +23,17 @@
   "liveNow": false,
   "panels": [
     {
+      "id": 1,
+      "type": "timeseries",
+      "title": "Metric Values Over Time",
       "datasource": {
         "type": "frser-sqlite-datasource",
         "uid": "kpi-datasource"
       },
+      "gridPos": { "h": 10, "w": 18, "x": 0, "y": 0 },
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
+          "color": { "mode": "palette-classic" },
           "custom": {
             "axisCenteredZero": false,
             "axisColorMode": "text",
@@ -41,732 +43,140 @@
             "drawStyle": "line",
             "fillOpacity": 10,
             "gradientMode": "none",
-            "hideFrom": {
-              "tooltip": false,
-              "viz": false,
-              "legend": false
-            },
+            "hideFrom": { "tooltip": false, "viz": false, "legend": false },
             "lineInterpolation": "smooth",
             "lineWidth": 2,
             "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
+            "scaleDistribution": { "type": "linear" },
             "showPoints": "never",
             "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
           },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
+            "steps": [{ "color": "green", "value": null }]
           },
           "unit": "short"
         },
         "overrides": []
       },
-      "gridPos": {
-        "h": 10,
-        "w": 18,
-        "x": 0,
-        "y": 0
-      },
-      "id": 1,
       "options": {
-        "legend": {
-          "calcs": ["last", "mean", "max"],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
+        "legend": { "calcs": ["last", "mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
       },
       "targets": [
         {
-          "datasource": {
-            "type": "frser-sqlite-datasource",
-            "uid": "kpi-datasource"
-          },
           "queryType": "table",
-          "rawQueryText": "SELECT timestamp_value AS time, metric_value, metric_labels FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE kpi_id = '${kpi}' AND ('${cluster}' = '$__all' OR c.cluster_name = '${cluster}') AND timestamp_value >= $__from / 1000 AND timestamp_value < $__to / 1000 AND ('${cluster_type}' = '$__all' OR c.cluster_type = '${cluster_type}') ORDER BY time ASC",
+          "rawQueryText": "SELECT timestamp_value AS time, metric_value, metric_labels FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE kpi_id = '${kpi}' AND NOT '${kpi}' = '$__all' AND ('${cluster}' = '$__all' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = '$__all' OR c.cluster_type = '${cluster_type}') AND ('${node}' = '$__all' OR json_extract(metric_labels, '$.node') = '${node}') AND ('${job}' = '$__all' OR json_extract(metric_labels, '$.job') = '${job}') AND ('${pod}' = '$__all' OR json_extract(metric_labels, '$.pod') = '${pod}') AND ('${container}' = '$__all' OR json_extract(metric_labels, '$.container') = '${container}') AND timestamp_value >= $__from / 1000 AND timestamp_value < $__to / 1000 ORDER BY time ASC",
           "refId": "A",
           "timeColumns": ["time", "ts"]
         }
       ],
-      "title": "Metric Values Over Time (Selected KPI: ${kpi})",
-      "type": "timeseries",
       "transformations": [
-        {
-          "id": "extractFields",
-          "options": {
-            "source": "metric_labels",
-            "format": "json",
-            "replace": false,
-            "keepTime": true
-          }
-        },
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "metric_labels": true
-            },
-            "indexByName": {},
-            "renameByName": {}
-          }
-        },
-        {
-          "id": "prepareTimeSeries",
-          "options": {
-            "format": "multi"
-          }
-        }
+        { "id": "extractFields", "options": { "source": "metric_labels", "format": "json", "replace": false, "keepTime": true } },
+        { "id": "organize", "options": { "excludeByName": { "metric_labels": true }, "indexByName": {}, "renameByName": {} } },
+        { "id": "prepareTimeSeries", "options": { "format": "multi" } }
       ]
     },
+
     {
-      "datasource": {
-        "type": "frser-sqlite-datasource",
-        "uid": "kpi-datasource"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 10,
-        "w": 6,
-        "x": 18,
-        "y": 0
-      },
       "id": 2,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "vertical",
-        "reduceOptions": {
-          "values": false,
-          "calcs": ["lastNotNull"],
-          "fields": ""
-        },
-        "textMode": "value_and_name",
-        "showPercentChange": false
-      },
-      "pluginVersion": "10.0.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "frser-sqlite-datasource",
-            "uid": "kpi-datasource"
-          },
-          "queryType": "table",
-          "rawQueryText": "SELECT COUNT(*) as 'Samples', ROUND(AVG(metric_value), 6) as 'Average', ROUND(MIN(metric_value), 6) as 'Minimum', ROUND(MAX(metric_value), 6) as 'Maximum' FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE kpi_id = '${kpi}' AND ('${cluster}' = '$__all' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = '$__all' OR c.cluster_type = '${cluster_type}')",
-          "refId": "A"
-        }
-      ],
-      "title": "KPI Statistics (${kpi})",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "frser-sqlite-datasource",
-        "uid": "kpi-datasource"
-      },
+      "type": "stat",
+      "title": "KPI Statistics Summary",
+      "datasource": { "type": "frser-sqlite-datasource", "uid": "kpi-datasource" },
+      "gridPos": { "h": 10, "w": 6, "x": 18, "y": 0 },
       "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {
-            "align": "auto",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "inspect": false,
-            "filterable": true
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          }
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "avg_value"
-            },
-            "properties": [
-              {
-                "id": "displayName",
-                "value": "Avg Value"
-              },
-              {
-                "id": "custom.width",
-                "value": 120
-              },
-              {
-                "id": "decimals",
-                "value": 6
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "min_value"
-            },
-            "properties": [
-              {
-                "id": "displayName",
-                "value": "Min Value"
-              },
-              {
-                "id": "custom.width",
-                "value": 120
-              },
-              {
-                "id": "decimals",
-                "value": 6
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "max_value"
-            },
-            "properties": [
-              {
-                "id": "displayName",
-                "value": "Max Value"
-              },
-              {
-                "id": "custom.width",
-                "value": 120
-              },
-              {
-                "id": "decimals",
-                "value": 6
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "samples"
-            },
-            "properties": [
-              {
-                "id": "displayName",
-                "value": "Samples"
-              },
-              {
-                "id": "custom.width",
-                "value": 100
-              }
-            ]
-          }
-        ]
+        "defaults": { "color": { "mode": "thresholds" }, "mappings": [], "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] } },
+        "overrides": []
       },
-      "gridPos": {
-        "h": 10,
-        "w": 24,
-        "x": 0,
-        "y": 10
-      },
-      "id": 3,
-      "options": {
-        "showHeader": true,
-        "cellHeight": "sm",
-        "footer": {
-          "show": false,
-          "reducer": ["sum"],
-          "countRows": false,
-          "fields": ""
-        },
-        "sortBy": [
-          {
-            "displayName": "Avg Value",
-            "desc": true
-          }
-        ]
-      },
-      "pluginVersion": "10.0.0",
+      "options": { "colorMode": "background", "graphMode": "none", "justifyMode": "center", "orientation": "vertical", "reduceOptions": { "values": false, "calcs": ["lastNotNull"], "fields": "" }, "textMode": "value_and_name", "showPercentChange": false },
       "targets": [
         {
-          "datasource": {
-            "type": "frser-sqlite-datasource",
-            "uid": "kpi-datasource"
-          },
           "queryType": "table",
-          "rawQueryText": "SELECT metric_labels, ROUND(AVG(metric_value), 6) AS avg_value, ROUND(MIN(metric_value), 6) AS min_value, ROUND(MAX(metric_value), 6) AS max_value, COUNT(*) AS samples FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE kpi_id = '${kpi}' AND ('${cluster}' = '$__all' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = '$__all' OR c.cluster_type = '${cluster_type}') GROUP BY metric_labels ORDER BY avg_value DESC LIMIT 100",
+          "rawQueryText": "SELECT COUNT(*) as 'Samples', ROUND(AVG(metric_value), 6) as 'Average', ROUND(MIN(metric_value), 6) as 'Minimum', ROUND(MAX(metric_value), 6) as 'Maximum' FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE kpi_id = '${kpi}' AND NOT '${kpi}' = '$__all' AND ('${cluster}' = '$__all' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = '$__all' OR c.cluster_type = '${cluster_type}') AND ('${node}' = '$__all' OR json_extract(metric_labels, '$.node') = '${node}') AND ('${job}' = '$__all' OR json_extract(metric_labels, '$.job') = '${job}') AND ('${pod}' = '$__all' OR json_extract(metric_labels, '$.pod') = '${pod}') AND ('${container}' = '$__all' OR json_extract(metric_labels, '$.container') = '${container}')",
           "refId": "A"
-        }
-      ],
-      "title": "Detailed Metrics with All Labels (${kpi})",
-      "type": "table",
-      "transformations": [
-        {
-          "id": "extractFields",
-          "options": {
-            "source": "metric_labels",
-            "format": "json",
-            "replace": true
-          }
         }
       ]
     },
+
     {
-      "datasource": {
-        "type": "frser-sqlite-datasource",
-        "uid": "kpi-datasource"
-      },
+      "id": 3,
+      "type": "table",
+      "title": "Detailed Metrics with All Labels",
+      "datasource": { "type": "frser-sqlite-datasource", "uid": "kpi-datasource" },
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 10 },
       "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "fillOpacity": 80,
-            "gradientMode": "none",
-            "hideFrom": {
-              "tooltip": false,
-              "viz": false,
-              "legend": false
-            },
-            "lineWidth": 1,
-            "scaleDistribution": {
-              "type": "linear"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "yellow",
-                "value": 1
-              },
-              {
-                "color": "red",
-                "value": 5
-              }
-            ]
-          }
-        },
+        "defaults": { "color": { "mode": "thresholds" }, "custom": { "align": "auto", "cellOptions": { "type": "auto" }, "inspect": false, "filterable": true }, "mappings": [], "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] } },
         "overrides": []
       },
-      "gridPos": {
-        "h": 8,
-        "w": 24,
-        "x": 0,
-        "y": 20
-      },
+      "options": { "showHeader": true, "cellHeight": "sm", "sortBy": [{ "displayName": "Avg Value", "desc": true }] },
+      "targets": [
+        {
+          "queryType": "table",
+          "rawQueryText": "SELECT metric_labels, ROUND(AVG(metric_value), 6) AS avg_value, ROUND(MIN(metric_value), 6) AS min_value, ROUND(MAX(metric_value), 6) AS max_value, COUNT(*) AS samples FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = '$__all' OR kpi_id = '${kpi}') AND ('${cluster}' = '$__all' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = '$__all' OR c.cluster_type = '${cluster_type}') AND ('${node}' = '$__all' OR json_extract(metric_labels, '$.node') = '${node}') AND ('${job}' = '$__all' OR json_extract(metric_labels, '$.job') = '${job}') AND ('${pod}' = '$__all' OR json_extract(metric_labels, '$.pod') = '${pod}') AND ('${container}' = '$__all' OR json_extract(metric_labels, '$.container') = '${container}') GROUP BY metric_labels ORDER BY avg_value DESC LIMIT 100",
+          "refId": "A"
+        }
+      ],
+      "transformations": [{ "id": "extractFields", "options": { "source": "metric_labels", "format": "json", "replace": true } }]
+    },
+
+    {
       "id": 5,
-      "options": {
-        "barRadius": 0,
-        "barWidth": 0.97,
-        "fullHighlight": false,
-        "groupWidth": 0.7,
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": false
-        },
-        "orientation": "horizontal",
-        "showValue": "always",
-        "stacking": "none",
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        },
-        "xTickLabelRotation": 0,
-        "xTickLabelSpacing": 0
-      },
-      "pluginVersion": "10.0.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "frser-sqlite-datasource",
-            "uid": "kpi-datasource"
-          },
-          "queryType": "table",
-          "rawQueryText": "SELECT kpi_id AS metric, errors AS value FROM query_errors WHERE errors > 0 ORDER BY errors DESC",
-          "refId": "A"
-        }
-      ],
+      "type": "barchart",
       "title": "Query Errors by KPI",
-      "type": "barchart"
-    },
-    {
-      "datasource": {
-        "type": "frser-sqlite-datasource",
-        "uid": "kpi-datasource"
-      },
+      "datasource": { "type": "frser-sqlite-datasource", "uid": "kpi-datasource" },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 20 },
       "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {
-            "align": "auto",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "inspect": false,
-            "filterable": true
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          }
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "kpi_id"
-            },
-            "properties": [
-              {
-                "id": "displayName",
-                "value": "KPI ID"
-              },
-              {
-                "id": "custom.width",
-                "value": 300
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "sample_count"
-            },
-            "properties": [
-              {
-                "id": "displayName",
-                "value": "Samples"
-              },
-              {
-                "id": "custom.width",
-                "value": 100
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "avg_value"
-            },
-            "properties": [
-              {
-                "id": "displayName",
-                "value": "Avg Value"
-              },
-              {
-                "id": "decimals",
-                "value": 6
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "min_value"
-            },
-            "properties": [
-              {
-                "id": "displayName",
-                "value": "Min Value"
-              },
-              {
-                "id": "decimals",
-                "value": 6
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "max_value"
-            },
-            "properties": [
-              {
-                "id": "displayName",
-                "value": "Max Value"
-              },
-              {
-                "id": "decimals",
-                "value": 6
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "range"
-            },
-            "properties": [
-              {
-                "id": "displayName",
-                "value": "Range"
-              },
-              {
-                "id": "decimals",
-                "value": 6
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "unique_metrics"
-            },
-            "properties": [
-              {
-                "id": "displayName",
-                "value": "Unique Metrics"
-              },
-              {
-                "id": "custom.width",
-                "value": 120
-              }
-            ]
-          }
-        ]
+        "defaults": { "color": { "mode": "thresholds" }, "mappings": [], "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 1 }, { "color": "red", "value": 5 }] } },
+        "overrides": []
       },
-      "gridPos": {
-        "h": 9,
-        "w": 24,
-        "x": 0,
-        "y": 28
-      },
+      "options": { "barRadius": 0, "barWidth": 0.97, "fullHighlight": false, "groupWidth": 0.7, "legend": { "displayMode": "list", "showLegend": false }, "orientation": "horizontal", "showValue": "always", "stacking": "none", "tooltip": { "mode": "single", "sort": "none" } },
+      "targets": [
+        {
+          "queryType": "table",
+          "rawQueryText": "SELECT kpi_id AS metric, errors AS value FROM query_errors WHERE errors > 0 ORDER BY errors DESC;",
+          "refId": "A"
+        }
+      ]
+    },
+
+    {
       "id": 6,
-      "options": {
-        "showHeader": true,
-        "cellHeight": "sm",
-        "footer": {
-          "show": false,
-          "reducer": ["sum"],
-          "countRows": false,
-          "fields": ""
-        },
-        "sortBy": [
-          {
-            "displayName": "KPI ID",
-            "desc": false
-          }
-        ]
-      },
-      "pluginVersion": "10.0.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "frser-sqlite-datasource",
-            "uid": "kpi-datasource"
-          },
-          "queryType": "table",
-          "rawQueryText": "SELECT kpi_id, COUNT(*) AS sample_count, ROUND(AVG(metric_value), 6) AS avg_value, ROUND(MIN(metric_value), 6) AS min_value, ROUND(MAX(metric_value), 6) AS max_value, ROUND(MAX(metric_value) - MIN(metric_value), 6) AS range, COUNT(DISTINCT metric_labels) AS unique_metrics FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${cluster}' = '$__all' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = '$__all' OR c.cluster_type = '${cluster_type}') GROUP BY kpi_id ORDER BY kpi_id",
-          "refId": "A"
-        }
-      ],
+      "type": "table",
       "title": "All KPIs - Summary Statistics",
-      "type": "table"
-    },
-    {
-      "datasource": {
-        "type": "frser-sqlite-datasource",
-        "uid": "kpi-datasource"
-      },
+      "datasource": { "type": "frser-sqlite-datasource", "uid": "kpi-datasource" },
+      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 28 },
       "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {
-            "align": "auto",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "inspect": false
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          }
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "cluster_name"
-            },
-            "properties": [
-              {
-                "id": "displayName",
-                "value": "Cluster"
-              },
-              {
-                "id": "custom.width",
-                "value": 200
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "cluster_type"
-            },
-            "properties": [
-              {
-                "id": "displayName",
-                "value": "Type"
-              },
-              {
-                "id": "custom.width",
-                "value": 150
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "kpi_count"
-            },
-            "properties": [
-              {
-                "id": "displayName",
-                "value": "KPIs"
-              },
-              {
-                "id": "custom.width",
-                "value": 80
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "total_samples"
-            },
-            "properties": [
-              {
-                "id": "displayName",
-                "value": "Total Samples"
-              },
-              {
-                "id": "custom.width",
-                "value": 120
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "last_collection"
-            },
-            "properties": [
-              {
-                "id": "displayName",
-                "value": "Last Collection"
-              },
-              {
-                "id": "unit",
-                "value": "dateTimeAsIso"
-              }
-            ]
-          }
-        ]
+        "defaults": { "color": { "mode": "thresholds" }, "custom": { "align": "auto", "cellOptions": { "type": "auto" }, "inspect": false }, "mappings": [], "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] } },
+        "overrides": []
       },
-      "gridPos": {
-        "h": 6,
-        "w": 24,
-        "x": 0,
-        "y": 37
-      },
-      "id": 7,
-      "options": {
-        "showHeader": true,
-        "cellHeight": "sm",
-        "footer": {
-          "show": false,
-          "reducer": ["sum"],
-          "countRows": false,
-          "fields": ""
-        },
-        "sortBy": []
-      },
-      "pluginVersion": "10.0.0",
+      "options": { "showHeader": true, "cellHeight": "sm", "footer": { "show": false }, "sortBy": [{ "displayName": "KPI ID", "desc": false }] },
       "targets": [
         {
-          "datasource": {
-            "type": "frser-sqlite-datasource",
-            "uid": "kpi-datasource"
-          },
           "queryType": "table",
-          "rawQueryText": "SELECT c.cluster_name, c.cluster_type, COUNT(DISTINCT qr.kpi_id) AS kpi_count, COUNT(*) AS total_samples, MAX(qr.created_at) AS last_collection FROM clusters c LEFT JOIN query_results qr ON c.id = qr.cluster_id WHERE ('${cluster_type}' = '$__all' OR c.cluster_type = '${cluster_type}') GROUP BY c.cluster_name, c.cluster_type ORDER BY c.cluster_name",
+          "rawQueryText": "SELECT kpi_id, COUNT(*) AS sample_count, ROUND(AVG(metric_value), 6) AS avg_value, ROUND(MIN(metric_value), 6) AS min_value, ROUND(MAX(metric_value), 6) AS max_value, ROUND(MAX(metric_value) - MIN(metric_value), 6) AS range, COUNT(DISTINCT metric_labels) AS unique_metrics FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${cluster}' = '$__all' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = '$__all' OR c.cluster_type = '${cluster_type}') AND ('${node}' = '$__all' OR json_extract(metric_labels, '$.node') = '${node}') AND ('${job}' = '$__all' OR json_extract(metric_labels, '$.job') = '${job}') AND ('${pod}' = '$__all' OR json_extract(metric_labels, '$.pod') = '${pod}') AND ('${container}' = '$__all' OR json_extract(metric_labels, '$.container') = '${container}') GROUP BY kpi_id ORDER BY kpi_id",
           "refId": "A"
         }
-      ],
+      ]
+    },
+
+    {
+      "id": 7,
+      "type": "table",
       "title": "Cluster Monitoring Status",
-      "type": "table"
+      "datasource": { "type": "frser-sqlite-datasource", "uid": "kpi-datasource" },
+      "gridPos": { "h": 6, "w": 24, "x": 0, "y": 37 },
+      "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "custom": { "align": "auto", "cellOptions": { "type": "auto" }, "inspect": false }, "mappings": [], "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] } }, "overrides": [] },
+      "options": { "showHeader": true, "cellHeight": "sm" },
+      "targets": [
+        {
+          "queryType": "table",
+          "rawQueryText": "SELECT c.cluster_name, c.cluster_type, COUNT(DISTINCT qr.kpi_id) AS kpi_count, COUNT(*) AS total_samples, MAX(qr.created_at) AS last_collection FROM clusters c LEFT JOIN query_results qr ON c.id = qr.cluster_id WHERE ('${cluster_type}' = '$__all' OR c.cluster_type = '${cluster_type}') AND ('${cluster}' = '$__all' OR c.cluster_name = '${cluster}') AND ('${node}' = '$__all' OR json_extract(qr.metric_labels, '$.node') = '${node}') AND ('${job}' = '$__all' OR json_extract(qr.metric_labels, '$.job') = '${job}') AND ('${pod}' = '$__all' OR json_extract(qr.metric_labels, '$.pod') = '${pod}') AND ('${container}' = '$__all' OR json_extract(qr.metric_labels, '$.container') = '${container}') GROUP BY c.cluster_name, c.cluster_type ORDER BY c.cluster_name",
+          "refId": "A"
+        }
+      ]
     }
   ],
   "refresh": "10s",
@@ -776,77 +186,89 @@
   "templating": {
     "list": [
       {
-        "current": {},
-        "datasource": {
-          "type": "frser-sqlite-datasource",
-          "uid": "kpi-datasource"
-        },
-        "definition": "SELECT DISTINCT cluster_type FROM clusters WHERE cluster_type IS NOT NULL ORDER BY cluster_type;",
-        "hide": 0,
-        "includeAll": true,
-        "label": "Cluster Type",
-        "multi": false,
         "name": "cluster_type",
-        "options": [],
-        "query": "SELECT DISTINCT cluster_type FROM clusters WHERE cluster_type IS NOT NULL ORDER BY cluster_type;",
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
         "type": "query",
-        "allValue": "$__all"
-      },
-      {
-        "current": {},
-        "datasource": {
-          "type": "frser-sqlite-datasource",
-          "uid": "kpi-datasource"
-        },
-        "definition": "SELECT cluster_name FROM clusters WHERE ('${cluster_type}' = '$__all' OR cluster_type = '${cluster_type}') ORDER BY cluster_name;",
-        "hide": 0,
+        "label": "Cluster Type",
+        "datasource": { "type": "frser-sqlite-datasource", "uid": "kpi-datasource" },
+        "query": "SELECT DISTINCT cluster_type FROM clusters WHERE cluster_type IS NOT NULL AND cluster_type <> '' ORDER BY cluster_type;",
         "includeAll": true,
-        "label": "Cluster",
         "multi": false,
-        "name": "cluster",
-        "options": [],
-        "query": "SELECT cluster_name FROM clusters WHERE ('${cluster_type}' = '$__all' OR cluster_type = '${cluster_type}') ORDER BY cluster_name;",
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "type": "query",
-        "allValue": "$__all"
+        "allValue": "$__all",
+        "current": { "text": "All", "value": "$__all" }
       },
       {
-        "current": {},
-        "datasource": {
-          "type": "frser-sqlite-datasource",
-          "uid": "kpi-datasource"
-        },
-        "definition": "SELECT DISTINCT kpi_id FROM query_results ORDER BY kpi_id;",
-        "hide": 0,
-        "includeAll": false,
-        "label": "KPI",
+        "name": "cluster",
+        "type": "query",
+        "label": "Cluster",
+        "datasource": { "type": "frser-sqlite-datasource", "uid": "kpi-datasource" },
+        "query": "SELECT DISTINCT cluster_name FROM clusters WHERE cluster_name IS NOT NULL AND cluster_name <> '' AND ('${cluster_type}' = '$__all' OR cluster_type = '${cluster_type}') ORDER BY cluster_name;",
+        "includeAll": true,
         "multi": false,
+        "allValue": "$__all",
+        "current": { "text": "All", "value": "$__all" }
+      },
+      {
         "name": "kpi",
-        "options": [],
-        "query": "SELECT DISTINCT kpi_id FROM query_results ORDER BY kpi_id;",
-        "refresh": 1,
-        "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
-        "type": "query"
+        "type": "query",
+        "label": "KPI",
+        "datasource": { "type": "frser-sqlite-datasource", "uid": "kpi-datasource" },
+        "query": "SELECT DISTINCT kpi_id FROM query_results WHERE kpi_id IS NOT NULL AND kpi_id <> '' ORDER BY kpi_id;",
+        "includeAll": true,
+        "multi": false,
+        "allValue": "$__all",
+        "current": { "text": "All", "value": "$__all" }
+      },
+      {
+        "name": "node",
+        "type": "query",
+        "label": "Node",
+        "datasource": { "type": "frser-sqlite-datasource", "uid": "kpi-datasource" },
+        "query": "SELECT DISTINCT json_extract(metric_labels, '$.node') AS node FROM query_results WHERE metric_labels IS NOT NULL AND json_extract(metric_labels, '$.node') IS NOT NULL AND json_extract(metric_labels, '$.node') <> '' ORDER BY 1;",
+        "includeAll": true,
+        "multi": false,
+        "allValue": "$__all",
+        "current": { "text": "All", "value": "$__all" }
+      },
+      {
+        "name": "job",
+        "type": "query",
+        "label": "Job",
+        "datasource": { "type": "frser-sqlite-datasource", "uid": "kpi-datasource" },
+        "query": "SELECT DISTINCT json_extract(metric_labels, '$.job') AS job FROM query_results WHERE metric_labels IS NOT NULL AND json_extract(metric_labels, '$.job') IS NOT NULL AND json_extract(metric_labels, '$.job') <> '' ORDER BY 1;",
+        "includeAll": true,
+        "multi": false,
+        "allValue": "$__all",
+        "current": { "text": "All", "value": "$__all" }
+      },
+      {
+        "name": "pod",
+        "type": "query",
+        "label": "Pod",
+        "datasource": { "type": "frser-sqlite-datasource", "uid": "kpi-datasource" },
+        "query": "SELECT DISTINCT json_extract(metric_labels, '$.pod') AS pod FROM query_results WHERE metric_labels IS NOT NULL AND json_extract(metric_labels, '$.pod') IS NOT NULL AND json_extract(metric_labels, '$.pod') <> '' ORDER BY 1;",
+        "includeAll": true,
+        "multi": false,
+        "allValue": "$__all",
+        "current": { "text": "All", "value": "$__all" }
+      },
+      {
+        "name": "container",
+        "type": "query",
+        "label": "Container",
+        "datasource": { "type": "frser-sqlite-datasource", "uid": "kpi-datasource" },
+        "query": "SELECT DISTINCT json_extract(metric_labels, '$.container') AS container FROM query_results WHERE metric_labels IS NOT NULL AND json_extract(metric_labels, '$.container') IS NOT NULL AND json_extract(metric_labels, '$.container') <> '' ORDER BY 1;",
+        "includeAll": true,
+        "multi": false,
+        "allValue": "$__all",
+        "current": { "text": "All", "value": "$__all" }
       }
     ]
   },
-  "time": {
-    "from": "now-6h",
-    "to": "now"
-  },
+  "time": { "from": "now-6h", "to": "now" },
   "timepicker": {},
   "timezone": "",
   "title": "KPI Collection Tool - Dynamic Dashboard",
   "uid": "kpi-collector-dynamic",
-  "version": 1,
+  "version": 3,
   "weekStart": ""
 }


### PR DESCRIPTION
**This PR adds four new filters to the sqlite-dashboard.json** 

- pod 
- node
- container
- job 

It also updates the README to clarify that these new filters are available only for SQLite dashboards.

**Changes included:**

1. Updated sqlite-dashboard.json with the new filters.
2. Updated README to document the availability of these filters for SQLite.
3. Ensures consistency between dashboard functionality and documentation.