### PR TITLE
Handle NaN values and empty results

### DIFF
--- a/internal/prometheus/client.go
+++ b/internal/prometheus/client.go
@@ -9,6 +9,8 @@ import (
 	"crypto/tls"
 	"database/sql"
 	"fmt"
+	"log"
+	"math"
 	"net/http"
 	"os"
 	"time"
@@ -142,6 +144,24 @@ func executeQuery(ctx context.Context, v1api promv1.API, db *sql.DB, dbImpl data
 		return
 	}
 
+	// Filter out NaN/Inf values
+	var nanCount int
+	result, nanCount = filterNaNValues(result)
+
+	// Check if anything remains to store
+	if isEmptyResult(result) {
+		queryResult.Success = true
+		output.PrintQueryResult(info, queryResult)
+		if nanCount > 0 {
+			fmt.Printf("  Warning: all %d sample(s) were NaN — nothing stored\n", nanCount)
+			log.Printf("[%s] All %d sample(s) were NaN, nothing stored: %s", info.QueryID, nanCount, info.PromQuery)
+		} else {
+			fmt.Printf("  Warning: query returned no data (metric may not exist on this cluster)\n")
+			log.Printf("[%s] Query returned no data: %s", info.QueryID, info.PromQuery)
+		}
+		return
+	}
+
 	// Store results
 	err = dbImpl.StoreQueryResults(db, clusterID, info.QueryID, result)
 	if err != nil {
@@ -153,4 +173,60 @@ func executeQuery(ctx context.Context, v1api promv1.API, db *sql.DB, dbImpl data
 
 	queryResult.Success = true
 	output.PrintQueryResult(info, queryResult)
+	if nanCount > 0 {
+		fmt.Printf("  Note: skipped %d NaN value(s)\n", nanCount)
+		log.Printf("[%s] Skipped %d NaN/Inf value(s): %s", info.QueryID, nanCount, info.PromQuery)
+	}
+}
+
+// isEmptyResult checks whether a Prometheus query returned no data points.
+func isEmptyResult(result model.Value) bool {
+	switch v := result.(type) {
+	case model.Vector:
+		return len(v) == 0
+	case model.Matrix:
+		return len(v) == 0
+	default:
+		return false
+	}
+}
+
+// filterNaNValues removes NaN and Inf samples from a Prometheus result,
+// returning the cleaned result and the number of samples removed.
+func filterNaNValues(result model.Value) (model.Value, int) {
+	switch v := result.(type) {
+	case model.Vector:
+		filtered := make(model.Vector, 0, len(v))
+		for _, sample := range v {
+			if math.IsNaN(float64(sample.Value)) || math.IsInf(float64(sample.Value), 0) {
+				continue
+			}
+			filtered = append(filtered, sample)
+		}
+		return filtered, len(v) - len(filtered)
+
+	case model.Matrix:
+		skipped := 0
+		filtered := make(model.Matrix, 0, len(v))
+		for _, stream := range v {
+			cleanPairs := make([]model.SamplePair, 0, len(stream.Values))
+			for _, pair := range stream.Values {
+				if math.IsNaN(float64(pair.Value)) || math.IsInf(float64(pair.Value), 0) {
+					skipped++
+					continue
+				}
+				cleanPairs = append(cleanPairs, pair)
+			}
+			if len(cleanPairs) > 0 {
+				filtered = append(filtered, &model.SampleStream{
+					Metric: stream.Metric,
+					Values: cleanPairs,
+				})
+			}
+		}
+		return filtered, skipped
+
+	default:
+		return result, 0
+	}
 }

--- a/internal/prometheus/client_test.go
+++ b/internal/prometheus/client_test.go
@@ -3,6 +3,7 @@ package prometheus
 import (
 	"context"
 	"database/sql"
+	"math"
 	"os"
 	"time"
 
@@ -91,6 +92,167 @@ func (m *mockPromAPI) Buildinfo(ctx context.Context) (v1.BuildinfoResult, error)
 func (m *mockPromAPI) QueryExemplars(ctx context.Context, query string, startTime, endTime time.Time) ([]v1.ExemplarQueryResult, error) {
 	return nil, nil
 }
+
+var _ = Describe("filterNaNValues", func() {
+	Describe("Vector input", func() {
+		It("should keep all samples when none are NaN or Inf", func() {
+			input := model.Vector{
+				&model.Sample{Metric: model.Metric{"__name__": "cpu"}, Value: 0.5, Timestamp: model.Now()},
+				&model.Sample{Metric: model.Metric{"__name__": "cpu"}, Value: 1.0, Timestamp: model.Now()},
+			}
+
+			result, skipped := filterNaNValues(input)
+
+			vec := result.(model.Vector)
+			Expect(vec).To(HaveLen(2))
+			Expect(skipped).To(Equal(0))
+		})
+
+		It("should remove NaN samples from vector", func() {
+			input := model.Vector{
+				&model.Sample{Metric: model.Metric{"job": "a"}, Value: 0.5},
+				&model.Sample{Metric: model.Metric{"job": "b"}, Value: model.SampleValue(math.NaN())},
+				&model.Sample{Metric: model.Metric{"job": "c"}, Value: 0.9},
+			}
+
+			result, skipped := filterNaNValues(input)
+
+			vec := result.(model.Vector)
+			Expect(vec).To(HaveLen(2))
+			Expect(skipped).To(Equal(1))
+			Expect(float64(vec[0].Value)).To(Equal(0.5))
+			Expect(float64(vec[1].Value)).To(Equal(0.9))
+		})
+
+		It("should remove +Inf and -Inf samples from vector", func() {
+			input := model.Vector{
+				&model.Sample{Metric: model.Metric{"job": "a"}, Value: model.SampleValue(math.Inf(1))},
+				&model.Sample{Metric: model.Metric{"job": "b"}, Value: 42},
+				&model.Sample{Metric: model.Metric{"job": "c"}, Value: model.SampleValue(math.Inf(-1))},
+			}
+
+			result, skipped := filterNaNValues(input)
+
+			vec := result.(model.Vector)
+			Expect(vec).To(HaveLen(1))
+			Expect(skipped).To(Equal(2))
+			Expect(float64(vec[0].Value)).To(Equal(42.0))
+		})
+
+		It("should return empty vector and correct count when all values are NaN", func() {
+			input := model.Vector{
+				&model.Sample{Metric: model.Metric{"job": "a"}, Value: model.SampleValue(math.NaN())},
+				&model.Sample{Metric: model.Metric{"job": "b"}, Value: model.SampleValue(math.NaN())},
+			}
+
+			result, skipped := filterNaNValues(input)
+
+			vec := result.(model.Vector)
+			Expect(vec).To(BeEmpty())
+			Expect(skipped).To(Equal(2))
+		})
+
+		It("should handle an empty vector", func() {
+			result, skipped := filterNaNValues(model.Vector{})
+
+			vec := result.(model.Vector)
+			Expect(vec).To(BeEmpty())
+			Expect(skipped).To(Equal(0))
+		})
+	})
+
+	Describe("Matrix input", func() {
+		It("should keep all sample pairs when none are NaN or Inf", func() {
+			input := model.Matrix{
+				&model.SampleStream{
+					Metric: model.Metric{"__name__": "cpu", "instance": "node1"},
+					Values: []model.SamplePair{
+						{Timestamp: model.TimeFromUnix(1000), Value: 0.1},
+						{Timestamp: model.TimeFromUnix(1030), Value: 0.2},
+					},
+				},
+			}
+
+			result, skipped := filterNaNValues(input)
+
+			mat := result.(model.Matrix)
+			Expect(mat).To(HaveLen(1))
+			Expect(mat[0].Values).To(HaveLen(2))
+			Expect(skipped).To(Equal(0))
+		})
+
+		It("should remove NaN sample pairs and keep the stream", func() {
+			input := model.Matrix{
+				&model.SampleStream{
+					Metric: model.Metric{"cpu": "0"},
+					Values: []model.SamplePair{
+						{Timestamp: model.TimeFromUnix(1000), Value: 0.5},
+						{Timestamp: model.TimeFromUnix(1030), Value: model.SampleValue(math.NaN())},
+						{Timestamp: model.TimeFromUnix(1060), Value: 0.7},
+					},
+				},
+			}
+
+			result, skipped := filterNaNValues(input)
+
+			mat := result.(model.Matrix)
+			Expect(mat).To(HaveLen(1))
+			Expect(mat[0].Values).To(HaveLen(2))
+			Expect(skipped).To(Equal(1))
+		})
+
+		It("should drop an entire stream when all its values are NaN/Inf", func() {
+			input := model.Matrix{
+				&model.SampleStream{
+					Metric: model.Metric{"cpu": "0"},
+					Values: []model.SamplePair{
+						{Timestamp: model.TimeFromUnix(1000), Value: model.SampleValue(math.NaN())},
+						{Timestamp: model.TimeFromUnix(1030), Value: model.SampleValue(math.Inf(1))},
+					},
+				},
+				&model.SampleStream{
+					Metric: model.Metric{"cpu": "1"},
+					Values: []model.SamplePair{
+						{Timestamp: model.TimeFromUnix(1000), Value: 0.3},
+					},
+				},
+			}
+
+			result, skipped := filterNaNValues(input)
+
+			mat := result.(model.Matrix)
+			Expect(mat).To(HaveLen(1))
+			Expect(string(mat[0].Metric["cpu"])).To(Equal("1"))
+			Expect(skipped).To(Equal(2))
+		})
+
+		It("should return empty matrix when all streams are fully NaN", func() {
+			input := model.Matrix{
+				&model.SampleStream{
+					Metric: model.Metric{"cpu": "0"},
+					Values: []model.SamplePair{
+						{Timestamp: model.TimeFromUnix(1000), Value: model.SampleValue(math.NaN())},
+					},
+				},
+			}
+
+			result, skipped := filterNaNValues(input)
+
+			mat := result.(model.Matrix)
+			Expect(mat).To(BeEmpty())
+			Expect(skipped).To(Equal(1))
+		})
+
+		It("should handle an empty matrix", func() {
+			result, skipped := filterNaNValues(model.Matrix{})
+
+			mat := result.(model.Matrix)
+			Expect(mat).To(BeEmpty())
+			Expect(skipped).To(Equal(0))
+		})
+	})
+
+})
 
 var _ = Describe("Client", func() {
 


### PR DESCRIPTION
Queries like `histogram_quantile` can return NaN for series with no data (e.g., idle HTTP verbs). These were stored as NaN in SQLite, crashing `db show kpis`. 
Queries for nonexistent metrics (e.g., PTP on a non-PTP cluster) returned empty results silently.

NaN/Inf values are now filtered before storage. Empty results are detected. Both print a warning to the console and log file. Valid samples from partially-NaN results are still stored normally.

