### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: Upload release assets
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  upload-release-assets:
+    name: Upload release assets
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - name: Check out code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+
+      - name: Build kpi-collector binary (x86_64)
+        env:
+          SHELL: /bin/bash
+        run: |
+          make build
+          tar -cvzf kpi-collector-${GITHUB_REF_NAME}-x86_64.tar.gz kpi-collector
+          rm kpi-collector
+
+      - name: Build kpi-collector binary (ARM 64)
+        env:
+          SHELL: /bin/bash
+        run: |
+          make build-darwin-arm64
+          tar -cvzf kpi-collector-${GITHUB_REF_NAME}-arm64.tar.gz kpi-collector
+          rm kpi-collector
+
+      - name: Upload kpi-collector binaries
+        env:
+          SHELL: /bin/bash
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload ${GITHUB_REF_NAME} kpi-collector-${GITHUB_REF_NAME}-x86_64.tar.gz kpi-collector-${GITHUB_REF_NAME}-arm64.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -5,17 +5,27 @@ BINARY_NAME=kpi-collector
 # Module path for go install
 MODULE_PATH=github.com/redhat-best-practices-for-k8s/kpi-collection-tool
 
+# Release and commit injected at build time
+GIT_COMMIT  ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+GIT_RELEASE ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+LINKER_FLAGS = -s -w \
+	-X '$(MODULE_PATH)/internal/commands.gitCommit=$(GIT_COMMIT)' \
+	-X '$(MODULE_PATH)/internal/commands.gitRelease=$(GIT_RELEASE)'
+
 build:
-	CGO_ENABLED=0 go build -ldflags="-s -w" -o $(BINARY_NAME) ./cmd/kpi-collector
+	CGO_ENABLED=0 go build -ldflags="$(LINKER_FLAGS)" -o $(BINARY_NAME) ./cmd/kpi-collector
+
+build-darwin-arm64:
+	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -ldflags="$(LINKER_FLAGS)" -o $(BINARY_NAME) ./cmd/kpi-collector
 
 build-debug:
-	CGO_ENABLED=0 go build -gcflags="all=-N -l" -o $(BINARY_NAME) ./cmd/kpi-collector
+	CGO_ENABLED=0 go build -gcflags="all=-N -l" -ldflags="$(LINKER_FLAGS)" -o $(BINARY_NAME) ./cmd/kpi-collector
 
 build-dynamic-linking:
-	CGO_ENABLED=1 go build -ldflags="-s -w -extldflags '-z relro -z now'" -o $(BINARY_NAME) ./cmd/kpi-collector
+	CGO_ENABLED=1 go build -ldflags="$(LINKER_FLAGS) -extldflags '-z relro -z now'" -o $(BINARY_NAME) ./cmd/kpi-collector
 
 build-dynamic-linking-debug:
-	CGO_ENABLED=1 go build -gcflags="all=-N -l" -o $(BINARY_NAME) ./cmd/kpi-collector
+	CGO_ENABLED=1 go build -gcflags="all=-N -l" -ldflags="$(LINKER_FLAGS)" -o $(BINARY_NAME) ./cmd/kpi-collector
 
 # Mac installation via Homebrew
 install-golangci-lint-mac:

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -3,18 +3,40 @@ package commands
 import (
 	"fmt"
 	"os"
+	"runtime/debug"
 
 	"github.com/redhat-best-practices-for-k8s/kpi-collection-tool/internal/database"
 
 	"github.com/spf13/cobra"
 )
 
+// Set at build time via -ldflags "-X ...commands.gitRelease=..." and "-X ...commands.gitCommit=..."
+// Falls back to Go module build info for `go install` users.
+var (
+	gitCommit  = "unknown"
+	gitRelease = "dev"
+)
+
+func init() {
+	if gitRelease != "dev" {
+		return
+	}
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return
+	}
+	if info.Main.Version != "" {
+		gitRelease = info.Main.Version
+	}
+}
+
 var artifactsDirFlag string
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Use:   "kpi-collector",
-	Short: "KPI Collection and Visualization Tool",
+	Use:     "kpi-collector",
+	Version: gitRelease,
+	Short:   "KPI Collection and Visualization Tool",
 	Long: `A tool to automate metrics gathering and visualization for KPIs 
 in disconnected environments. Supports Kubernetes auto-discovery, 
 Prometheus/Thanos integration, and multiple database backends.`,
@@ -25,9 +47,18 @@ Prometheus/Thanos integration, and multiple database backends.`,
 	},
 }
 
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print the version and commit information",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("kpi-collector %s (%s)\n", gitRelease, gitCommit)
+	},
+}
+
 func init() {
 	rootCmd.PersistentFlags().StringVar(&artifactsDirFlag, "artifacts-dir", "",
 		"directory for storing artifacts: database, logs, and Grafana config (default: ./kpi-collector-artifacts/)")
+	rootCmd.AddCommand(versionCmd)
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -17,26 +17,25 @@ var (
 	gitRelease = "dev"
 )
 
-func init() {
+// gitVersion returns the display version string.
+// If gitRelease was set via ldflags, it is used directly.
+// Otherwise, falls back to Go module build info for `go install` users.
+func gitVersion() string {
 	if gitRelease != "dev" {
-		return
+		return gitRelease
 	}
-	info, ok := debug.ReadBuildInfo()
-	if !ok {
-		return
+	if info, ok := debug.ReadBuildInfo(); ok && info.Main.Version != "" {
+		return info.Main.Version
 	}
-	if info.Main.Version != "" {
-		gitRelease = info.Main.Version
-	}
+	return gitRelease
 }
 
 var artifactsDirFlag string
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Use:     "kpi-collector",
-	Version: gitRelease,
-	Short:   "KPI Collection and Visualization Tool",
+	Use:   "kpi-collector",
+	Short: "KPI Collection and Visualization Tool",
 	Long: `A tool to automate metrics gathering and visualization for KPIs 
 in disconnected environments. Supports Kubernetes auto-discovery, 
 Prometheus/Thanos integration, and multiple database backends.`,
@@ -51,7 +50,7 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print the version and commit information",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("kpi-collector %s (%s)\n", gitRelease, gitCommit)
+		fmt.Printf("kpi-collector %s (%s)\n", gitVersion(), gitCommit)
 	},
 }
 
@@ -59,6 +58,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&artifactsDirFlag, "artifacts-dir", "",
 		"directory for storing artifacts: database, logs, and Grafana config (default: ./kpi-collector-artifacts/)")
 	rootCmd.AddCommand(versionCmd)
+	rootCmd.Version = gitVersion()
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.


### PR DESCRIPTION
- Added a GitHub Actions release workflow that builds and publishes pre-built binaries (linux/x86_64 and darwin/arm64) when a release is published.
- Makefile now injects git release and commit info into the binary via linker flags, and a new build-darwin-arm64 cross-compilation target is added. 

(took certsuite's release workflow as reference for best practice)

- Added a version subcommand and --version flag, with a debug.ReadBuildInfo() fallback so go install users also see the correct version.