### PR TITLE
Improve CLI output, logging, and cleanup unused flags

### DIFF
--- a/docs/collecting-metrics.md
+++ b/docs/collecting-metrics.md
@@ -31,10 +31,8 @@ kpi-collector run \
   --cluster-type ran \
   --kubeconfig ~/.kube/config \
   --kpis-file kpis.json \
-  --frequency 30 \
-  --duration 1h \
-  --output my-metrics.json \
-  --log my-app.log
+  --frequency 30s \
+  --duration 1h
 ```
 
 Explicitly using SQLite:
@@ -134,8 +132,6 @@ kpi-collector run \
 | `--insecure-tls` | No | false | Skip TLS certificate verification (dev only) |
 | `--frequency` | No | 1m | Sampling frequency (for example: `10s`, `1m`, `2h`, `24h`) |
 | `--duration` | No | 45m | Total sampling duration (for example: `10s`, `1m`, `2h`, `24h`) |
-| `--output` | No | `kpi-output.json` | Output file name for results |
-| `--log` | No | `kpi.log` | Log file name |
 | `--db-type` | No | sqlite | Database type: `sqlite` or `postgres` |
 | `--postgres-url` | No** | - | PostgreSQL connection string |
 | `--once` | No | false | Collect all KPIs once and exit (ignores `--frequency` and `--duration`) |

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -18,12 +18,12 @@ import (
 	"github.com/redhat-best-practices-for-k8s/kpi-collection-tool/internal/prometheus"
 )
 
-const HUNDRED_MILLIS_DURATION_BUFFER = 100 * time.Millisecond
+const durationBuffer = 100 * time.Millisecond
 
 // RunOnce executes every KPI query exactly once and returns.
 // It ignores frequency and duration settings entirely.
 func RunOnce(kpis config.KPIs, flags config.InputFlags) {
-	fmt.Printf("\nKPI Collection Started - Single run mode\n\n")
+	fmt.Printf("\nKPI Collection Started - Single run mode\n")
 
 	log.Printf("Single run: executing %d KPIs", len(kpis.Queries))
 
@@ -34,7 +34,7 @@ func RunOnce(kpis config.KPIs, flags config.InputFlags) {
 	output.PrintShutdown("Single run completed")
 }
 
-// Run executes the KPI collection loop
+// Run executes the KPI collection loop until duration expires or interrupted.
 func Run(kpis config.KPIs, flags config.InputFlags) {
 	runOnceKPIs, repeatingKPIs := splitRunOnceQueries(kpis)
 
@@ -53,7 +53,7 @@ func Run(kpis config.KPIs, flags config.InputFlags) {
 		return
 	}
 
-	durationTimer := time.NewTimer(flags.Duration + HUNDRED_MILLIS_DURATION_BUFFER)
+	durationTimer := time.NewTimer(flags.Duration + durationBuffer)
 	defer durationTimer.Stop()
 
 	interruptChan := make(chan os.Signal, 1)
@@ -95,8 +95,8 @@ func splitRunOnceQueries(kpis config.KPIs) (runOnce config.KPIs, repeating confi
 	return runOnce, repeating
 }
 
-// groupKPIsByFrequency groups KPIs by their effective sampling frequency
-// This includes both default and custom frequency KPIs
+// groupKPIsByFrequency groups KPIs by their effective sampling frequency.
+// This includes both default and custom frequency KPIs.
 func groupKPIsByFrequency(kpis config.KPIs, defaultFreq time.Duration) map[time.Duration]config.KPIs {
 	kpisByFreq := make(map[time.Duration]config.KPIs)
 
@@ -111,7 +111,7 @@ func groupKPIsByFrequency(kpis config.KPIs, defaultFreq time.Duration) map[time.
 	if len(kpisByFreq) > 0 {
 		log.Printf("Grouped all KPIs into %d unique frequency groups", len(kpisByFreq))
 		for freq, group := range kpisByFreq {
-			log.Printf("  Frequency %ds: %d KPIs", freq, len(group.Queries))
+			log.Printf("  Frequency %s: %d KPIs", freq, len(group.Queries))
 		}
 	}
 
@@ -181,10 +181,10 @@ func runKPIs(kpis config.KPIs, flags config.InputFlags, sampleNumber int, totalS
 	}
 }
 
-// calculateTotalSamples calculates how many samples will run for a given frequency and duration
+// calculateTotalSamples calculates how many samples will run for a given frequency and duration.
+// First sample runs immediately at t=0, then every frequency seconds.
+// For duration D and frequency F: samples at 0, F, 2F, ... up to < D
 func calculateTotalSamples(frequency time.Duration, duration time.Duration) int {
-	// First sample runs immediately at t=0, then every frequency seconds
-	// For duration D and frequency F: samples at 0, F, 2F, ... up to < D
 	frequencySecs := int(frequency.Seconds())
 	durationSecs := int(duration.Seconds())
 	return (durationSecs / frequencySecs) + 1

--- a/internal/commands/db_remove.go
+++ b/internal/commands/db_remove.go
@@ -19,7 +19,7 @@ var removeCmd = &cobra.Command{
 	Short: "Delete data from the database",
 	Long: `Delete clusters, KPI metrics, or error records from the database.
 
-	WARNING: All remove operations are immediate and cannot be undone.`,
+WARNING: All remove operations are immediate and cannot be undone.`,
 }
 
 var removeClustersCmd = &cobra.Command{

--- a/internal/commands/db_show.go
+++ b/internal/commands/db_show.go
@@ -83,8 +83,8 @@ var showErrorsCmd = &cobra.Command{
 	Use:   "errors",
 	Short: "Show query error counts",
 	Long: `Display KPI queries that have encountered errors during collection.
-
-This helps identify which KPI queries are failing and need attention.`,
+Shows the error count per KPI — not the error details. To see the actual
+error messages, check the log file (--log flag on the run command).`,
 	Example: `  # List all query errors
   kpi-collector db show errors`,
 	RunE: runShowErrors,

--- a/internal/commands/run.go
+++ b/internal/commands/run.go
@@ -3,15 +3,19 @@ package commands
 import (
 	"fmt"
 	"log"
+	"os"
 	"time"
 
 	"github.com/redhat-best-practices-for-k8s/kpi-collection-tool/internal/collector"
 	"github.com/redhat-best-practices-for-k8s/kpi-collection-tool/internal/config"
+	"github.com/redhat-best-practices-for-k8s/kpi-collection-tool/internal/database"
 	"github.com/redhat-best-practices-for-k8s/kpi-collection-tool/internal/kubernetes"
 	"github.com/redhat-best-practices-for-k8s/kpi-collection-tool/internal/logger"
 
 	"github.com/spf13/cobra"
 )
+
+const defaultLogFile = "kpi.log"
 
 // Use the existing InputFlags struct directly!
 var flags config.InputFlags
@@ -26,16 +30,30 @@ in a database (SQLite or PostgreSQL). Supports two authentication modes:
   2. Manual bearer token and Thanos URL
 
 The tool will continuously collect metrics at the specified frequency 
-for the specified duration.`,
-	Example: `  # Using kubeconfig (auto-discovery)
-  kpi-collector collect --cluster-name prod --cluster-type ran --kubeconfig ~/.kube/config
+for the specified duration.
+
+For more usage options, see the docs/ directory.`,
+	Example: `  # Using kubeconfig (auto-discovery of Thanos URL and token)
+  kpi-collector run --cluster-name prod --cluster-type ran \
+    --kubeconfig ~/.kube/config --kpis-file kpis.json
 
   # Using manual credentials
-  kpi-collector collect --cluster-name prod --cluster-type core --token TOKEN --thanos-url thanos.example.com
+  kpi-collector run --cluster-name prod --cluster-type core \
+    --token $TOKEN --thanos-url thanos.example.com --kpis-file kpis.json
+
+  # Collect all KPIs once and exit
+  kpi-collector run --cluster-name prod --cluster-type ran \
+    --kubeconfig ~/.kube/config --kpis-file kpis.json --once
+
+  # Custom sampling: every 30s for 2 hours
+  kpi-collector run --cluster-name prod --cluster-type ran \
+    --kubeconfig ~/.kube/config --kpis-file kpis.json \
+    --frequency 30s --duration 2h
 
   # With PostgreSQL backend
-  kpi-collector collect --cluster-name prod --cluster-type hub --kubeconfig ~/.kube/config \
-    --db-type postgres --postgres-url "postgresql://user:pass@localhost/kpi`,
+  kpi-collector run --cluster-name prod --cluster-type hub \
+    --kubeconfig ~/.kube/config --kpis-file kpis.json \
+    --db-type postgres --postgres-url "postgresql://user:pass@localhost:5432/kpi"`,
 	RunE: runCollect,
 }
 
@@ -61,12 +79,6 @@ func init() {
 		"sampling frequency (e.g. 30s, 1m, 2h)")
 	runCmd.Flags().DurationVar(&flags.Duration, "duration", 45*time.Minute,
 		"total duration for sampling (e.g. 10s, 1m, 2h)")
-
-	// Output flags
-	runCmd.Flags().StringVar(&flags.OutputFile, "output", "kpi-output.json",
-		"output file name for results")
-	runCmd.Flags().StringVar(&flags.LogFile, "log", "kpi.log",
-		"log file name")
 
 	// Database flags
 	runCmd.Flags().StringVar(&flags.DatabaseType, "db-type", "sqlite",
@@ -103,26 +115,29 @@ func runCollect(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("invalid flags: %w", err)
 	}
 
-	fmt.Printf("Cluster: %s\n", flags.ClusterName)
+	fmt.Printf("Cluster: %s (%s)\n", flags.ClusterName, flags.ClusterType)
 
 	// Initialize logger
-	logF, err := logger.InitLogger(flags.LogFile)
+	logF, err := logger.InitLogger(defaultLogFile)
 	if err != nil {
 		return fmt.Errorf("failed to initialize logger: %w", err)
 	}
 	defer func() {
 		if err := logF.Close(); err != nil {
-			fmt.Printf("Failed to close log file: %v\n", err)
+			fmt.Fprintf(os.Stderr, "Warning: failed to close log file: %v\n", err)
 		}
 	}()
+	fmt.Printf("Log file: %s\n", defaultLogFile)
+	fmt.Printf("Database: %s\n", databaseLocation(flags))
 
-	log.Println("KPI Collector initialized.")
+	log.Println("KPI Collector initialized")
 
 	// Load KPI queries
 	kpis, err := config.LoadKPIs(flags.KPIsFile)
 	if err != nil {
 		return fmt.Errorf("failed to load KPI queries: %w", err)
 	}
+	log.Printf("Loaded KPIs from %s", flags.KPIsFile)
 
 	// Validate KPI configurations (syntax, duplicates, etc.)
 	if validationErrors := config.ValidateKPIs(kpis); len(validationErrors) > 0 {
@@ -150,12 +165,15 @@ func runCollect(cmd *cobra.Command, args []string) error {
 
 	// If kubeconfig is provided, discover Thanos URL and token
 	if flags.Kubeconfig != "" {
+		log.Printf("Using kubeconfig authentication: %s", flags.Kubeconfig)
 		flags.ThanosURL, flags.BearerToken, err = kubernetes.SetupKubeconfigAuth(flags.Kubeconfig)
 		if err != nil {
 			return fmt.Errorf("failed to setup kubeconfig auth: %w", err)
 		}
 		fmt.Printf("Discovered Thanos URL: %s\n", flags.ThanosURL)
-		fmt.Printf("Created service account token!\n")
+		fmt.Println("Created service account token")
+	} else {
+		log.Printf("Using manual token authentication for %s", flags.ThanosURL)
 	}
 
 	// Run collection
@@ -165,9 +183,14 @@ func runCollect(cmd *cobra.Command, args []string) error {
 		collector.Run(kpis, flags)
 	}
 
-	fmt.Println("All queries completed successfully!")
-
 	return nil
+}
+
+func databaseLocation(flags config.InputFlags) string {
+	if flags.DatabaseType == "postgres" {
+		return "postgres (external)"
+	}
+	return fmt.Sprintf("sqlite (%s)", database.GetSQLiteDBPath())
 }
 
 // substituteCPUsIfNeeded checks if queries contain CPU placeholders and if so,

--- a/internal/commands/run.go
+++ b/internal/commands/run.go
@@ -179,7 +179,10 @@ func runCollect(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("failed to setup kubeconfig auth: %w", err)
 		}
 		fmt.Printf("Discovered Thanos URL: %s\n", flags.ThanosURL)
-		fmt.Printf("Created service account token (%s)!\n", kubernetes.TokenServiceAccountName)
+		fmt.Printf("Created service account token (sa=%s, ns=%s, duration=%s)\n",
+			kubernetes.TokenServiceAccountName,
+			kubernetes.MonitoringNamespace,
+			"10h")
 	}
 
 	// Run collection

--- a/internal/config/cli_flags.go
+++ b/internal/config/cli_flags.go
@@ -39,14 +39,6 @@ func ValidateFlags(flags InputFlags) error {
 		return fmt.Errorf("duration must be greater than 0")
 	}
 
-	if flags.OutputFile == "" {
-		return fmt.Errorf("output file must be specified")
-	}
-
-	if flags.LogFile == "" {
-		return fmt.Errorf("log file must be specified")
-	}
-
 	if flags.DatabaseType != "sqlite" && flags.DatabaseType != "postgres" {
 		return fmt.Errorf("invalid db-type: must be 'sqlite' or 'postgres'")
 	}

--- a/internal/config/cli_flags_test.go
+++ b/internal/config/cli_flags_test.go
@@ -13,24 +13,20 @@ const (
 	validBearerToken  = "test-token"
 	validThanosURL    = "https://thanos.example.com"
 	validKubeconfig   = "/path/to/kubeconfig"
-	validOutputFile   = "output.json"
-	validLogFile      = "app.log"
 	validSamplingFreq = 60 * time.Second
 	validDuration     = 45 * time.Minute
 	validDatabaseType = "sqlite"
 	validKPIsFile     = "/path/to/kpis.json"
 
-	errClusterNameRequiredMsg    = "cluster name is required: use --cluster-name flag"
-	errClusterTypeRequiredMsg    = "cluster-type is required: must be 'ran', 'core', or 'hub'"
-	errInvalidClusterTypeMsg     = "invalid cluster-type 'invalid': must be 'ran', 'core', or 'hub'"
-	errInvalidFlagComboMsg       = "invalid flag combination: either provide --token and --thanos-url, or provide --kubeconfig"
-	errSamplingFreqMsg           = "sampling frequency must be greater than 0"
-	errDurationMsg               = "duration must be greater than 0"
-	errOutputFileMsg             = "output file must be specified"
-	errLogFileMsg                = "log file must be specified"
-	errInvalidDBTypeMsg          = "invalid db-type: must be 'sqlite' or 'postgres'"
-	errPostgresURLRequiredMsg    = "postgres-url is required when db-type=postgres"
-	errKPIsFileMsg               = "kpis-file must be specified"
+	errClusterNameRequiredMsg = "cluster name is required: use --cluster-name flag"
+	errClusterTypeRequiredMsg = "cluster-type is required: must be 'ran', 'core', or 'hub'"
+	errInvalidClusterTypeMsg  = "invalid cluster-type 'invalid': must be 'ran', 'core', or 'hub'"
+	errInvalidFlagComboMsg    = "invalid flag combination: either provide --token and --thanos-url, or provide --kubeconfig"
+	errSamplingFreqMsg        = "sampling frequency must be greater than 0"
+	errDurationMsg            = "duration must be greater than 0"
+	errInvalidDBTypeMsg       = "invalid db-type: must be 'sqlite' or 'postgres'"
+	errPostgresURLRequiredMsg = "postgres-url is required when db-type=postgres"
+	errKPIsFileMsg            = "kpis-file must be specified"
 )
 
 var _ = Describe("validateFlags test", func() {
@@ -56,8 +52,6 @@ var _ = Describe("validateFlags test", func() {
 				ThanosURL:    validThanosURL,
 				SamplingFreq: validSamplingFreq,
 				Duration:     validDuration,
-				OutputFile:   validOutputFile,
-				LogFile:      validLogFile,
 				DatabaseType: validDatabaseType,
 				KPIsFile:     validKPIsFile,
 			},
@@ -70,8 +64,6 @@ var _ = Describe("validateFlags test", func() {
 				Kubeconfig:   validKubeconfig,
 				SamplingFreq: validSamplingFreq,
 				Duration:     validDuration,
-				OutputFile:   validOutputFile,
-				LogFile:      validLogFile,
 				DatabaseType: validDatabaseType,
 				KPIsFile:     validKPIsFile,
 			},
@@ -94,8 +86,6 @@ var _ = Describe("validateFlags test", func() {
 				ThanosURL:    validThanosURL,
 				SamplingFreq: validSamplingFreq,
 				Duration:     validDuration,
-				OutputFile:   validOutputFile,
-				LogFile:      validLogFile,
 				DatabaseType: validDatabaseType,
 				KPIsFile:     validKPIsFile,
 			},
@@ -109,8 +99,6 @@ var _ = Describe("validateFlags test", func() {
 				ThanosURL:    validThanosURL,
 				SamplingFreq: validSamplingFreq,
 				Duration:     validDuration,
-				OutputFile:   validOutputFile,
-				LogFile:      validLogFile,
 				DatabaseType: validDatabaseType,
 				KPIsFile:     validKPIsFile,
 			},
@@ -177,8 +165,6 @@ var _ = Describe("validateFlags test", func() {
 				ThanosURL:    validThanosURL,
 				SamplingFreq: 0,
 				Duration:     validDuration,
-				OutputFile:   validOutputFile,
-				LogFile:      validLogFile,
 				DatabaseType: validDatabaseType,
 				KPIsFile:     validKPIsFile,
 			},
@@ -192,8 +178,6 @@ var _ = Describe("validateFlags test", func() {
 				ThanosURL:    validThanosURL,
 				SamplingFreq: -10,
 				Duration:     validDuration,
-				OutputFile:   validOutputFile,
-				LogFile:      validLogFile,
 				DatabaseType: validDatabaseType,
 				KPIsFile:     validKPIsFile,
 			},
@@ -208,8 +192,6 @@ var _ = Describe("validateFlags test", func() {
 				ThanosURL:    validThanosURL,
 				SamplingFreq: validSamplingFreq,
 				Duration:     0,
-				OutputFile:   validOutputFile,
-				LogFile:      validLogFile,
 				DatabaseType: validDatabaseType,
 				KPIsFile:     validKPIsFile,
 			},
@@ -223,44 +205,10 @@ var _ = Describe("validateFlags test", func() {
 				ThanosURL:    validThanosURL,
 				SamplingFreq: validSamplingFreq,
 				Duration:     -10 * time.Minute,
-				OutputFile:   validOutputFile,
-				LogFile:      validLogFile,
 				DatabaseType: validDatabaseType,
 				KPIsFile:     validKPIsFile,
 			},
 			errDurationMsg,
-		),
-		// Error cases - missing output file
-		Entry("empty output file",
-			InputFlags{
-				ClusterName:  validClusterName,
-				ClusterType:  validClusterType,
-				BearerToken:  validBearerToken,
-				ThanosURL:    validThanosURL,
-				SamplingFreq: validSamplingFreq,
-				Duration:     validDuration,
-				OutputFile:   "",
-				LogFile:      validLogFile,
-				DatabaseType: validDatabaseType,
-				KPIsFile:     validKPIsFile,
-			},
-			errOutputFileMsg,
-		),
-		// Error cases - missing log file
-		Entry("empty log file",
-			InputFlags{
-				ClusterName:  validClusterName,
-				ClusterType:  validClusterType,
-				BearerToken:  validBearerToken,
-				ThanosURL:    validThanosURL,
-				SamplingFreq: validSamplingFreq,
-				Duration:     validDuration,
-				OutputFile:   validOutputFile,
-				LogFile:      "",
-				DatabaseType: validDatabaseType,
-				KPIsFile:     validKPIsFile,
-			},
-			errLogFileMsg,
 		),
 		// Error cases - invalid database type
 		Entry("invalid database type",
@@ -271,8 +219,6 @@ var _ = Describe("validateFlags test", func() {
 				ThanosURL:    validThanosURL,
 				SamplingFreq: validSamplingFreq,
 				Duration:     validDuration,
-				OutputFile:   validOutputFile,
-				LogFile:      validLogFile,
 				DatabaseType: "mysql",
 				KPIsFile:     validKPIsFile,
 			},
@@ -286,8 +232,6 @@ var _ = Describe("validateFlags test", func() {
 				ThanosURL:    validThanosURL,
 				SamplingFreq: validSamplingFreq,
 				Duration:     validDuration,
-				OutputFile:   validOutputFile,
-				LogFile:      validLogFile,
 				DatabaseType: "",
 				KPIsFile:     validKPIsFile,
 			},
@@ -302,8 +246,6 @@ var _ = Describe("validateFlags test", func() {
 				ThanosURL:    validThanosURL,
 				SamplingFreq: validSamplingFreq,
 				Duration:     validDuration,
-				OutputFile:   validOutputFile,
-				LogFile:      validLogFile,
 				DatabaseType: "postgres",
 				PostgresURL:  "",
 				KPIsFile:     validKPIsFile,
@@ -319,8 +261,6 @@ var _ = Describe("validateFlags test", func() {
 				ThanosURL:    validThanosURL,
 				SamplingFreq: validSamplingFreq,
 				Duration:     validDuration,
-				OutputFile:   validOutputFile,
-				LogFile:      validLogFile,
 				DatabaseType: "postgres",
 				PostgresURL:  "postgresql://user:pass@localhost:5432/dbname",
 				KPIsFile:     validKPIsFile,
@@ -337,8 +277,6 @@ var _ = Describe("validateFlags test", func() {
 				SingleRun:    true,
 				SamplingFreq: validSamplingFreq,
 				Duration:     validDuration,
-				OutputFile:   validOutputFile,
-				LogFile:      validLogFile,
 				DatabaseType: validDatabaseType,
 				KPIsFile:     validKPIsFile,
 			},
@@ -353,8 +291,6 @@ var _ = Describe("validateFlags test", func() {
 				ThanosURL:    validThanosURL,
 				SamplingFreq: validSamplingFreq,
 				Duration:     validDuration,
-				OutputFile:   validOutputFile,
-				LogFile:      validLogFile,
 				DatabaseType: validDatabaseType,
 				KPIsFile:     "",
 			},

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -56,8 +56,6 @@ type InputFlags struct {
 	InsecureTLS  bool
 	SamplingFreq time.Duration
 	Duration     time.Duration
-	OutputFile   string
-	LogFile      string
 	DatabaseType string // "sqlite" or "postgres"
 	PostgresURL  string // PostgreSQL connection string
 	KPIsFile     string

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -1,6 +1,5 @@
 // Package logger provides file-based logging initialization for the KPI collector.
-// It configures the standard log package to write to a specified file with
-// timestamps and source file information.
+// It configures the standard log package to write to a specified file with timestamps.
 package logger
 
 import (
@@ -16,6 +15,6 @@ func InitLogger(logFile string) (*os.File, error) {
 		return nil, fmt.Errorf("failed to open log file: %w", err)
 	}
 	log.SetOutput(file)
-	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
+	log.SetFlags(log.Ldate | log.Ltime)
 	return file, nil
 }

--- a/internal/output/collection_printer.go
+++ b/internal/output/collection_printer.go
@@ -65,7 +65,6 @@ func PrintStartup(duration string, deadline string) {
 
 	fmt.Println()
 	fmt.Printf("KPI Collection Started - Duration: %s (until %s)\n", duration, deadline)
-	fmt.Println()
 }
 
 // PrintShutdown prints collection shutdown info (thread-safe)

--- a/internal/prometheus/client.go
+++ b/internal/prometheus/client.go
@@ -101,7 +101,6 @@ func RunQueries(kpisToRun config.KPIs, flags config.InputFlags, sampleNumber int
 			Range:        queryRangeDuration,
 		}
 		executeQuery(ctx, v1api, db, dbImpl, clusterID, queryInfo)
-
 	}
 
 	return nil
@@ -111,13 +110,13 @@ func RunQueries(kpisToRun config.KPIs, flags config.InputFlags, sampleNumber int
 func executeQuery(ctx context.Context, v1api promv1.API, db *sql.DB, dbImpl database.Database, clusterID int64, info output.QueryInfo) {
 	now := time.Now()
 
-	// Execute query using the Prometheus client library.
 	var (
 		result   model.Value
 		warnings promv1.Warnings
 		err      error
 	)
 
+	// Execute query using the Prometheus client library
 	if info.QueryType == "range" {
 		queryRange := promv1.Range{
 			Start: now.Add(-info.Range),
@@ -134,7 +133,6 @@ func executeQuery(ctx context.Context, v1api promv1.API, db *sql.DB, dbImpl data
 	}
 
 	if err != nil {
-		queryResult.Success = false
 		queryResult.Error = err
 		output.PrintQueryResult(info, queryResult)
 		if storeErr := dbImpl.IncrementQueryError(db, info.QueryID); storeErr != nil {
@@ -146,7 +144,6 @@ func executeQuery(ctx context.Context, v1api promv1.API, db *sql.DB, dbImpl data
 	// Store results
 	err = dbImpl.StoreQueryResults(db, clusterID, info.QueryID, result)
 	if err != nil {
-		queryResult.Success = false
 		queryResult.Error = fmt.Errorf("failed to store: %v", err)
 		output.PrintQueryResult(info, queryResult)
 		return

--- a/kpis.json.template
+++ b/kpis.json.template
@@ -50,13 +50,13 @@
             "query-type": "range",
             "step": "30s",
             "range": "1h"
-        }
+        },
         {
             // only needs a single snapshot, not repeated sampling
             "id": "cluster-uptime",
             "promquery": "max(time() - process_start_time_seconds{job=\"kubelet\"})",
             "run-once": true
-        },
+        }
     ]
 }
 


### PR DESCRIPTION
- Remove unused `--output` and `--log` CLI flags and all their references across code, tests, and docs. Log file is now hardcoded to `kpi.log`.
- Improve startup output with cluster type, log file path, database location, and authentication method.
- Fix `run --help` examples (wrong command name, missing quote, missing scenarios).
- Clean up console messages
- Make log format user-friendly by removing source file/line info.
- Fix misc issues: `db remove` help indentation, `kpis.json.template` JSON syntax errors, non-idiomatic constant name.
