### PR TITLE
Move all artifacts to ./kpi-collector-artifacts/ in CWD with --artifact-dir flag

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,12 +145,13 @@ type Database interface {
 
 ### Configuration
 - Default artifact directory: `./kpi-collector-artifacts/` (created in the user's current working directory)
-- SQLite database: `./kpi-collector-artifacts/kpi_metrics.db`
-- Log files: `./kpi-collector-artifacts/kpi-<timestamp>.log`
-- Output files: `./kpi-collector-artifacts/kpi-output-<timestamp>.json`
-- Grafana config directory: `./kpi-collector-artifacts/grafana/`
+- Override with `--artifact-dir` flag (available on all commands)
+- SQLite database: `<output-dir>/kpi_metrics.db`
+- Log files: `<output-dir>/kpi-<timestamp>.log`
+- Output files: `<output-dir>/kpi-output-<timestamp>.json`
+- Grafana config directory: `<output-dir>/grafana/`
 - Environment variables: `KPI_COLLECTOR_DB_TYPE`, `KPI_COLLECTOR_DB_URL`
-- All commands (`run`, `db`, `grafana`) must be executed from the same working directory when using SQLite
+- All commands (`run`, `db`, `grafana`) must be executed from the same working directory when using SQLite, or use `--artifact-dir`
 
 ### KPI Configuration File Format
 KPIs are defined in JSON format (see `kpis.json.template`):

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,9 +144,13 @@ type Database interface {
 ```
 
 ### Configuration
-- Default SQLite database: `~/.kpi-collector/kpi_metrics.db`
-- Grafana config directory: `~/.kpi-collector/grafana/`
+- Default artifact directory: `./kpi-collector-artifacts/` (created in the user's current working directory)
+- SQLite database: `./kpi-collector-artifacts/kpi_metrics.db`
+- Log files: `./kpi-collector-artifacts/kpi-<timestamp>.log`
+- Output files: `./kpi-collector-artifacts/kpi-output-<timestamp>.json`
+- Grafana config directory: `./kpi-collector-artifacts/grafana/`
 - Environment variables: `KPI_COLLECTOR_DB_TYPE`, `KPI_COLLECTOR_DB_URL`
+- All commands (`run`, `db`, `grafana`) must be executed from the same working directory when using SQLite
 
 ### KPI Configuration File Format
 KPIs are defined in JSON format (see `kpis.json.template`):

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,14 +144,14 @@ type Database interface {
 ```
 
 ### Configuration
-- Default artifact directory: `./kpi-collector-artifacts/` (created in the user's current working directory)
-- Override with `--artifact-dir` flag (available on all commands)
-- SQLite database: `<output-dir>/kpi_metrics.db`
-- Log files: `<output-dir>/kpi-<timestamp>.log`
-- Output files: `<output-dir>/kpi-output-<timestamp>.json`
-- Grafana config directory: `<output-dir>/grafana/`
+- Default artifacts directory: `./kpi-collector-artifacts/` (created in the current working directory)
+- Override with `--artifacts-dir` flag (available on all commands); the provided path is used directly
+- SQLite database: `<artifacts-dir>/kpi_metrics.db`
+- Log files: `<artifacts-dir>/kpi-<timestamp>.log`
+- Output files: `<artifacts-dir>/kpi-output-<timestamp>.json`
+- Grafana config directory: `<artifacts-dir>/grafana/`
 - Environment variables: `KPI_COLLECTOR_DB_TYPE`, `KPI_COLLECTOR_DB_URL`
-- All commands (`run`, `db`, `grafana`) must be executed from the same working directory when using SQLite, or use `--artifact-dir`
+- All commands (`run`, `db`, `grafana`) must be executed from the same working directory when using SQLite, or use `--artifacts-dir`
 
 ### KPI Configuration File Format
 KPIs are defined in JSON format (see `kpis.json.template`):

--- a/docs/database-commands.md
+++ b/docs/database-commands.md
@@ -13,7 +13,7 @@ You can specify the database connection in this order:
 
 1. CLI flags: `--db-type`, `--postgres-url`
 2. Environment variables: `KPI_COLLECTOR_DB_TYPE`, `KPI_COLLECTOR_DB_URL`
-3. SQLite (used when no `--db-type` is specified): `./kpi-collector-artifacts/kpi_metrics.db`
+3. SQLite (used when no `--db-type` is specified): `<artifacts-dir>/kpi_metrics.db` (default: `./kpi-collector-artifacts/`)
 
 Using environment variables:
 
@@ -246,10 +246,10 @@ SQLite is the default when no `--db-type` is specified.
 ### SQLite (default)
 
 - No configuration required
-- Data stored at `./kpi-collector-artifacts/kpi_metrics.db` (relative to where you run the command)
+- Data stored at `<artifacts-dir>/kpi_metrics.db` (default: `./kpi-collector-artifacts/`)
 - Automatically created on first run
 - No external dependencies
-- All commands (`run`, `db`, `grafana`) must be executed from the same working directory, or use `--artifact-dir` to specify the artifact directory
+- All commands (`run`, `db`, `grafana`) must be executed from the same working directory, or use `--artifacts-dir` to specify the artifacts directory
 
 ### PostgreSQL
 

--- a/docs/database-commands.md
+++ b/docs/database-commands.md
@@ -13,7 +13,7 @@ You can specify the database connection in this order:
 
 1. CLI flags: `--db-type`, `--postgres-url`
 2. Environment variables: `KPI_COLLECTOR_DB_TYPE`, `KPI_COLLECTOR_DB_URL`
-3. Default: SQLite at `~/.kpi-collector/kpi_metrics.db`
+3. SQLite (used when no `--db-type` is specified): `./kpi-collector-artifacts/kpi_metrics.db`
 
 Using environment variables:
 
@@ -241,15 +241,15 @@ kpi-collector db show kpis --name="<kpi-name>" \
 
 ## Database Support
 
-SQLite is used by default when no `--db-type` is specified.
+SQLite is the default when no `--db-type` is specified.
 
-### SQLite (Default)
+### SQLite (default)
 
 - No configuration required
-- Data stored at `~/.kpi-collector/kpi_metrics.db`
+- Data stored at `./kpi-collector-artifacts/kpi_metrics.db` (relative to where you run the command)
 - Automatically created on first run
 - No external dependencies
-- Works from any directory
+- All commands (`run`, `db`, `grafana`) must be executed from the same working directory
 
 ### PostgreSQL
 

--- a/docs/database-commands.md
+++ b/docs/database-commands.md
@@ -249,7 +249,7 @@ SQLite is the default when no `--db-type` is specified.
 - Data stored at `./kpi-collector-artifacts/kpi_metrics.db` (relative to where you run the command)
 - Automatically created on first run
 - No external dependencies
-- All commands (`run`, `db`, `grafana`) must be executed from the same working directory
+- All commands (`run`, `db`, `grafana`) must be executed from the same working directory, or use `--artifact-dir` to specify the artifact directory
 
 ### PostgreSQL
 

--- a/docs/grafana.md
+++ b/docs/grafana.md
@@ -4,7 +4,7 @@ View collected KPI metrics in Grafana with a pre-configured dashboard.
 
 The `grafana` command manages a local Grafana instance via Docker. Configuration files are generated in `./kpi-collector-artifacts/grafana/`.
 
-When using SQLite, run `grafana start` from the same directory where `kpi-collector run` was executed.
+When using SQLite, run `grafana start` from the same directory where `kpi-collector run` was executed, or use `--artifact-dir` to point to the artifact directory.
 
 Related guides:
 - [Collecting Metrics](collecting-metrics.md)

--- a/docs/grafana.md
+++ b/docs/grafana.md
@@ -2,7 +2,9 @@
 
 View collected KPI metrics in Grafana with a pre-configured dashboard.
 
-The `grafana` command manages a local Grafana instance via Docker. Configuration files are generated in `~/.kpi-collector/grafana/`.
+The `grafana` command manages a local Grafana instance via Docker. Configuration files are generated in `./kpi-collector-artifacts/grafana/`.
+
+When using SQLite, run `grafana start` from the same directory where `kpi-collector run` was executed.
 
 Related guides:
 - [Collecting Metrics](collecting-metrics.md)

--- a/docs/grafana.md
+++ b/docs/grafana.md
@@ -2,9 +2,9 @@
 
 View collected KPI metrics in Grafana with a pre-configured dashboard.
 
-The `grafana` command manages a local Grafana instance via Docker. Configuration files are generated in `./kpi-collector-artifacts/grafana/`.
+The `grafana` command manages a local Grafana instance via Docker. Configuration files are generated in `<artifacts-dir>/grafana/` (default: `./kpi-collector-artifacts/`).
 
-When using SQLite, run `grafana start` from the same directory where `kpi-collector run` was executed, or use `--artifact-dir` to point to the artifact directory.
+When using SQLite, run `grafana start` from the same directory where `kpi-collector run` was executed, or use `--artifacts-dir` to point to the artifacts directory.
 
 Related guides:
 - [Collecting Metrics](collecting-metrics.md)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -5,7 +5,7 @@
 1. Ensure data was collected first with `kpi-collector run`
 2. Check Grafana time range (top-right), for example "Last 24 hours" or "Last 7 days"
 3. Verify the KPI dropdown has a selected value
-4. For SQLite, ensure `./kpi-collector-artifacts/kpi_metrics.db` exists in the directory where you ran `kpi-collector run` (or use `--artifact-dir` to point to the artifact directory)
+4. For SQLite, ensure the database exists in the artifacts directory (default: `./kpi-collector-artifacts/kpi_metrics.db`), or use `--artifacts-dir` to point to the artifacts directory
 5. For PostgreSQL, test datasource connectivity in Grafana (**Settings** -> **Data Sources**)
 
 ## PostgreSQL connection errors

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -5,7 +5,7 @@
 1. Ensure data was collected first with `kpi-collector run`
 2. Check Grafana time range (top-right), for example "Last 24 hours" or "Last 7 days"
 3. Verify the KPI dropdown has a selected value
-4. For SQLite, ensure `./kpi-collector-artifacts/kpi_metrics.db` exists in the directory where you ran `kpi-collector run`
+4. For SQLite, ensure `./kpi-collector-artifacts/kpi_metrics.db` exists in the directory where you ran `kpi-collector run` (or use `--artifact-dir` to point to the artifact directory)
 5. For PostgreSQL, test datasource connectivity in Grafana (**Settings** -> **Data Sources**)
 
 ## PostgreSQL connection errors

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -5,7 +5,7 @@
 1. Ensure data was collected first with `kpi-collector run`
 2. Check Grafana time range (top-right), for example "Last 24 hours" or "Last 7 days"
 3. Verify the KPI dropdown has a selected value
-4. For SQLite, ensure `~/.kpi-collector/kpi_metrics.db` exists
+4. For SQLite, ensure `./kpi-collector-artifacts/kpi_metrics.db` exists in the directory where you ran `kpi-collector run`
 5. For PostgreSQL, test datasource connectivity in Grafana (**Settings** -> **Data Sources**)
 
 ## PostgreSQL connection errors

--- a/internal/commands/db.go
+++ b/internal/commands/db.go
@@ -28,7 +28,9 @@ Works with both SQLite (default) and PostgreSQL databases.
 Database connection can be specified via:
   1. CLI flags: --db-type and --postgres-url
   2. Environment variables: KPI_COLLECTOR_DB_TYPE and KPI_COLLECTOR_DB_URL
-  3. Default: SQLite at ~/.kpi-collector/kpi_metrics.db`,
+  3. SQLite (used when no db-type is specified): ./kpi-collector-artifacts/kpi_metrics.db
+
+When using SQLite, run this command from the same directory where 'kpi-collector run' was executed.`,
 	Example: `  # Using SQLite (default)
   kpi-collector db show clusters
   

--- a/internal/commands/db.go
+++ b/internal/commands/db.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/redhat-best-practices-for-k8s/kpi-collection-tool/internal/database"
 
@@ -28,9 +29,10 @@ Works with both SQLite (default) and PostgreSQL databases.
 Database connection can be specified via:
   1. CLI flags: --db-type and --postgres-url
   2. Environment variables: KPI_COLLECTOR_DB_TYPE and KPI_COLLECTOR_DB_URL
-  3. SQLite (used when no db-type is specified): ./kpi-collector-artifacts/kpi_metrics.db
+  3. SQLite (used when no db-type is specified): <output-dir>/kpi_metrics.db
 
-When using SQLite, run this command from the same directory where 'kpi-collector run' was executed.`,
+When using SQLite, run this command from the same directory where 'kpi-collector run' was executed,
+or use --artifact-dir to specify the artifact directory.`,
 	Example: `  # Using SQLite (default)
   kpi-collector db show clusters
   
@@ -86,6 +88,12 @@ func connectToDB() (*sql.DB, database.Database, error) {
 	case "postgres":
 		dbImpl = database.NewPostgresDB(postgresURL)
 	case "sqlite":
+		dbPath := filepath.Join(database.OutputDir, database.DefaultDBFileName)
+		if _, err := os.Stat(dbPath); os.IsNotExist(err) {
+			return nil, nil, fmt.Errorf("SQLite database not found at %s\n"+
+				"Run 'kpi-collector run' first to collect data, or use --artifact-dir to specify the artifact directory",
+				dbPath)
+		}
 		dbImpl = database.NewSQLiteDB()
 	default:
 		return nil, nil, fmt.Errorf("invalid database type: %s (must be 'sqlite' or 'postgres')", dbType)

--- a/internal/commands/db.go
+++ b/internal/commands/db.go
@@ -29,10 +29,10 @@ Works with both SQLite (default) and PostgreSQL databases.
 Database connection can be specified via:
   1. CLI flags: --db-type and --postgres-url
   2. Environment variables: KPI_COLLECTOR_DB_TYPE and KPI_COLLECTOR_DB_URL
-  3. SQLite (used when no db-type is specified): <output-dir>/kpi_metrics.db
+  3. SQLite (used when no db-type is specified): <artifacts-dir>/kpi_metrics.db
 
 When using SQLite, run this command from the same directory where 'kpi-collector run' was executed,
-or use --artifact-dir to specify the artifact directory.`,
+or use --artifacts-dir to specify the artifacts directory.`,
 	Example: `  # Using SQLite (default)
   kpi-collector db show clusters
   
@@ -91,7 +91,7 @@ func connectToDB() (*sql.DB, database.Database, error) {
 		dbPath := filepath.Join(database.OutputDir, database.DefaultDBFileName)
 		if _, err := os.Stat(dbPath); os.IsNotExist(err) {
 			return nil, nil, fmt.Errorf("SQLite database not found at %s\n"+
-				"Run 'kpi-collector run' first to collect data, or use --artifact-dir to specify the artifact directory",
+				"Run 'kpi-collector run' first to collect data, or use --artifacts-dir to specify the artifacts directory",
 				dbPath)
 		}
 		dbImpl = database.NewSQLiteDB()

--- a/internal/commands/grafana.go
+++ b/internal/commands/grafana.go
@@ -21,15 +21,15 @@ Supports both SQLite and PostgreSQL datasources.
   Use 'grafana start' to launch Grafana and 'grafana stop' to stop it.
 
 When using SQLite, run this command from the same directory where 'kpi-collector run' was executed,
-or use --artifact-dir to point to the artifact directory.`,
+or use --artifacts-dir to point to the artifacts directory.`,
 }
 
 func init() {
 	rootCmd.AddCommand(grafanaCmd)
 }
 
-// getGrafanaConfigDir returns the path to the grafana config directory
-// <OutputDir>/grafana/
+// getGrafanaConfigDir returns the path to the Grafana config directory
+// inside the artifacts directory.
 func getGrafanaConfigDir() string {
 	return filepath.Join(database.OutputDir, "grafana")
 }

--- a/internal/commands/grafana.go
+++ b/internal/commands/grafana.go
@@ -20,7 +20,8 @@ Supports both SQLite and PostgreSQL datasources.
 
   Use 'grafana start' to launch Grafana and 'grafana stop' to stop it.
 
-When using SQLite, run this command from the same directory where 'kpi-collector run' was executed.`,
+When using SQLite, run this command from the same directory where 'kpi-collector run' was executed,
+or use --artifact-dir to point to the artifact directory.`,
 }
 
 func init() {
@@ -28,9 +29,9 @@ func init() {
 }
 
 // getGrafanaConfigDir returns the path to the grafana config directory
-// ./kpi-collector-artifacts/grafana/
+// <OutputDir>/grafana/
 func getGrafanaConfigDir() string {
-	return filepath.Join(database.DefaultDataDir, "grafana")
+	return filepath.Join(database.OutputDir, "grafana")
 }
 
 // createGrafanaDirectories creates all necessary directories for grafana config

--- a/internal/commands/grafana.go
+++ b/internal/commands/grafana.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/redhat-best-practices-for-k8s/kpi-collection-tool/internal/database"
+
 	"github.com/spf13/cobra"
 )
 
@@ -16,23 +18,19 @@ var grafanaCmd = &cobra.Command{
 	Long: `Manage a local Grafana instance with the KPI dashboard pre-configured.
 Supports both SQLite and PostgreSQL datasources.
 
-  Use 'grafana start' to launch Grafana and 'grafana stop' to stop it.`,
+  Use 'grafana start' to launch Grafana and 'grafana stop' to stop it.
+
+When using SQLite, run this command from the same directory where 'kpi-collector run' was executed.`,
 }
 
 func init() {
 	rootCmd.AddCommand(grafanaCmd)
-
 }
 
 // getGrafanaConfigDir returns the path to the grafana config directory
-// ~/.kpi-collector/grafana/
-func getGrafanaConfigDir() (string, error) {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return "", fmt.Errorf("failed to get home directory: %w", err)
-	}
-
-	return filepath.Join(homeDir, ".kpi-collector", "grafana"), nil
+// ./kpi-collector-artifacts/grafana/
+func getGrafanaConfigDir() string {
+	return filepath.Join(database.DefaultDataDir, "grafana")
 }
 
 // createGrafanaDirectories creates all necessary directories for grafana config

--- a/internal/commands/grafana_start.go
+++ b/internal/commands/grafana_start.go
@@ -247,11 +247,11 @@ func runGrafanaContainer(grafanaDir string) error {
 
 	// For SQLite, mount the database file
 	if grafanaStartFlags.datasource == "sqlite" {
-		dbPath := filepath.Join(database.DefaultDataDir, database.DefaultDBFileName)
+		dbPath := filepath.Join(database.OutputDir, database.DefaultDBFileName)
 
 		// Ensure database file exists (podman requires source to exist before mounting)
 		if _, err := os.Stat(dbPath); os.IsNotExist(err) {
-			if err := os.MkdirAll(database.DefaultDataDir, 0755); err != nil {
+			if err := os.MkdirAll(database.OutputDir, 0755); err != nil {
 				return fmt.Errorf("failed to create database directory: %w", err)
 			}
 			file, err := os.Create(dbPath)

--- a/internal/commands/grafana_start.go
+++ b/internal/commands/grafana_start.go
@@ -23,10 +23,11 @@ var grafanaStartCmd = &cobra.Command{
 	Use:   "start",
 	Short: "Start Grafana dashboard",
 	Long: `Start a local Grafana instance with the KPI dashboard pre-configured.
-Generates configuration files in ./kpi-collector-artifacts/grafana/ and
-launches Grafana via Docker with all necessary volume mounts.
+Generates configuration files in <artifacts-dir>/grafana/ and launches Grafana
+via Docker with all necessary volume mounts.
 
-When using SQLite, run this command from the same directory where 'kpi-collector run' was executed.`,
+When using SQLite, run this command from the same directory where 'kpi-collector run' was executed,
+or use --artifacts-dir to point to the artifacts directory.`,
 	Example: `  # Using SQLite
   kpi-collector grafana start --datasource=sqlite
   # Using PostgreSQL

--- a/internal/commands/grafana_start.go
+++ b/internal/commands/grafana_start.go
@@ -23,8 +23,10 @@ var grafanaStartCmd = &cobra.Command{
 	Use:   "start",
 	Short: "Start Grafana dashboard",
 	Long: `Start a local Grafana instance with the KPI dashboard pre-configured.
-Generates configuration files in ~/.kpi-collector/grafana/ and
-launches Grafana via Docker with all necessary volume mounts.`,
+Generates configuration files in ./kpi-collector-artifacts/grafana/ and
+launches Grafana via Docker with all necessary volume mounts.
+
+When using SQLite, run this command from the same directory where 'kpi-collector run' was executed.`,
 	Example: `  # Using SQLite
   kpi-collector grafana start --datasource=sqlite
   # Using PostgreSQL
@@ -61,10 +63,7 @@ func runGrafanaStart(cmd *cobra.Command, args []string) error {
 	fmt.Printf("Starting Grafana with %s datasource...\n", grafanaStartFlags.datasource)
 
 	// Get the grafana config directory
-	grafanaDir, err := getGrafanaConfigDir()
-	if err != nil {
-		return fmt.Errorf("failed to get grafana config directory: %w", err)
-	}
+	grafanaDir := getGrafanaConfigDir()
 
 	// Create all necessary directories
 	if err := createGrafanaDirectories(grafanaDir); err != nil {
@@ -225,6 +224,11 @@ func runGrafanaContainer(grafanaDir string) error {
 	stopCmd := exec.Command(runtime, "rm", "-f", grafanaContainerName)
 	_ = stopCmd.Run() // Ignore error if container doesn't exist
 
+	absGrafanaDir, err := filepath.Abs(grafanaDir)
+	if err != nil {
+		return fmt.Errorf("failed to resolve grafana config path: %w", err)
+	}
+
 	// Build docker run command
 	args := []string{
 		"run", "-d",
@@ -232,22 +236,22 @@ func runGrafanaContainer(grafanaDir string) error {
 		"-p", fmt.Sprintf("%d:3000", grafanaStartFlags.port),
 		// Mount datasource config
 		"-v", fmt.Sprintf("%s:/etc/grafana/provisioning/datasources:ro,z",
-			filepath.Join(grafanaDir, "datasources")),
+			filepath.Join(absGrafanaDir, "datasources")),
 		// Mount dashboard provisioning config
 		"-v", fmt.Sprintf("%s:/etc/grafana/provisioning/dashboards:ro,z",
-			filepath.Join(grafanaDir, "provisioning", "dashboards")),
+			filepath.Join(absGrafanaDir, "provisioning", "dashboards")),
 		// Mount dashboard JSON
 		"-v", fmt.Sprintf("%s:/var/lib/grafana/dashboards:ro",
-			filepath.Join(grafanaDir, "dashboards")),
+			filepath.Join(absGrafanaDir, "dashboards")),
 	}
 
 	// For SQLite, mount the database file
 	if grafanaStartFlags.datasource == "sqlite" {
-		dbPath := database.GetSQLiteDBPath()
+		dbPath := filepath.Join(database.DefaultDataDir, database.DefaultDBFileName)
 
 		// Ensure database file exists (podman requires source to exist before mounting)
 		if _, err := os.Stat(dbPath); os.IsNotExist(err) {
-			if err := os.MkdirAll(filepath.Dir(dbPath), 0755); err != nil {
+			if err := os.MkdirAll(database.DefaultDataDir, 0755); err != nil {
 				return fmt.Errorf("failed to create database directory: %w", err)
 			}
 			file, err := os.Create(dbPath)
@@ -260,8 +264,13 @@ func runGrafanaContainer(grafanaDir string) error {
 			fmt.Println("📝 Created empty database file (no data collected yet)")
 		}
 
+		absDBPath, err := filepath.Abs(dbPath)
+		if err != nil {
+			return fmt.Errorf("failed to resolve database path: %w", err)
+		}
+
 		args = append(args,
-			"-v", fmt.Sprintf("%s:/var/lib/grafana/kpi_metrics.db:ro", dbPath),
+			"-v", fmt.Sprintf("%s:/var/lib/grafana/kpi_metrics.db:ro", absDBPath),
 			"-e", "GF_INSTALL_PLUGINS=frser-sqlite-datasource",
 		)
 	}

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -3,9 +3,14 @@ package commands
 import (
 	"fmt"
 	"os"
+	"path/filepath"
+
+	"github.com/redhat-best-practices-for-k8s/kpi-collection-tool/internal/database"
 
 	"github.com/spf13/cobra"
 )
+
+var artifactDirFlag string
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
@@ -14,6 +19,16 @@ var rootCmd = &cobra.Command{
 	Long: `A tool to automate metrics gathering and visualization for KPIs 
 in disconnected environments. Supports Kubernetes auto-discovery, 
 Prometheus/Thanos integration, and multiple database backends.`,
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		if artifactDirFlag != "" {
+			database.OutputDir = filepath.Join(artifactDirFlag, database.DefaultOutputDir)
+		}
+	},
+}
+
+func init() {
+	rootCmd.PersistentFlags().StringVar(&artifactDirFlag, "artifact-dir", "",
+		"parent directory for the kpi-collector-artifacts folder (default: current directory)")
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -3,14 +3,13 @@ package commands
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/redhat-best-practices-for-k8s/kpi-collection-tool/internal/database"
 
 	"github.com/spf13/cobra"
 )
 
-var artifactDirFlag string
+var artifactsDirFlag string
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
@@ -20,15 +19,15 @@ var rootCmd = &cobra.Command{
 in disconnected environments. Supports Kubernetes auto-discovery, 
 Prometheus/Thanos integration, and multiple database backends.`,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		if artifactDirFlag != "" {
-			database.OutputDir = filepath.Join(artifactDirFlag, database.DefaultOutputDir)
+		if artifactsDirFlag != "" {
+			database.OutputDir = artifactsDirFlag
 		}
 	},
 }
 
 func init() {
-	rootCmd.PersistentFlags().StringVar(&artifactDirFlag, "artifact-dir", "",
-		"parent directory for the kpi-collector-artifacts folder (default: current directory)")
+	rootCmd.PersistentFlags().StringVar(&artifactsDirFlag, "artifacts-dir", "",
+		"directory for storing artifacts: database, logs, and Grafana config (default: ./kpi-collector-artifacts/)")
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/internal/commands/run.go
+++ b/internal/commands/run.go
@@ -31,8 +31,8 @@ in a database (SQLite or PostgreSQL). Supports two authentication modes:
 The tool will continuously collect metrics at the specified frequency 
 for the specified duration.
 
-All artifacts (database, logs, output) are stored in a ./kpi-collector-artifacts/ directory
-in the current working directory. Use --artifact-dir to override.`,
+All artifacts (database, logs, output) are stored in ./kpi-collector-artifacts/ by default.
+Use --artifacts-dir to override.`,
 	Example: `  # Using kubeconfig (auto-discovery)
   kpi-collector collect --cluster-name prod --cluster-type ran --kubeconfig ~/.kube/config
 
@@ -70,9 +70,9 @@ func init() {
 
 	// Output flags
 	runCmd.Flags().StringVar(&flags.OutputFile, "output", "",
-		"output file path (default: ./kpi-collector-artifacts/kpi-output-<timestamp>.json)")
+		"output file path (default: <artifacts-dir>/kpi-output-<timestamp>.json)")
 	runCmd.Flags().StringVar(&flags.LogFile, "log", "",
-		"log file path (default: ./kpi-collector-artifacts/kpi-<timestamp>.log)")
+		"log file path (default: <artifacts-dir>/kpi-<timestamp>.log)")
 
 	// Database flags
 	runCmd.Flags().StringVar(&flags.DatabaseType, "db-type", "sqlite",
@@ -121,7 +121,7 @@ func runCollect(cmd *cobra.Command, args []string) error {
 	fmt.Printf("Cluster: %s\n", flags.ClusterName)
 
 	if err := os.MkdirAll(database.OutputDir, 0755); err != nil {
-		return fmt.Errorf("failed to create artifact directory: %w", err)
+		return fmt.Errorf("failed to create artifacts directory: %w", err)
 	}
 
 	// Initialize logger

--- a/internal/commands/run.go
+++ b/internal/commands/run.go
@@ -32,7 +32,7 @@ The tool will continuously collect metrics at the specified frequency
 for the specified duration.
 
 All artifacts (database, logs, output) are stored in a ./kpi-collector-artifacts/ directory
-in the current working directory.`,
+in the current working directory. Use --artifact-dir to override.`,
 	Example: `  # Using kubeconfig (auto-discovery)
   kpi-collector collect --cluster-name prod --cluster-type ran --kubeconfig ~/.kube/config
 
@@ -104,13 +104,13 @@ func init() {
 func runCollect(cmd *cobra.Command, args []string) error {
 	fmt.Println("KPI Collector starting...")
 
-	// Generate timestamped file paths inside kpi-collector/ if not explicitly set
+	// Generate timestamped file paths inside the artifact directory if not explicitly set
 	timestamp := time.Now().Format("2006-01-02-150405")
 	if flags.LogFile == "" {
-		flags.LogFile = filepath.Join(database.DefaultDataDir, fmt.Sprintf("kpi-%s.log", timestamp))
+		flags.LogFile = filepath.Join(database.OutputDir, fmt.Sprintf("kpi-%s.log", timestamp))
 	}
 	if flags.OutputFile == "" {
-		flags.OutputFile = filepath.Join(database.DefaultDataDir, fmt.Sprintf("kpi-output-%s.json", timestamp))
+		flags.OutputFile = filepath.Join(database.OutputDir, fmt.Sprintf("kpi-output-%s.json", timestamp))
 	}
 
 	// Validate all flags (including cluster type)
@@ -120,7 +120,7 @@ func runCollect(cmd *cobra.Command, args []string) error {
 
 	fmt.Printf("Cluster: %s\n", flags.ClusterName)
 
-	if err := os.MkdirAll(database.DefaultDataDir, 0755); err != nil {
+	if err := os.MkdirAll(database.OutputDir, 0755); err != nil {
 		return fmt.Errorf("failed to create artifact directory: %w", err)
 	}
 
@@ -184,7 +184,12 @@ func runCollect(cmd *cobra.Command, args []string) error {
 		collector.Run(kpis, flags)
 	}
 
+	absOutputDir, err := filepath.Abs(database.OutputDir)
+	if err != nil {
+		absOutputDir = database.OutputDir
+	}
 	fmt.Println("All queries completed successfully!")
+	fmt.Printf("Artifacts stored in: %s\n", absOutputDir)
 
 	return nil
 }

--- a/internal/commands/run.go
+++ b/internal/commands/run.go
@@ -3,10 +3,13 @@ package commands
 import (
 	"fmt"
 	"log"
+	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/redhat-best-practices-for-k8s/kpi-collection-tool/internal/collector"
 	"github.com/redhat-best-practices-for-k8s/kpi-collection-tool/internal/config"
+	"github.com/redhat-best-practices-for-k8s/kpi-collection-tool/internal/database"
 	"github.com/redhat-best-practices-for-k8s/kpi-collection-tool/internal/kubernetes"
 	"github.com/redhat-best-practices-for-k8s/kpi-collection-tool/internal/logger"
 
@@ -26,7 +29,10 @@ in a database (SQLite or PostgreSQL). Supports two authentication modes:
   2. Manual bearer token and Thanos URL
 
 The tool will continuously collect metrics at the specified frequency 
-for the specified duration.`,
+for the specified duration.
+
+All artifacts (database, logs, output) are stored in a ./kpi-collector-artifacts/ directory
+in the current working directory.`,
 	Example: `  # Using kubeconfig (auto-discovery)
   kpi-collector collect --cluster-name prod --cluster-type ran --kubeconfig ~/.kube/config
 
@@ -63,14 +69,14 @@ func init() {
 		"total duration for sampling (e.g. 10s, 1m, 2h)")
 
 	// Output flags
-	runCmd.Flags().StringVar(&flags.OutputFile, "output", "kpi-output.json",
-		"output file name for results")
-	runCmd.Flags().StringVar(&flags.LogFile, "log", "kpi.log",
-		"log file name")
+	runCmd.Flags().StringVar(&flags.OutputFile, "output", "",
+		"output file path (default: ./kpi-collector-artifacts/kpi-output-<timestamp>.json)")
+	runCmd.Flags().StringVar(&flags.LogFile, "log", "",
+		"log file path (default: ./kpi-collector-artifacts/kpi-<timestamp>.log)")
 
 	// Database flags
 	runCmd.Flags().StringVar(&flags.DatabaseType, "db-type", "sqlite",
-		"database type: sqlite or postgres")
+		"database type: sqlite (default) or postgres")
 	runCmd.Flags().StringVar(&flags.PostgresURL, "postgres-url", "",
 		"PostgreSQL connection string (required if db-type=postgres)")
 
@@ -98,12 +104,25 @@ func init() {
 func runCollect(cmd *cobra.Command, args []string) error {
 	fmt.Println("KPI Collector starting...")
 
+	// Generate timestamped file paths inside kpi-collector/ if not explicitly set
+	timestamp := time.Now().Format("2006-01-02-150405")
+	if flags.LogFile == "" {
+		flags.LogFile = filepath.Join(database.DefaultDataDir, fmt.Sprintf("kpi-%s.log", timestamp))
+	}
+	if flags.OutputFile == "" {
+		flags.OutputFile = filepath.Join(database.DefaultDataDir, fmt.Sprintf("kpi-output-%s.json", timestamp))
+	}
+
 	// Validate all flags (including cluster type)
 	if err := config.ValidateFlags(flags); err != nil {
 		return fmt.Errorf("invalid flags: %w", err)
 	}
 
 	fmt.Printf("Cluster: %s\n", flags.ClusterName)
+
+	if err := os.MkdirAll(database.DefaultDataDir, 0755); err != nil {
+		return fmt.Errorf("failed to create artifact directory: %w", err)
+	}
 
 	// Initialize logger
 	logF, err := logger.InitLogger(flags.LogFile)

--- a/internal/database/sqlite.go
+++ b/internal/database/sqlite.go
@@ -12,11 +12,15 @@ import (
 )
 
 const (
-	// DefaultDataDir is the artifact directory created in the user's working directory
-	DefaultDataDir = "kpi-collector-artifacts"
+	// DefaultOutputDir is the default artifact directory name, relative to CWD
+	DefaultOutputDir = "kpi-collector-artifacts"
 	// DefaultDBFileName is the SQLite database file name
 	DefaultDBFileName = "kpi_metrics.db"
 )
+
+// OutputDir is the resolved artifact directory. It defaults to DefaultOutputDir
+// and can be overridden via the --artifact-dir flag.
+var OutputDir = DefaultOutputDir
 
 type SQLiteDB struct{}
 
@@ -26,11 +30,11 @@ func NewSQLiteDB() *SQLiteDB {
 }
 
 // InitDB initializes the SQLite database and creates required tables.
-// The database is stored in ./kpi-collector-artifacts/kpi_metrics.db (relative to CWD).
+// The database is stored in <OutputDir>/kpi_metrics.db.
 func (sqlite_db *SQLiteDB) InitDB() (*sql.DB, error) {
-	dbPath := filepath.Join(DefaultDataDir, DefaultDBFileName)
+	dbPath := filepath.Join(OutputDir, DefaultDBFileName)
 
-	if err := os.MkdirAll(DefaultDataDir, 0755); err != nil {
+	if err := os.MkdirAll(OutputDir, 0755); err != nil {
 		return nil, err
 	}
 

--- a/internal/database/sqlite.go
+++ b/internal/database/sqlite.go
@@ -12,24 +12,13 @@ import (
 )
 
 const (
-	// DefaultDataDir is the directory name under user's data folder
-	DefaultDataDir = "kpi-collector"
+	// DefaultDataDir is the artifact directory created in the user's working directory
+	DefaultDataDir = "kpi-collector-artifacts"
 	// DefaultDBFileName is the SQLite database file name
 	DefaultDBFileName = "kpi_metrics.db"
 )
 
 type SQLiteDB struct{}
-
-// GetSQLiteDBPath returns the path to the SQLite database file.
-// The database is stored in ~/.kpi-collector/kpi_metrics.db
-func GetSQLiteDBPath() string {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		// Fallback to current directory if home can't be determined
-		return DefaultDBFileName
-	}
-	return filepath.Join(homeDir, ".kpi-collector", DefaultDBFileName)
-}
 
 // NewSQLiteDB creates a new SQLite database instance
 func NewSQLiteDB() *SQLiteDB {
@@ -37,13 +26,11 @@ func NewSQLiteDB() *SQLiteDB {
 }
 
 // InitDB initializes the SQLite database and creates required tables.
-// The database is stored in ~/.kpi-collector/kpi_metrics.db
+// The database is stored in ./kpi-collector-artifacts/kpi_metrics.db (relative to CWD).
 func (sqlite_db *SQLiteDB) InitDB() (*sql.DB, error) {
-	dbPath := GetSQLiteDBPath()
+	dbPath := filepath.Join(DefaultDataDir, DefaultDBFileName)
 
-	// Create data directory if it doesn't exist
-	dataDir := filepath.Dir(dbPath)
-	if err := os.MkdirAll(dataDir, 0755); err != nil {
+	if err := os.MkdirAll(DefaultDataDir, 0755); err != nil {
 		return nil, err
 	}
 

--- a/internal/database/sqlite.go
+++ b/internal/database/sqlite.go
@@ -12,14 +12,14 @@ import (
 )
 
 const (
-	// DefaultOutputDir is the default artifact directory name, relative to CWD
+	// DefaultOutputDir is the default artifacts directory name, relative to CWD
 	DefaultOutputDir = "kpi-collector-artifacts"
 	// DefaultDBFileName is the SQLite database file name
 	DefaultDBFileName = "kpi_metrics.db"
 )
 
-// OutputDir is the resolved artifact directory. It defaults to DefaultOutputDir
-// and can be overridden via the --artifact-dir flag.
+// OutputDir is the resolved artifacts directory. It defaults to DefaultOutputDir
+// and can be overridden via the --artifacts-dir flag.
 var OutputDir = DefaultOutputDir
 
 type SQLiteDB struct{}

--- a/internal/database/sqlite_test.go
+++ b/internal/database/sqlite_test.go
@@ -19,12 +19,13 @@ var _ = Describe("Sqlite", func() {
 
 	BeforeEach(func() {
 		sqliteDB = NewSQLiteDB()
+		OutputDir = DefaultOutputDir
 
 		var err error
 		tmpDir, err = os.MkdirTemp("", "sqlite-test-*")
 		Expect(err).NotTo(HaveOccurred())
 
-		// Change to temp directory so InitDB creates kpi-collector/ there
+		// Change to temp directory so InitDB creates the artifact dir there
 		originCwd, err = os.Getwd()
 		Expect(err).NotTo(HaveOccurred())
 		err = os.Chdir(tmpDir)
@@ -40,6 +41,7 @@ var _ = Describe("Sqlite", func() {
 			err := db.Close()
 			Expect(err).NotTo(HaveOccurred())
 		}
+		OutputDir = DefaultOutputDir
 		if originCwd != "" {
 			err := os.Chdir(originCwd)
 			Expect(err).NotTo(HaveOccurred())
@@ -67,13 +69,13 @@ var _ = Describe("Sqlite", func() {
 		})
 
 		It("should create the data directory", func() {
-			dataDir := filepath.Join(tmpDir, DefaultDataDir)
+			dataDir := filepath.Join(tmpDir, DefaultOutputDir)
 			_, err := os.Stat(dataDir)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("should create the database file", func() {
-			dbFile := filepath.Join(tmpDir, DefaultDataDir, DefaultDBFileName)
+			dbFile := filepath.Join(tmpDir, DefaultOutputDir, DefaultDBFileName)
 			_, err := os.Stat(dbFile)
 			Expect(err).NotTo(HaveOccurred())
 		})

--- a/internal/database/sqlite_test.go
+++ b/internal/database/sqlite_test.go
@@ -11,29 +11,25 @@ import (
 
 var _ = Describe("Sqlite", func() {
 	var (
-		db           *sql.DB
-		tmpDir       string
-		sqliteDB     *SQLiteDB
-		originalHome string
+		db        *sql.DB
+		tmpDir    string
+		sqliteDB  *SQLiteDB
+		originCwd string
 	)
 
-	// Runs before and after each test (It section)
-	// To provide clean, isolated environment for each test
 	BeforeEach(func() {
-		// Create SQLiteDB instance
 		sqliteDB = NewSQLiteDB()
 
-		// Create a temporary directory to act as HOME for test isolation
 		var err error
 		tmpDir, err = os.MkdirTemp("", "sqlite-test-*")
 		Expect(err).NotTo(HaveOccurred())
 
-		// Override HOME environment variable so GetSQLiteDBPath() uses our temp dir
-		originalHome = os.Getenv("HOME")
-		err = os.Setenv("HOME", tmpDir)
+		// Change to temp directory so InitDB creates kpi-collector/ there
+		originCwd, err = os.Getwd()
+		Expect(err).NotTo(HaveOccurred())
+		err = os.Chdir(tmpDir)
 		Expect(err).NotTo(HaveOccurred())
 
-		// Initialize database (will create in tmpDir/.kpi-collector/)
 		db, err = sqliteDB.InitDB()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(db).NotTo(BeNil())
@@ -44,12 +40,10 @@ var _ = Describe("Sqlite", func() {
 			err := db.Close()
 			Expect(err).NotTo(HaveOccurred())
 		}
-		// Restore original HOME
-		if originalHome != "" {
-			err := os.Setenv("HOME", originalHome)
+		if originCwd != "" {
+			err := os.Chdir(originCwd)
 			Expect(err).NotTo(HaveOccurred())
 		}
-		// Clean up temporary directory
 		if tmpDir != "" {
 			err := os.RemoveAll(tmpDir)
 			Expect(err).NotTo(HaveOccurred())
@@ -58,9 +52,6 @@ var _ = Describe("Sqlite", func() {
 
 	Describe("SQLite-Specific Features", func() {
 		It("should create the database and required tables", func() {
-			// sqlite_master = special system table in SQLite that contains
-			// metadata about all the database objects (tables, indexes, views, triggers)
-			// in your SQLite database.
 			var tableName string
 			err := db.QueryRow("SELECT name FROM sqlite_master WHERE type='table' AND name='clusters'").Scan(&tableName)
 			Expect(err).NotTo(HaveOccurred())
@@ -76,18 +67,17 @@ var _ = Describe("Sqlite", func() {
 		})
 
 		It("should create the data directory", func() {
-			dataDir := filepath.Join(tmpDir, ".kpi-collector")
+			dataDir := filepath.Join(tmpDir, DefaultDataDir)
 			_, err := os.Stat(dataDir)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("should create the database file", func() {
-			dbFile := filepath.Join(tmpDir, ".kpi-collector", "kpi_metrics.db")
+			dbFile := filepath.Join(tmpDir, DefaultDataDir, DefaultDBFileName)
 			_, err := os.Stat(dbFile)
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 
-	// Run all the shared interface tests
 	RunDatabaseInterfaceTests(func() (Database, *sql.DB) { return sqliteDB, db })
 })

--- a/internal/prometheus/client_test.go
+++ b/internal/prometheus/client_test.go
@@ -158,7 +158,9 @@ var _ = Describe("Client", func() {
 			tmpDir, err = os.MkdirTemp("", "prom-test-*")
 			Expect(err).NotTo(HaveOccurred())
 
-			// Change to temp directory so InitDB creates kpi-collector/ there
+			database.OutputDir = database.DefaultOutputDir
+
+			// Change to temp directory so InitDB creates the artifact dir there
 			originCwd, err = os.Getwd()
 			Expect(err).NotTo(HaveOccurred())
 			err = os.Chdir(tmpDir)
@@ -177,6 +179,7 @@ var _ = Describe("Client", func() {
 				err := testDB.Close()
 				Expect(err).NotTo(HaveOccurred())
 			}
+			database.OutputDir = database.DefaultOutputDir
 			if originCwd != "" {
 				err := os.Chdir(originCwd)
 				Expect(err).NotTo(HaveOccurred())

--- a/internal/prometheus/client_test.go
+++ b/internal/prometheus/client_test.go
@@ -146,47 +146,41 @@ var _ = Describe("Client", func() {
 	// Test executeQuery with mock Prometheus client
 	Describe("executeQuery", func() {
 		var (
-			testDB       *sql.DB
-			sqliteDB     database.Database
-			clusterID    int64
-			tmpDir       string
-			originalHome string
+			testDB    *sql.DB
+			sqliteDB  database.Database
+			clusterID int64
+			tmpDir    string
+			originCwd string
 		)
 
-		// Setup: Create a test database before each test
 		BeforeEach(func() {
 			var err error
-			// Create a temporary directory to act as HOME for test isolation
 			tmpDir, err = os.MkdirTemp("", "prom-test-*")
 			Expect(err).NotTo(HaveOccurred())
 
-			// Override HOME environment variable so GetSQLiteDBPath() uses our temp dir
-			originalHome = os.Getenv("HOME")
-			err = os.Setenv("HOME", tmpDir)
+			// Change to temp directory so InitDB creates kpi-collector/ there
+			originCwd, err = os.Getwd()
+			Expect(err).NotTo(HaveOccurred())
+			err = os.Chdir(tmpDir)
 			Expect(err).NotTo(HaveOccurred())
 
-			// Initialize the test database (will create in tmpDir/.kpi-collector/)
 			sqliteDB = database.NewSQLiteDB()
 			testDB, err = sqliteDB.InitDB()
 			Expect(err).NotTo(HaveOccurred())
 
-			// Create a test cluster
 			clusterID, err = sqliteDB.GetOrCreateCluster(testDB, "test-cluster", "")
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		// Cleanup: Close database and remove temp files after each test
 		AfterEach(func() {
 			if testDB != nil {
 				err := testDB.Close()
 				Expect(err).NotTo(HaveOccurred())
 			}
-			// Restore original HOME
-			if originalHome != "" {
-				err := os.Setenv("HOME", originalHome)
+			if originCwd != "" {
+				err := os.Chdir(originCwd)
 				Expect(err).NotTo(HaveOccurred())
 			}
-			// Clean up temporary directory
 			if tmpDir != "" {
 				err := os.RemoveAll(tmpDir)
 				Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
Storing artifacts in a hidden home directory made them hard to find and manage. Placing everything in a visible `./kpi-collector-artifacts/` directory in the working directory makes per-run artifacts easy to locate, inspect, and clean up. The `--artifact-dir` flag gives users control over where the directory is created.

Moved all artifacts (SQLite database, logs, Grafana config) from `~/.kpi-collector/` to `./kpi-collector-artifacts/` in the user's current working directory.
Added `--artifacts-dir` persistent flag on the root command to let users choose where artifacts are stored directly, without creating a subdirectory

## Artifact layout
- `kpi-collector-artifacts/`
  - `kpi_metrics.db` — database (accumulates across runs)
  - `kpi-<timestamp>.log` — per-run log
  - `grafana/` — created by `grafana start`
    - `datasources/datasource.yaml`
    - `dashboards/dashboard.json`
    - `provisioning/dashboards/dashboards.yaml`
## Note
- All commands (`run`, `db`, `grafana`) must be executed from the same working directory when using SQLite
