### PR TITLE
Update Go to 1.25.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module kpi-collector
 
-go 1.25.1
+go 1.25.5
 
 require (
 	github.com/dustin/go-humanize v1.0.1


### PR DESCRIPTION
This PR updates the Go version to 1.25.5.

Related to: https://github.com/redhat-best-practices-for-k8s/certsuite/pull/3363