### PR TITLE
Use collection duration for service account token expiry instead of hardcoded 10h

### DIFF
--- a/internal/commands/run.go
+++ b/internal/commands/run.go
@@ -174,15 +174,18 @@ func runCollect(cmd *cobra.Command, args []string) error {
 	// If kubeconfig is provided, discover Thanos URL and token
 	if flags.Kubeconfig != "" {
 		log.Printf("Using kubeconfig authentication: %s", flags.Kubeconfig)
-		flags.ThanosURL, flags.BearerToken, err = kubernetes.SetupKubeconfigAuth(flags.Kubeconfig)
+
+		tokenDuration := tokenDurationForCollection(flags.SingleRun, flags.Duration)
+
+		flags.ThanosURL, flags.BearerToken, err = kubernetes.SetupKubeconfigAuth(flags.Kubeconfig, tokenDuration)
 		if err != nil {
 			return fmt.Errorf("failed to setup kubeconfig auth: %w", err)
 		}
 		fmt.Printf("Discovered Thanos URL: %s\n", flags.ThanosURL)
-		fmt.Printf("Created service account token (sa=%s, ns=%s, duration=%s)\n",
+		fmt.Printf("Created service account token (sa=%s, ns=%s, expiry=%s)\n",
 			kubernetes.TokenServiceAccountName,
 			kubernetes.MonitoringNamespace,
-			"10h")
+			tokenDuration)
 	}
 
 	// Run collection
@@ -207,6 +210,17 @@ func databaseLocation(flags config.InputFlags) string {
 		return "postgres (external)"
 	}
 	return fmt.Sprintf("sqlite (%s)", filepath.Join(database.OutputDir, database.DefaultDBFileName))
+}
+
+// tokenDurationForCollection returns the token expiration to use when creating
+// a service-account token via kubeconfig.  In single-run mode the token
+// is short-lived (10 min); otherwise it matches the collection duration
+// plus a 10-minute buffer so it won't expire mid-collection.
+func tokenDurationForCollection(isSingleRun bool, collectionDuration time.Duration) time.Duration {
+	if isSingleRun {
+		return 10 * time.Minute
+	}
+	return collectionDuration + 10*time.Minute
 }
 
 // substituteCPUsIfNeeded checks if queries contain CPU placeholders and if so,

--- a/internal/kubernetes/client.go
+++ b/internal/kubernetes/client.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	authv1 "k8s.io/api/authentication/v1"
 	"k8s.io/client-go/kubernetes"
@@ -20,15 +21,15 @@ const (
 	TokenServiceAccountName  = "prometheus-k8s"
 )
 
-// setupKubeconfigAuth sets up authentication using kubeconfig file
-// and discovers Thanos URL and creates service account token
-func SetupKubeconfigAuth(kubeconfig string) (string, string, error) {
+// SetupKubeconfigAuth sets up authentication using kubeconfig file,
+// discovers the Thanos URL, and creates a service account token
+// whose lifetime matches tokenDuration.
+func SetupKubeconfigAuth(kubeconfig string, tokenDuration time.Duration) (string, string, error) {
 	clientset, err := setupKubernetesClient(kubeconfig)
 	if err != nil {
 		return "", "", fmt.Errorf("failed to setup Kubernetes client: %v", err)
 	}
 
-	// Wrap the clientset in our interface implementation
 	client := &k8sClientImpl{clientset: clientset}
 
 	thanosURL, err := getThanosURL(client)
@@ -36,7 +37,7 @@ func SetupKubeconfigAuth(kubeconfig string) (string, string, error) {
 		return "", "", fmt.Errorf("failed to get Thanos URL: %v", err)
 	}
 
-	bearerToken, err := createServiceAccountToken(client)
+	bearerToken, err := createServiceAccountToken(client, tokenDuration)
 	if err != nil {
 		return "", "", fmt.Errorf("failed to create service account token: %v", err)
 	}
@@ -80,11 +81,13 @@ func getThanosURL(client K8sClient) (string, error) {
 }
 
 // createServiceAccountToken creates a service account token for authentication
-// Equivalent to: oc create token prometheus-k8s -n openshift-monitoring --duration=10h
-func createServiceAccountToken(client K8sClient) (string, error) {
+// with the given expiration duration.
+func createServiceAccountToken(client K8sClient, expiration time.Duration) (string, error) {
+	expirationSeconds := int64(expiration.Seconds())
+
 	tokenRequest := &authv1.TokenRequest{
 		Spec: authv1.TokenRequestSpec{
-			ExpirationSeconds: int64Ptr(36000), // 10 hours = 36000 seconds
+			ExpirationSeconds: &expirationSeconds,
 		},
 	}
 
@@ -101,7 +104,3 @@ func createServiceAccountToken(client K8sClient) (string, error) {
 	return result.Status.Token, nil
 }
 
-// int64Ptr returns a pointer to an int64 value
-func int64Ptr(i int64) *int64 {
-	return &i
-}

--- a/internal/kubernetes/client_test.go
+++ b/internal/kubernetes/client_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -243,76 +244,60 @@ users:
 
 	Describe("createServiceAccountToken", func() {
 		It("should successfully create and return a service account token", func() {
-			// A mock client that returns a valid token response (no actual server)
+			requestedDuration := 45 * time.Minute
+
 			mock := &mockK8sClient{
 				createServiceAccountTokenFunc: func(ctx context.Context, namespace, serviceAccount string, tokenRequest *authv1.TokenRequest) (*authv1.TokenRequest, error) {
-				// Verify the correct namespace and service account
-				Expect(namespace).To(Equal(MonitoringNamespace))
-				Expect(serviceAccount).To(Equal(TokenServiceAccountName))
+					Expect(namespace).To(Equal(MonitoringNamespace))
+					Expect(serviceAccount).To(Equal(TokenServiceAccountName))
+					Expect(*tokenRequest.Spec.ExpirationSeconds).To(Equal(int64(requestedDuration.Seconds())))
 
-					// Return a mock token response
 					return &authv1.TokenRequest{
 						Status: authv1.TokenRequestStatus{
 							Token: "mock-service-account-token-12345",
 							ExpirationTimestamp: metav1.Time{
-								Time: metav1.Now().Add(36000),
+								Time: metav1.Now().Add(requestedDuration),
 							},
 						},
 					}, nil
 				},
 			}
 
-			// We call createServiceAccountToken
-			token, err := createServiceAccountToken(mock)
+			token, err := createServiceAccountToken(mock, requestedDuration)
 
-			// We should not get an error
 			Expect(err).NotTo(HaveOccurred())
-			// The token should not be empty
-			Expect(token).NotTo(BeEmpty())
-			// The token should match what the mock returned
 			Expect(token).To(Equal("mock-service-account-token-12345"))
 		})
 
 		It("should return an error when service account does not exist", func() {
-			// A mock client that returns an error (no actual server)
 			mock := &mockK8sClient{
 				createServiceAccountTokenFunc: func(ctx context.Context, namespace, serviceAccount string, tokenRequest *authv1.TokenRequest) (*authv1.TokenRequest, error) {
 					return nil, fmt.Errorf("serviceaccount not found")
 				},
 			}
 
-			// We call createServiceAccountToken
-			token, err := createServiceAccountToken(mock)
+			token, err := createServiceAccountToken(mock, time.Hour)
 
-			// We should get an error
 			Expect(err).To(HaveOccurred())
-			// The token should be empty
 			Expect(token).To(BeEmpty())
 		})
 
 		It("should return an error when API returns empty token", func() {
-			// A mock client that returns a response with an empty token (no actual server)
 			mock := &mockK8sClient{
 				createServiceAccountTokenFunc: func(ctx context.Context, namespace, serviceAccount string, tokenRequest *authv1.TokenRequest) (*authv1.TokenRequest, error) {
 					return &authv1.TokenRequest{
 						Status: authv1.TokenRequestStatus{
-							Token: "", // Empty token
+							Token: "",
 						},
 					}, nil
 				},
 			}
 
-			// We call createServiceAccountToken
-			token, err := createServiceAccountToken(mock)
-			// We should not get an error (API call succeeded)
+			token, err := createServiceAccountToken(mock, time.Hour)
+
 			Expect(err).NotTo(HaveOccurred())
-			// The token should be empty
 			Expect(token).To(BeEmpty())
 		})
-
-		// Note: This test is not applicable with mock client
-		// The mock returns Go structs directly, not JSON
-		// JSON parsing errors would only occur at the HTTP layer
 	})
 
 	Describe("SetupKubeconfigAuth", func() {
@@ -339,37 +324,28 @@ users:
 		})
 
 		It("should return an error when kubeconfig file does not exist", func() {
-			// A path to a non-existent kubeconfig file
 			nonExistentPath := filepath.Join(tmpDir, "nonexistent")
 
-			// We call SetupKubeconfigAuth
-			thanosURL, token, err := SetupKubeconfigAuth(nonExistentPath)
+			thanosURL, token, err := SetupKubeconfigAuth(nonExistentPath, time.Hour)
 
-			// We should get an error
 			Expect(err).To(HaveOccurred())
-			// Both return values should be empty
 			Expect(thanosURL).To(BeEmpty())
 			Expect(token).To(BeEmpty())
 		})
 
 		It("should return an error when kubeconfig is invalid", func() {
-			// An invalid kubeconfig file
 			invalidConfig := []byte("invalid yaml {[}")
 			err := os.WriteFile(kubeconfigPath, invalidConfig, 0644)
 			Expect(err).NotTo(HaveOccurred())
 
-			// We call SetupKubeconfigAuth
-			thanosURL, token, err := SetupKubeconfigAuth(kubeconfigPath)
+			thanosURL, token, err := SetupKubeconfigAuth(kubeconfigPath, time.Hour)
 
-			// We should get an error
 			Expect(err).To(HaveOccurred())
-			// Both return values should be empty
 			Expect(thanosURL).To(BeEmpty())
 			Expect(token).To(BeEmpty())
 		})
 
 		It("should return an error when unable to connect to cluster", func() {
-			// A valid kubeconfig structure but pointing to non-existent server
 			validConfig := `
 apiVersion: v1
 kind: Config
@@ -392,12 +368,9 @@ users:
 			err := os.WriteFile(kubeconfigPath, []byte(validConfig), 0644)
 			Expect(err).NotTo(HaveOccurred())
 
-			// We call SetupKubeconfigAuth
-			thanosURL, token, err := SetupKubeconfigAuth(kubeconfigPath)
+			thanosURL, token, err := SetupKubeconfigAuth(kubeconfigPath, time.Hour)
 
-			// We should get an error (cannot connect to non-existent server)
 			Expect(err).To(HaveOccurred())
-			// Both return values should be empty
 			Expect(thanosURL).To(BeEmpty())
 			Expect(token).To(BeEmpty())
 		})


### PR DESCRIPTION
When `--kubeconfig` is used, the tool creates a temporary service account token. Previously the token expiry was hardcoded to 10h regardless of the actual collection duration.
Now the token expiry matches the `--duration` flag (plus a 10-minute buffer), and uses a short 10-minute expiry when `--once` is set.

Addresses feedback from [comment#83](https://github.com/redhat-best-practices-for-k8s/kpi-collection-tool/pull/83#pullrequestreview-4080686330)
