### PR TITLE
 Grafana dashboard improvements: auto-fit button, stats summary, and home dashboard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -274,7 +274,11 @@ The database stores:
 - **Query Errors**: KPI ID, error count
 
 ### Grafana Integration
-The tool manages Grafana via Docker:
+The tool manages Grafana via Docker/Podman:
 - Generates datasource configuration for SQLite or PostgreSQL
 - Provisions pre-built dashboards from embedded templates
+- Sets the KPI dashboard as the home page on login (`GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH`)
 - Handles container lifecycle (start/stop)
+
+Dashboard templates include hidden variables for "Fit to data" (time range auto-adjustment)
+and inline statistics (sample count, average, min, max) displayed as a text panel.

--- a/docs/grafana.md
+++ b/docs/grafana.md
@@ -115,9 +115,23 @@ kpi-collector grafana start --datasource=postgres \
    - Username: `admin`
    - Password: `admin`
    - You will be prompted to change the password on first login
-3. Open dashboard: **Dashboards** -> **KPI Collection Tool - Dynamic Dashboard**
+3. The KPI dashboard loads automatically as the home page
 
 ## Dashboard Features
+
+### Auto-Refresh
+
+Auto-refresh is disabled by default. The typical workflow is to collect data first with `kpi-collector run` and then visualize it, so the dashboard does not need to poll for new data.
+
+If you are collecting and visualizing data at the same time, you can enable auto-refresh manually from the Grafana time picker (e.g. every 10s or 30s).
+
+### Fit to Data
+
+A **Fit to data** link in the dashboard header adjusts the time picker to span the full range of collected data (earliest to latest sample). It respects the currently selected filters.
+
+### Statistics Summary
+
+A compact text line below the main time series chart shows the sample count, average, maximum, and minimum values for the current filter selection.
 
 ### Dashboard Filters
 
@@ -136,11 +150,11 @@ Additional filters available only for SQLite:
 
 All filters default to `All`.
 
-The dashboard includes:
+### Panels
 
-- Dynamic metric selection
-- Time-series visualization
-- Statistical summary (average, min, max, sample count)
-- Detailed metrics table
-- Query error tracking
-- Multi-cluster support
+- Full-width time-series visualization
+- Statistics summary (samples, average, min, max)
+- Detailed metrics table with all labels
+- Query error tracking (bar chart)
+- All KPIs summary statistics
+- Cluster monitoring status

--- a/grafana-templates/postgres-dashboard.json
+++ b/grafana-templates/postgres-dashboard.json
@@ -665,7 +665,7 @@
       "type": "table"
     }
   ],
-  "refresh": "10s",
+  "refresh": "",
   "schemaVersion": 38,
   "style": "dark",
   "tags": [

--- a/grafana-templates/postgres-dashboard.json
+++ b/grafana-templates/postgres-dashboard.json
@@ -1,1 +1,828 @@
-{"annotations":{"list":[{"builtIn":1,"datasource":{"type":"grafana","uid":"kpi-postgres-datasource"},"enable":true,"hide":true,"iconColor":"rgba(0, 211, 255, 1)","name":"Annotations & Alerts","type":"dashboard"}]},"editable":true,"fiscalYearStartMonth":0,"graphTooltip":1,"id":null,"links":[],"liveNow":false,"panels":[{"datasource":{"type":"postgres","uid":"kpi-postgres-datasource"},"fieldConfig":{"defaults":{"color":{"mode":"palette-classic"},"custom":{"axisCenteredZero":false,"axisColorMode":"text","axisLabel":"","axisPlacement":"auto","barAlignment":0,"drawStyle":"line","fillOpacity":10,"gradientMode":"none","hideFrom":{"tooltip":false,"viz":false,"legend":false},"lineInterpolation":"smooth","lineWidth":2,"pointSize":4,"scaleDistribution":{"type":"linear"},"showPoints":"auto","spanNulls":false,"stacking":{"group":"A","mode":"none"},"thresholdsStyle":{"mode":"off"}},"mappings":[],"thresholds":{"mode":"absolute","steps":[{"color":"green","value":null}]}},"overrides":[{"matcher":{"id":"byName","options":"Max Value"},"properties":[{"id":"custom.drawStyle","value":"line"},{"id":"custom.lineStyle","value":{"fill":"dash","dash":[6,6]}},{"id":"custom.lineWidth","value":3},{"id":"color","value":{"fixedColor":"red","mode":"fixed"}},{"id":"custom.hideFrom","value":{"tooltip":true,"viz":false,"legend":false}}]},{"matcher":{"id":"byName","options":"Min Value"},"properties":[{"id":"custom.drawStyle","value":"line"},{"id":"custom.lineStyle","value":{"fill":"dash","dash":[6,6]}},{"id":"custom.lineWidth","value":3},{"id":"color","value":{"fixedColor":"green","mode":"fixed"}},{"id":"custom.hideFrom","value":{"tooltip":true,"viz":false,"legend":false}}]},{"matcher":{"id":"byName","options":"Average Value"},"properties":[{"id":"custom.drawStyle","value":"line"},{"id":"custom.lineStyle","value":{"fill":"dash","dash":[10,5]}},{"id":"custom.lineWidth","value":3},{"id":"color","value":{"fixedColor":"orange","mode":"fixed"}},{"id":"custom.hideFrom","value":{"tooltip":true,"viz":false,"legend":false}}]}]},"gridPos":{"h":10,"w":18,"x":0,"y":0},"id":1,"options":{"legend":{"showLegend":true,"displayMode":"table","placement":"bottom","calcs":["last","mean","max"]},"tooltip":{"mode":"multi","sort":"desc"}},"targets":[{"datasource":{"type":"postgres","uid":"kpi-postgres-datasource"},"format":"table","rawSql":"SELECT to_timestamp(timestamp_value) AS time, metric_value, metric_labels FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE timestamp_value >= $__from / 1000 AND timestamp_value < $__to / 1000 AND kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) AND COALESCE(metric_labels->>'node', 'N/A') LIKE (CASE WHEN '${node}' = 'All' THEN '%%' ELSE '${node}' END) AND COALESCE(metric_labels->>'job', 'N/A') LIKE (CASE WHEN '${job}' = 'All' THEN '%%' ELSE '${job}' END) AND COALESCE(metric_labels->>'container', 'N/A') LIKE (CASE WHEN '${container}' = 'All' THEN '%%' ELSE '${container}' END) AND COALESCE(metric_labels->>'pod', 'N/A') LIKE (CASE WHEN '${pod}' = 'All' THEN '%%' ELSE '${pod}' END) ORDER BY time ASC","refId":"A","timeColumns":["time"],"legendFormat":"Node: {{__field.labels.node}} | Pod: {{__field.labels.pod}} | Job: {{__field.labels.job}}"},{"datasource":{"type":"postgres","uid":"kpi-postgres-datasource"},"format":"table","rawSql":"SELECT 'Max Value' AS metric_labels, MAX(metric_value) AS metric_value, $__from/1000 AS time FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE timestamp_value >= $__from / 1000 AND timestamp_value < $__to / 1000 AND kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) AND COALESCE(metric_labels->>'node', 'N/A') LIKE (CASE WHEN '${node}' = 'All' THEN '%%' ELSE '${node}' END) AND COALESCE(metric_labels->>'job', 'N/A') LIKE (CASE WHEN '${job}' = 'All' THEN '%%' ELSE '${job}' END) AND COALESCE(metric_labels->>'container', 'N/A') LIKE (CASE WHEN '${container}' = 'All' THEN '%%' ELSE '${container}' END) AND COALESCE(metric_labels->>'pod', 'N/A') LIKE (CASE WHEN '${pod}' = 'All' THEN '%%' ELSE '${pod}' END)","refId":"B","legendFormat":"Max Value","timeColumns":["time"]},{"datasource":{"type":"postgres","uid":"kpi-postgres-datasource"},"format":"table","rawSql":"SELECT 'Min Value' AS metric_labels, MIN(metric_value) AS metric_value, $__from/1000 AS time FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE timestamp_value >= $__from / 1000 AND timestamp_value < $__to / 1000 AND kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) AND COALESCE(metric_labels->>'node', 'N/A') LIKE (CASE WHEN '${node}' = 'All' THEN '%%' ELSE '${node}' END) AND COALESCE(metric_labels->>'job', 'N/A') LIKE (CASE WHEN '${job}' = 'All' THEN '%%' ELSE '${job}' END) AND COALESCE(metric_labels->>'container', 'N/A') LIKE (CASE WHEN '${container}' = 'All' THEN '%%' ELSE '${container}' END) AND COALESCE(metric_labels->>'pod', 'N/A') LIKE (CASE WHEN '${pod}' = 'All' THEN '%%' ELSE '${pod}' END)","refId":"C","legendFormat":"Min Value","timeColumns":["time"]},{"datasource":{"type":"postgres","uid":"kpi-postgres-datasource"},"format":"table","rawSql":"SELECT 'Average Value' AS metric_labels, AVG(metric_value) AS metric_value, $__from/1000 AS time FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE timestamp_value >= $__from / 1000 AND timestamp_value < $__to / 1000 AND kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) AND COALESCE(metric_labels->>'node', 'N/A') LIKE (CASE WHEN '${node}' = 'All' THEN '%%' ELSE '${node}' END) AND COALESCE(metric_labels->>'job', 'N/A') LIKE (CASE WHEN '${job}' = 'All' THEN '%%' ELSE '${job}' END) AND COALESCE(metric_labels->>'container', 'N/A') LIKE (CASE WHEN '${container}' = 'All' THEN '%%' ELSE '${container}' END) AND COALESCE(metric_labels->>'pod', 'N/A') LIKE (CASE WHEN '${pod}' = 'All' THEN '%%' ELSE '${pod}' END)","refId":"D","legendFormat":"Average Value","timeColumns":["time"]}],"title":"Metric Values Over Time","type":"timeseries","transformations":[{"id":"extractFields","options":{"source":"metric_labels","format":"json","replace":false,"keepTime":true}},{"id":"prepareTimeSeries","options":{"format":"multi"}}]},{"datasource":{"type":"postgres","uid":"kpi-postgres-datasource"},"fieldConfig":{"defaults":{"color":{"mode":"thresholds"},"mappings":[],"thresholds":{"mode":"absolute","steps":[{"color":"green","value":null}]}},"overrides":[]},"gridPos":{"h":10,"w":6,"x":18,"y":0},"id":2,"options":{"colorMode":"background","graphMode":"none","justifyMode":"center","orientation":"vertical","reduceOptions":{"values":false,"calcs":["lastNotNull"],"fields":""},"textMode":"value_and_name","showPercentChange":false},"pluginVersion":"10.0.0","targets":[{"datasource":{"type":"postgres","uid":"kpi-postgres-datasource"},"format":"table","rawSql":"SELECT COUNT(*) as \"Samples\", ROUND(CAST(AVG(metric_value) AS numeric), 6) as \"Average\", ROUND(CAST(MIN(metric_value) AS numeric), 6) as \"Minimum\", ROUND(CAST(MAX(metric_value) AS numeric), 6) as \"Maximum\" FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE timestamp_value >= $__from / 1000 AND timestamp_value < $__to / 1000 AND kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) AND COALESCE(metric_labels->>'node', 'N/A') LIKE (CASE WHEN '${node}' = 'All' THEN '%%' ELSE '${node}' END) AND COALESCE(metric_labels->>'job', 'N/A') LIKE (CASE WHEN '${job}' = 'All' THEN '%%' ELSE '${job}' END) AND COALESCE(metric_labels->>'container', 'N/A') LIKE (CASE WHEN '${container}' = 'All' THEN '%%' ELSE '${container}' END) AND COALESCE(metric_labels->>'pod', 'N/A') LIKE (CASE WHEN '${pod}' = 'All' THEN '%%' ELSE '${pod}' END)","refId":"A"}],"title":"KPI Statistics","type":"stat"},{"datasource":{"type":"postgres","uid":"kpi-postgres-datasource"},"fieldConfig":{"defaults":{"color":{"mode":"thresholds"},"custom":{"align":"auto","cellOptions":{"type":"auto"},"inspect":false,"filterable":true},"mappings":[],"thresholds":{"mode":"absolute","steps":[{"color":"green","value":null}]}},"overrides":[]},"gridPos":{"h":10,"w":24,"x":0,"y":10},"id":3,"options":{"showHeader":true,"cellHeight":"sm","footer":{"show":false,"reducer":["sum"],"countRows":false,"fields":""},"sortBy":[{"displayName":"Avg Value","desc":true}]},"pluginVersion":"10.0.0","targets":[{"datasource":{"type":"postgres","uid":"kpi-postgres-datasource"},"format":"table","rawSql":"SELECT metric_labels, ROUND(CAST(AVG(metric_value) AS numeric), 6) AS avg_value, ROUND(CAST(MIN(metric_value) AS numeric), 6) AS min_value, ROUND(CAST(MAX(metric_value) AS numeric), 6) AS max_value, COUNT(*) AS samples FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE timestamp_value >= $__from / 1000 AND timestamp_value < $__to / 1000 AND kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) AND COALESCE(metric_labels->>'node', 'N/A') LIKE (CASE WHEN '${node}' = 'All' THEN '%%' ELSE '${node}' END) AND COALESCE(metric_labels->>'job', 'N/A') LIKE (CASE WHEN '${job}' = 'All' THEN '%%' ELSE '${job}' END) AND COALESCE(metric_labels->>'container', 'N/A') LIKE (CASE WHEN '${container}' = 'All' THEN '%%' ELSE '${container}' END) AND COALESCE(metric_labels->>'pod', 'N/A') LIKE (CASE WHEN '${pod}' = 'All' THEN '%%' ELSE '${pod}' END) GROUP BY metric_labels ORDER BY avg_value DESC LIMIT 100","refId":"A"}],"title":"Detailed Metrics with All Labels","type":"table","transformations":[{"id":"extractFields","options":{"source":"metric_labels","format":"json","replace":true}}]},{"datasource":{"type":"postgres","uid":"kpi-postgres-datasource"},"fieldConfig":{"defaults":{"color":{"mode":"thresholds"},"custom":{"axisCenteredZero":false,"axisColorMode":"text","axisLabel":"","axisPlacement":"auto","fillOpacity":80,"gradientMode":"none","hideFrom":{"tooltip":false,"viz":false,"legend":false},"lineWidth":1,"scaleDistribution":{"type":"linear"}},"mappings":[],"thresholds":{"mode":"absolute","steps":[{"color":"green","value":null},{"color":"yellow","value":1},{"color":"red","value":5}]}},"overrides":[]},"gridPos":{"h":8,"w":24,"x":0,"y":20},"id":5,"options":{"barRadius":0,"barWidth":0.97,"fullHighlight":false,"groupWidth":0.7,"legend":{"calcs":[],"displayMode":"list","placement":"bottom","showLegend":false},"orientation":"horizontal","showValue":"always","stacking":"none","tooltip":{"mode":"single","sort":"none"},"xTickLabelRotation":0,"xTickLabelSpacing":0},"pluginVersion":"10.0.0","targets":[{"datasource":{"type":"postgres","uid":"kpi-postgres-datasource"},"format":"table","rawSql":"SELECT kpi_id AS metric, errors AS value FROM query_errors WHERE errors > 0 ORDER BY errors DESC","refId":"A"}],"title":"Query Errors by KPI (Static)","type":"barchart"},{"datasource":{"type":"postgres","uid":"kpi-postgres-datasource"},"fieldConfig":{"defaults":{"color":{"mode":"thresholds"},"custom":{"align":"auto","cellOptions":{"type":"auto"},"inspect":false,"filterable":true},"mappings":[],"thresholds":{"mode":"absolute","steps":[{"color":"green","value":null}]}},"overrides":[]},"gridPos":{"h":9,"w":24,"x":0,"y":28},"id":6,"options":{"showHeader":true,"cellHeight":"sm","footer":{"show":false,"reducer":["sum"],"countRows":false,"fields":""},"sortBy":[{"displayName":"KPI ID","desc":false}]},"pluginVersion":"10.0.0","targets":[{"datasource":{"type":"postgres","uid":"kpi-postgres-datasource"},"format":"table","rawSql":"SELECT kpi_id, COUNT(*) AS sample_count, ROUND(CAST(AVG(metric_value) AS numeric), 6) AS avg_value, ROUND(CAST(MIN(metric_value) AS numeric), 6) AS min_value, ROUND(CAST(MAX(metric_value) AS numeric), 6) AS max_value, ROUND(CAST(MAX(metric_value) - MIN(metric_value) AS numeric), 6) AS range, COUNT(DISTINCT metric_labels) AS unique_metrics FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE timestamp_value >= $__from / 1000 AND timestamp_value < $__to / 1000 AND kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) AND COALESCE(metric_labels->>'node', 'N/A') LIKE (CASE WHEN '${node}' = 'All' THEN '%%' ELSE '${node}' END) AND COALESCE(metric_labels->>'job', 'N/A') LIKE (CASE WHEN '${job}' = 'All' THEN '%%' ELSE '${job}' END) AND COALESCE(metric_labels->>'container', 'N/A') LIKE (CASE WHEN '${container}' = 'All' THEN '%%' ELSE '${container}' END) AND COALESCE(metric_labels->>'pod', 'N/A') LIKE (CASE WHEN '${pod}' = 'All' THEN '%%' ELSE '${pod}' END) GROUP BY kpi_id ORDER BY kpi_id","refId":"A"}],"title":"All KPIs - Summary Statistics","type":"table"},{"datasource":{"type":"postgres","uid":"kpi-postgres-datasource"},"fieldConfig":{"defaults":{"color":{"mode":"thresholds"},"custom":{"align":"auto","cellOptions":{"type":"auto"},"inspect":false},"mappings":[],"thresholds":{"mode":"absolute","steps":[{"color":"green","value":null}]}},"overrides":[]},"gridPos":{"h":6,"w":24,"x":0,"y":37},"id":7,"options":{"showHeader":true,"cellHeight":"sm","footer":{"show":false,"reducer":["sum"],"countRows":false,"fields":""},"sortBy":[]},"pluginVersion":"10.0.0","targets":[{"datasource":{"type":"postgres","uid":"kpi-postgres-datasource"},"format":"table","rawSql":"SELECT c.cluster_name, COALESCE(c.cluster_type, 'N/A') AS cluster_type, COUNT(DISTINCT qr.kpi_id) AS kpi_count, COUNT(qr.metric_value) AS total_samples, MAX(qr.created_at) AS last_collection FROM clusters c LEFT JOIN query_results qr ON c.id = qr.cluster_id AND qr.timestamp_value >= $__from / 1000 AND qr.timestamp_value < $__to / 1000 WHERE COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) GROUP BY c.cluster_name, COALESCE(c.cluster_type, 'N/A') ORDER BY c.cluster_name","refId":"A"}],"title":"Cluster Monitoring Status (Time-Aware Counts)","type":"table"}],"refresh":"10s","schemaVersion":38,"style":"dark","tags":["kpi","metrics","monitoring"],"templating":{"list":[{"current":{"text":"All","value":"All"},"datasource":{"type":"postgres","uid":"kpi-postgres-datasource"},"definition":"SELECT cluster_type FROM (SELECT 'All' AS cluster_type, 1 AS order_col UNION ALL SELECT DISTINCT COALESCE(cluster_type, 'N/A'), 2 AS order_col FROM clusters) AS temp_data ORDER BY order_col, cluster_type;","hide":0,"includeAll":false,"label":"Cluster Type","multi":false,"name":"cluster_type","options":[],"query":"SELECT cluster_type FROM (SELECT 'All' AS cluster_type, 1 AS order_col UNION ALL SELECT DISTINCT COALESCE(cluster_type, 'N/A'), 2 AS order_col FROM clusters) AS temp_data ORDER BY order_col, cluster_type;","refresh":1,"type":"query"},{"current":{"text":"","value":""},"datasource":{"type":"postgres","uid":"kpi-postgres-datasource"},"definition":"SELECT cluster_name FROM (SELECT c.cluster_name, CASE WHEN c.id = (SELECT cluster_id FROM query_results ORDER BY created_at DESC LIMIT 1) THEN 1 ELSE 3 END AS sort_order FROM clusters c WHERE COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) UNION ALL SELECT 'All', 2) AS t ORDER BY sort_order, cluster_name;","hide":0,"includeAll":false,"label":"Cluster","multi":false,"name":"cluster","options":[],"query":"SELECT cluster_name FROM (SELECT c.cluster_name, CASE WHEN c.id = (SELECT cluster_id FROM query_results ORDER BY created_at DESC LIMIT 1) THEN 1 ELSE 3 END AS sort_order FROM clusters c WHERE COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) UNION ALL SELECT 'All', 2) AS t ORDER BY sort_order, cluster_name;","refresh":1,"type":"query"},{"current":{"text":"","value":""},"datasource":{"type":"postgres","uid":"kpi-postgres-datasource"},"definition":"SELECT kpi_id FROM (SELECT DISTINCT kpi_id, 1 AS sort_order FROM query_results WHERE kpi_id IS NOT NULL AND kpi_id != '' UNION ALL SELECT 'All', 2) AS t ORDER BY sort_order, kpi_id;","hide":0,"includeAll":false,"label":"KPI","multi":false,"name":"kpi","options":[],"query":"SELECT kpi_id FROM (SELECT DISTINCT kpi_id, 1 AS sort_order FROM query_results WHERE kpi_id IS NOT NULL AND kpi_id != '' UNION ALL SELECT 'All', 2) AS t ORDER BY sort_order, kpi_id;","refresh":1,"type":"query"},{"current":{"text":"All","value":"All"},"datasource":{"type":"postgres","uid":"kpi-postgres-datasource"},"definition":"SELECT node FROM (SELECT 'All' AS node, 1 AS order_col UNION ALL SELECT DISTINCT COALESCE(metric_labels->>'node', 'N/A'), 2 AS order_col FROM query_results WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND metric_labels->>'node' IS NOT NULL) AS temp_data ORDER BY order_col, node;","hide":0,"includeAll":false,"label":"Node","multi":false,"name":"node","options":[],"query":"SELECT node FROM (SELECT 'All' AS node, 1 AS order_col UNION ALL SELECT DISTINCT COALESCE(metric_labels->>'node', 'N/A'), 2 AS order_col FROM query_results WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND metric_labels->>'node' IS NOT NULL) AS temp_data ORDER BY order_col, node;","refresh":1,"type":"query"},{"current":{"text":"All","value":"All"},"datasource":{"type":"postgres","uid":"kpi-postgres-datasource"},"definition":"SELECT job FROM (SELECT 'All' AS job, 1 AS order_col UNION ALL SELECT DISTINCT COALESCE(metric_labels->>'job', 'N/A'), 2 AS order_col FROM query_results WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND metric_labels->>'job' IS NOT NULL) AS temp_data ORDER BY order_col, job;","hide":0,"includeAll":false,"label":"Job","multi":false,"name":"job","options":[],"query":"SELECT job FROM (SELECT 'All' AS job, 1 AS order_col UNION ALL SELECT DISTINCT COALESCE(metric_labels->>'job', 'N/A'), 2 AS order_col FROM query_results WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND metric_labels->>'job' IS NOT NULL) AS temp_data ORDER BY order_col, job;","refresh":1,"type":"query"},{"current":{"text":"All","value":"All"},"datasource":{"type":"postgres","uid":"kpi-postgres-datasource"},"definition":"SELECT container FROM (SELECT 'All' AS container, 1 AS order_col UNION ALL SELECT DISTINCT COALESCE(metric_labels->>'container', 'N/A'), 2 AS order_col FROM query_results WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND metric_labels->>'container' IS NOT NULL) AS temp_data ORDER BY order_col, container;","hide":0,"includeAll":false,"label":"Container","multi":false,"name":"container","options":[],"query":"SELECT container FROM (SELECT 'All' AS container, 1 AS order_col UNION ALL SELECT DISTINCT COALESCE(metric_labels->>'container', 'N/A'), 2 AS order_col FROM query_results WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND metric_labels->>'container' IS NOT NULL) AS temp_data ORDER BY order_col, container;","refresh":1,"type":"query"},{"current":{"text":"All","value":"All"},"datasource":{"type":"postgres","uid":"kpi-postgres-datasource"},"definition":"SELECT pod FROM (SELECT 'All' AS pod, 1 AS order_col UNION ALL SELECT DISTINCT COALESCE(metric_labels->>'pod', 'N/A'), 2 AS order_col FROM query_results WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND metric_labels->>'pod' IS NOT NULL) AS temp_data ORDER BY order_col, pod;","hide":0,"includeAll":false,"label":"Pod","multi":false,"name":"pod","options":[],"query":"SELECT pod FROM (SELECT 'All' AS pod, 1 AS order_col UNION ALL SELECT DISTINCT COALESCE(metric_labels->>'pod', 'N/A'), 2 AS order_col FROM query_results WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND metric_labels->>'pod' IS NOT NULL) AS temp_data ORDER BY order_col, pod;","refresh":1,"type":"query"}]},"time":{"from":"now-7d","to":"now"},"title":"KPI Collection Tool - Dynamic Dashboard (PostgreSQL)","uid":"kpi-collector-dynamic","version":83,"weekStart":""}
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "kpi-postgres-datasource"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "kpi-postgres-datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Max Value"
+            },
+            "properties": [
+              {
+                "id": "custom.drawStyle",
+                "value": "line"
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "fill": "dash",
+                  "dash": [
+                    6,
+                    6
+                  ]
+                }
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 3
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "tooltip": true,
+                  "viz": false,
+                  "legend": false
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Min Value"
+            },
+            "properties": [
+              {
+                "id": "custom.drawStyle",
+                "value": "line"
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "fill": "dash",
+                  "dash": [
+                    6,
+                    6
+                  ]
+                }
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 3
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "tooltip": true,
+                  "viz": false,
+                  "legend": false
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Average Value"
+            },
+            "properties": [
+              {
+                "id": "custom.drawStyle",
+                "value": "line"
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "fill": "dash",
+                  "dash": [
+                    10,
+                    5
+                  ]
+                }
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 3
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "tooltip": true,
+                  "viz": false,
+                  "legend": false
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 18,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "showLegend": true,
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "last",
+            "mean",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "kpi-postgres-datasource"
+          },
+          "format": "table",
+          "rawSql": "SELECT to_timestamp(timestamp_value) AS time, metric_value, metric_labels FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE timestamp_value >= $__from / 1000 AND timestamp_value < $__to / 1000 AND kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) AND COALESCE(metric_labels->>'node', 'N/A') LIKE (CASE WHEN '${node}' = 'All' THEN '%%' ELSE '${node}' END) AND COALESCE(metric_labels->>'job', 'N/A') LIKE (CASE WHEN '${job}' = 'All' THEN '%%' ELSE '${job}' END) AND COALESCE(metric_labels->>'container', 'N/A') LIKE (CASE WHEN '${container}' = 'All' THEN '%%' ELSE '${container}' END) AND COALESCE(metric_labels->>'pod', 'N/A') LIKE (CASE WHEN '${pod}' = 'All' THEN '%%' ELSE '${pod}' END) ORDER BY time ASC",
+          "refId": "A",
+          "timeColumns": [
+            "time"
+          ],
+          "legendFormat": "Node: {{__field.labels.node}} | Pod: {{__field.labels.pod}} | Job: {{__field.labels.job}}"
+        },
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "kpi-postgres-datasource"
+          },
+          "format": "table",
+          "rawSql": "SELECT 'Max Value' AS metric_labels, MAX(metric_value) AS metric_value, $__from/1000 AS time FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE timestamp_value >= $__from / 1000 AND timestamp_value < $__to / 1000 AND kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) AND COALESCE(metric_labels->>'node', 'N/A') LIKE (CASE WHEN '${node}' = 'All' THEN '%%' ELSE '${node}' END) AND COALESCE(metric_labels->>'job', 'N/A') LIKE (CASE WHEN '${job}' = 'All' THEN '%%' ELSE '${job}' END) AND COALESCE(metric_labels->>'container', 'N/A') LIKE (CASE WHEN '${container}' = 'All' THEN '%%' ELSE '${container}' END) AND COALESCE(metric_labels->>'pod', 'N/A') LIKE (CASE WHEN '${pod}' = 'All' THEN '%%' ELSE '${pod}' END)",
+          "refId": "B",
+          "legendFormat": "Max Value",
+          "timeColumns": [
+            "time"
+          ]
+        },
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "kpi-postgres-datasource"
+          },
+          "format": "table",
+          "rawSql": "SELECT 'Min Value' AS metric_labels, MIN(metric_value) AS metric_value, $__from/1000 AS time FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE timestamp_value >= $__from / 1000 AND timestamp_value < $__to / 1000 AND kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) AND COALESCE(metric_labels->>'node', 'N/A') LIKE (CASE WHEN '${node}' = 'All' THEN '%%' ELSE '${node}' END) AND COALESCE(metric_labels->>'job', 'N/A') LIKE (CASE WHEN '${job}' = 'All' THEN '%%' ELSE '${job}' END) AND COALESCE(metric_labels->>'container', 'N/A') LIKE (CASE WHEN '${container}' = 'All' THEN '%%' ELSE '${container}' END) AND COALESCE(metric_labels->>'pod', 'N/A') LIKE (CASE WHEN '${pod}' = 'All' THEN '%%' ELSE '${pod}' END)",
+          "refId": "C",
+          "legendFormat": "Min Value",
+          "timeColumns": [
+            "time"
+          ]
+        },
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "kpi-postgres-datasource"
+          },
+          "format": "table",
+          "rawSql": "SELECT 'Average Value' AS metric_labels, AVG(metric_value) AS metric_value, $__from/1000 AS time FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE timestamp_value >= $__from / 1000 AND timestamp_value < $__to / 1000 AND kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) AND COALESCE(metric_labels->>'node', 'N/A') LIKE (CASE WHEN '${node}' = 'All' THEN '%%' ELSE '${node}' END) AND COALESCE(metric_labels->>'job', 'N/A') LIKE (CASE WHEN '${job}' = 'All' THEN '%%' ELSE '${job}' END) AND COALESCE(metric_labels->>'container', 'N/A') LIKE (CASE WHEN '${container}' = 'All' THEN '%%' ELSE '${container}' END) AND COALESCE(metric_labels->>'pod', 'N/A') LIKE (CASE WHEN '${pod}' = 'All' THEN '%%' ELSE '${pod}' END)",
+          "refId": "D",
+          "legendFormat": "Average Value",
+          "timeColumns": [
+            "time"
+          ]
+        }
+      ],
+      "title": "Metric Values Over Time",
+      "type": "timeseries",
+      "transformations": [
+        {
+          "id": "extractFields",
+          "options": {
+            "source": "metric_labels",
+            "format": "json",
+            "replace": false,
+            "keepTime": true
+          }
+        },
+        {
+          "id": "prepareTimeSeries",
+          "options": {
+            "format": "multi"
+          }
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "kpi-postgres-datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "vertical",
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "textMode": "value_and_name",
+        "showPercentChange": false
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "kpi-postgres-datasource"
+          },
+          "format": "table",
+          "rawSql": "SELECT COUNT(*) as \"Samples\", ROUND(CAST(AVG(metric_value) AS numeric), 6) as \"Average\", ROUND(CAST(MIN(metric_value) AS numeric), 6) as \"Minimum\", ROUND(CAST(MAX(metric_value) AS numeric), 6) as \"Maximum\" FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE timestamp_value >= $__from / 1000 AND timestamp_value < $__to / 1000 AND kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) AND COALESCE(metric_labels->>'node', 'N/A') LIKE (CASE WHEN '${node}' = 'All' THEN '%%' ELSE '${node}' END) AND COALESCE(metric_labels->>'job', 'N/A') LIKE (CASE WHEN '${job}' = 'All' THEN '%%' ELSE '${job}' END) AND COALESCE(metric_labels->>'container', 'N/A') LIKE (CASE WHEN '${container}' = 'All' THEN '%%' ELSE '${container}' END) AND COALESCE(metric_labels->>'pod', 'N/A') LIKE (CASE WHEN '${pod}' = 'All' THEN '%%' ELSE '${pod}' END)",
+          "refId": "A"
+        }
+      ],
+      "title": "KPI Statistics",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "kpi-postgres-datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false,
+            "filterable": true
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 10
+      },
+      "id": 3,
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false,
+          "reducer": [
+            "sum"
+          ],
+          "countRows": false,
+          "fields": ""
+        },
+        "sortBy": [
+          {
+            "displayName": "Avg Value",
+            "desc": true
+          }
+        ]
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "kpi-postgres-datasource"
+          },
+          "format": "table",
+          "rawSql": "SELECT metric_labels, ROUND(CAST(AVG(metric_value) AS numeric), 6) AS avg_value, ROUND(CAST(MIN(metric_value) AS numeric), 6) AS min_value, ROUND(CAST(MAX(metric_value) AS numeric), 6) AS max_value, COUNT(*) AS samples FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE timestamp_value >= $__from / 1000 AND timestamp_value < $__to / 1000 AND kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) AND COALESCE(metric_labels->>'node', 'N/A') LIKE (CASE WHEN '${node}' = 'All' THEN '%%' ELSE '${node}' END) AND COALESCE(metric_labels->>'job', 'N/A') LIKE (CASE WHEN '${job}' = 'All' THEN '%%' ELSE '${job}' END) AND COALESCE(metric_labels->>'container', 'N/A') LIKE (CASE WHEN '${container}' = 'All' THEN '%%' ELSE '${container}' END) AND COALESCE(metric_labels->>'pod', 'N/A') LIKE (CASE WHEN '${pod}' = 'All' THEN '%%' ELSE '${pod}' END) GROUP BY metric_labels ORDER BY avg_value DESC LIMIT 100",
+          "refId": "A"
+        }
+      ],
+      "title": "Detailed Metrics with All Labels",
+      "type": "table",
+      "transformations": [
+        {
+          "id": "extractFields",
+          "options": {
+            "source": "metric_labels",
+            "format": "json",
+            "replace": true
+          }
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "kpi-postgres-datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineWidth": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 20
+      },
+      "id": 5,
+      "options": {
+        "barRadius": 0,
+        "barWidth": 0.97,
+        "fullHighlight": false,
+        "groupWidth": 0.7,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "orientation": "horizontal",
+        "showValue": "always",
+        "stacking": "none",
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        },
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 0
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "kpi-postgres-datasource"
+          },
+          "format": "table",
+          "rawSql": "SELECT kpi_id AS metric, errors AS value FROM query_errors WHERE errors > 0 ORDER BY errors DESC",
+          "refId": "A"
+        }
+      ],
+      "title": "Query Errors by KPI (Static)",
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "kpi-postgres-datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false,
+            "filterable": true
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 28
+      },
+      "id": 6,
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false,
+          "reducer": [
+            "sum"
+          ],
+          "countRows": false,
+          "fields": ""
+        },
+        "sortBy": [
+          {
+            "displayName": "KPI ID",
+            "desc": false
+          }
+        ]
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "kpi-postgres-datasource"
+          },
+          "format": "table",
+          "rawSql": "SELECT kpi_id, COUNT(*) AS sample_count, ROUND(CAST(AVG(metric_value) AS numeric), 6) AS avg_value, ROUND(CAST(MIN(metric_value) AS numeric), 6) AS min_value, ROUND(CAST(MAX(metric_value) AS numeric), 6) AS max_value, ROUND(CAST(MAX(metric_value) - MIN(metric_value) AS numeric), 6) AS range, COUNT(DISTINCT metric_labels) AS unique_metrics FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE timestamp_value >= $__from / 1000 AND timestamp_value < $__to / 1000 AND kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) AND COALESCE(metric_labels->>'node', 'N/A') LIKE (CASE WHEN '${node}' = 'All' THEN '%%' ELSE '${node}' END) AND COALESCE(metric_labels->>'job', 'N/A') LIKE (CASE WHEN '${job}' = 'All' THEN '%%' ELSE '${job}' END) AND COALESCE(metric_labels->>'container', 'N/A') LIKE (CASE WHEN '${container}' = 'All' THEN '%%' ELSE '${container}' END) AND COALESCE(metric_labels->>'pod', 'N/A') LIKE (CASE WHEN '${pod}' = 'All' THEN '%%' ELSE '${pod}' END) GROUP BY kpi_id ORDER BY kpi_id",
+          "refId": "A"
+        }
+      ],
+      "title": "All KPIs - Summary Statistics",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "kpi-postgres-datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 37
+      },
+      "id": 7,
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false,
+          "reducer": [
+            "sum"
+          ],
+          "countRows": false,
+          "fields": ""
+        },
+        "sortBy": []
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "kpi-postgres-datasource"
+          },
+          "format": "table",
+          "rawSql": "SELECT c.cluster_name, COALESCE(c.cluster_type, 'N/A') AS cluster_type, COUNT(DISTINCT qr.kpi_id) AS kpi_count, COUNT(qr.metric_value) AS total_samples, MAX(qr.created_at) AS last_collection FROM clusters c LEFT JOIN query_results qr ON c.id = qr.cluster_id AND qr.timestamp_value >= $__from / 1000 AND qr.timestamp_value < $__to / 1000 WHERE COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) GROUP BY c.cluster_name, COALESCE(c.cluster_type, 'N/A') ORDER BY c.cluster_name",
+          "refId": "A"
+        }
+      ],
+      "title": "Cluster Monitoring Status (Time-Aware Counts)",
+      "type": "table"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": [
+    "kpi",
+    "metrics",
+    "monitoring"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "text": "All",
+          "value": "All"
+        },
+        "datasource": {
+          "type": "postgres",
+          "uid": "kpi-postgres-datasource"
+        },
+        "definition": "SELECT cluster_type FROM (SELECT 'All' AS cluster_type, 1 AS order_col UNION ALL SELECT DISTINCT COALESCE(cluster_type, 'N/A'), 2 AS order_col FROM clusters) AS temp_data ORDER BY order_col, cluster_type;",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Cluster Type",
+        "multi": false,
+        "name": "cluster_type",
+        "options": [],
+        "query": "SELECT cluster_type FROM (SELECT 'All' AS cluster_type, 1 AS order_col UNION ALL SELECT DISTINCT COALESCE(cluster_type, 'N/A'), 2 AS order_col FROM clusters) AS temp_data ORDER BY order_col, cluster_type;",
+        "refresh": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "text": "",
+          "value": ""
+        },
+        "datasource": {
+          "type": "postgres",
+          "uid": "kpi-postgres-datasource"
+        },
+        "definition": "SELECT cluster_name FROM (SELECT c.cluster_name, CASE WHEN c.id = (SELECT cluster_id FROM query_results ORDER BY created_at DESC LIMIT 1) THEN 1 ELSE 3 END AS sort_order FROM clusters c WHERE COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) UNION ALL SELECT 'All', 2) AS t ORDER BY sort_order, cluster_name;",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Cluster",
+        "multi": false,
+        "name": "cluster",
+        "options": [],
+        "query": "SELECT cluster_name FROM (SELECT c.cluster_name, CASE WHEN c.id = (SELECT cluster_id FROM query_results ORDER BY created_at DESC LIMIT 1) THEN 1 ELSE 3 END AS sort_order FROM clusters c WHERE COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) UNION ALL SELECT 'All', 2) AS t ORDER BY sort_order, cluster_name;",
+        "refresh": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "text": "",
+          "value": ""
+        },
+        "datasource": {
+          "type": "postgres",
+          "uid": "kpi-postgres-datasource"
+        },
+        "definition": "SELECT kpi_id FROM (SELECT DISTINCT kpi_id, 1 AS sort_order FROM query_results WHERE kpi_id IS NOT NULL AND kpi_id != '' UNION ALL SELECT 'All', 2) AS t ORDER BY sort_order, kpi_id;",
+        "hide": 0,
+        "includeAll": false,
+        "label": "KPI",
+        "multi": false,
+        "name": "kpi",
+        "options": [],
+        "query": "SELECT kpi_id FROM (SELECT DISTINCT kpi_id, 1 AS sort_order FROM query_results WHERE kpi_id IS NOT NULL AND kpi_id != '' UNION ALL SELECT 'All', 2) AS t ORDER BY sort_order, kpi_id;",
+        "refresh": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "text": "All",
+          "value": "All"
+        },
+        "datasource": {
+          "type": "postgres",
+          "uid": "kpi-postgres-datasource"
+        },
+        "definition": "SELECT node FROM (SELECT 'All' AS node, 1 AS order_col UNION ALL SELECT DISTINCT COALESCE(metric_labels->>'node', 'N/A'), 2 AS order_col FROM query_results WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND metric_labels->>'node' IS NOT NULL) AS temp_data ORDER BY order_col, node;",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Node",
+        "multi": false,
+        "name": "node",
+        "options": [],
+        "query": "SELECT node FROM (SELECT 'All' AS node, 1 AS order_col UNION ALL SELECT DISTINCT COALESCE(metric_labels->>'node', 'N/A'), 2 AS order_col FROM query_results WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND metric_labels->>'node' IS NOT NULL) AS temp_data ORDER BY order_col, node;",
+        "refresh": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "text": "All",
+          "value": "All"
+        },
+        "datasource": {
+          "type": "postgres",
+          "uid": "kpi-postgres-datasource"
+        },
+        "definition": "SELECT job FROM (SELECT 'All' AS job, 1 AS order_col UNION ALL SELECT DISTINCT COALESCE(metric_labels->>'job', 'N/A'), 2 AS order_col FROM query_results WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND metric_labels->>'job' IS NOT NULL) AS temp_data ORDER BY order_col, job;",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Job",
+        "multi": false,
+        "name": "job",
+        "options": [],
+        "query": "SELECT job FROM (SELECT 'All' AS job, 1 AS order_col UNION ALL SELECT DISTINCT COALESCE(metric_labels->>'job', 'N/A'), 2 AS order_col FROM query_results WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND metric_labels->>'job' IS NOT NULL) AS temp_data ORDER BY order_col, job;",
+        "refresh": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "text": "All",
+          "value": "All"
+        },
+        "datasource": {
+          "type": "postgres",
+          "uid": "kpi-postgres-datasource"
+        },
+        "definition": "SELECT container FROM (SELECT 'All' AS container, 1 AS order_col UNION ALL SELECT DISTINCT COALESCE(metric_labels->>'container', 'N/A'), 2 AS order_col FROM query_results WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND metric_labels->>'container' IS NOT NULL) AS temp_data ORDER BY order_col, container;",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Container",
+        "multi": false,
+        "name": "container",
+        "options": [],
+        "query": "SELECT container FROM (SELECT 'All' AS container, 1 AS order_col UNION ALL SELECT DISTINCT COALESCE(metric_labels->>'container', 'N/A'), 2 AS order_col FROM query_results WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND metric_labels->>'container' IS NOT NULL) AS temp_data ORDER BY order_col, container;",
+        "refresh": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "text": "All",
+          "value": "All"
+        },
+        "datasource": {
+          "type": "postgres",
+          "uid": "kpi-postgres-datasource"
+        },
+        "definition": "SELECT pod FROM (SELECT 'All' AS pod, 1 AS order_col UNION ALL SELECT DISTINCT COALESCE(metric_labels->>'pod', 'N/A'), 2 AS order_col FROM query_results WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND metric_labels->>'pod' IS NOT NULL) AS temp_data ORDER BY order_col, pod;",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Pod",
+        "multi": false,
+        "name": "pod",
+        "options": [],
+        "query": "SELECT pod FROM (SELECT 'All' AS pod, 1 AS order_col UNION ALL SELECT DISTINCT COALESCE(metric_labels->>'pod', 'N/A'), 2 AS order_col FROM query_results WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND metric_labels->>'pod' IS NOT NULL) AS temp_data ORDER BY order_col, pod;",
+        "refresh": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-7d",
+    "to": "now"
+  },
+  "title": "KPI Collection Tool - Dynamic Dashboard (PostgreSQL)",
+  "uid": "kpi-collector-dynamic",
+  "version": 83,
+  "weekStart": ""
+}

--- a/grafana-templates/postgres-dashboard.json
+++ b/grafana-templates/postgres-dashboard.json
@@ -19,7 +19,19 @@
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
   "id": null,
-  "links": [],
+  "links": [
+    {
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": false,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Auto Fit",
+      "tooltip": "Adjust time range to fit all available data",
+      "type": "link",
+      "url": "/d/kpi-collector-dynamic/?from=${data_start}&to=${data_end}"
+    }
+  ],
   "liveNow": false,
   "panels": [
     {
@@ -814,11 +826,49 @@
         "query": "SELECT pod FROM (SELECT 'All' AS pod, 1 AS order_col UNION ALL SELECT DISTINCT COALESCE(metric_labels->>'pod', 'N/A'), 2 AS order_col FROM query_results WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND metric_labels->>'pod' IS NOT NULL) AS temp_data ORDER BY order_col, pod;",
         "refresh": 1,
         "type": "query"
+      },
+      {
+        "name": "data_start",
+        "type": "query",
+        "datasource": {
+          "type": "postgres",
+          "uid": "kpi-postgres-datasource"
+        },
+        "query": "SELECT COALESCE(CAST(MIN(timestamp_value) * 1000 AS BIGINT), 0) FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END)",
+        "definition": "SELECT COALESCE(CAST(MIN(timestamp_value) * 1000 AS BIGINT), 0) FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END)",
+        "includeAll": false,
+        "multi": false,
+        "current": {
+          "text": "",
+          "value": ""
+        },
+        "options": [],
+        "refresh": 1,
+        "hide": 2
+      },
+      {
+        "name": "data_end",
+        "type": "query",
+        "datasource": {
+          "type": "postgres",
+          "uid": "kpi-postgres-datasource"
+        },
+        "query": "SELECT COALESCE(CAST(MAX(timestamp_value) * 1000 AS BIGINT), 0) FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END)",
+        "definition": "SELECT COALESCE(CAST(MAX(timestamp_value) * 1000 AS BIGINT), 0) FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END)",
+        "includeAll": false,
+        "multi": false,
+        "current": {
+          "text": "",
+          "value": ""
+        },
+        "options": [],
+        "refresh": 1,
+        "hide": 2
       }
     ]
   },
   "time": {
-    "from": "now-7d",
+    "from": "now-24h",
     "to": "now"
   },
   "title": "KPI Collection Tool - Dynamic Dashboard (PostgreSQL)",

--- a/grafana-templates/sqlite-dashboard.json
+++ b/grafana-templates/sqlite-dashboard.json
@@ -637,7 +637,7 @@
       ]
     }
   ],
-  "refresh": "10s",
+  "refresh": "",
   "schemaVersion": 38,
   "style": "dark",
   "tags": [

--- a/grafana-templates/sqlite-dashboard.json
+++ b/grafana-templates/sqlite-dashboard.json
@@ -19,7 +19,19 @@
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
   "id": null,
-  "links": [],
+  "links": [
+    {
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": false,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Fit to data",
+      "tooltip": "Adjust time range to fit all available data",
+      "type": "link",
+      "url": "/d/kpi-collector-dynamic/?from=${data_start}&to=${data_end}"
+    }
+  ],
   "liveNow": false,
   "panels": [
     {
@@ -765,11 +777,45 @@
           "value": "All"
         },
         "refresh": 1
+      },
+      {
+        "name": "data_start",
+        "type": "query",
+        "datasource": {
+          "type": "frser-sqlite-datasource",
+          "uid": "kpi-datasource"
+        },
+        "query": "SELECT COALESCE(CAST(MIN(timestamp_value) * 1000 AS INTEGER), 0) FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}')",
+        "includeAll": false,
+        "multi": false,
+        "current": {
+          "text": "",
+          "value": ""
+        },
+        "refresh": 1,
+        "hide": 2
+      },
+      {
+        "name": "data_end",
+        "type": "query",
+        "datasource": {
+          "type": "frser-sqlite-datasource",
+          "uid": "kpi-datasource"
+        },
+        "query": "SELECT COALESCE(CAST(MAX(timestamp_value) * 1000 AS INTEGER), 0) FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}')",
+        "includeAll": false,
+        "multi": false,
+        "current": {
+          "text": "",
+          "value": ""
+        },
+        "refresh": 1,
+        "hide": 2
       }
     ]
   },
   "time": {
-    "from": "now-7d",
+    "from": "now-24h",
     "to": "now"
   },
   "timepicker": {},

--- a/grafana-templates/sqlite-dashboard.json
+++ b/grafana-templates/sqlite-dashboard.json
@@ -44,7 +44,7 @@
       },
       "gridPos": {
         "h": 10,
-        "w": 18,
+        "w": 24,
         "x": 0,
         "y": 0
       },
@@ -351,58 +351,19 @@
     },
     {
       "id": 2,
-      "type": "stat",
-      "title": "KPI Statistics Summary",
-      "datasource": {
-        "type": "frser-sqlite-datasource",
-        "uid": "kpi-datasource"
-      },
+      "type": "text",
+      "title": "",
       "gridPos": {
-        "h": 10,
-        "w": 6,
-        "x": 18,
-        "y": 0
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          }
-        },
-        "overrides": []
+        "h": 2,
+        "w": 24,
+        "x": 0,
+        "y": 10
       },
       "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "vertical",
-        "reduceOptions": {
-          "values": false,
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": ""
-        },
-        "textMode": "value_and_name",
-        "showPercentChange": false
+        "mode": "html",
+        "content": "<div style=\"text-align: center; vertical-align: middle\">sample count: ${samples_count}, average value: ${avg_value}, max value: ${max_value}, min value: ${min_value}</div>"
       },
-      "targets": [
-        {
-          "queryType": "table",
-          "rawQueryText": "SELECT COUNT(*) as 'Samples', ROUND(AVG(metric_value), 6) as 'Average', ROUND(MIN(metric_value), 6) as 'Minimum', ROUND(MAX(metric_value), 6) as 'Maximum' FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR json_extract(metric_labels, '$.node') = '${node}') AND ('${job}' = 'All' OR json_extract(metric_labels, '$.job') = '${job}') AND ('${pod}' = 'All' OR json_extract(metric_labels, '$.pod') = '${pod}') AND ('${container}' = 'All' OR json_extract(metric_labels, '$.container') = '${container}')",
-          "refId": "A"
-        }
-      ]
+      "transparent": true
     },
     {
       "id": 3,
@@ -416,7 +377,7 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 10
+        "y": 12
       },
       "fieldConfig": {
         "defaults": {
@@ -484,7 +445,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 20
+        "y": 22
       },
       "fieldConfig": {
         "defaults": {
@@ -549,7 +510,7 @@
         "h": 9,
         "w": 24,
         "x": 0,
-        "y": 28
+        "y": 30
       },
       "fieldConfig": {
         "defaults": {
@@ -609,7 +570,7 @@
         "h": 6,
         "w": 24,
         "x": 0,
-        "y": 37
+        "y": 39
       },
       "fieldConfig": {
         "defaults": {
@@ -777,6 +738,74 @@
           "value": "All"
         },
         "refresh": 1
+      },
+      {
+        "name": "samples_count",
+        "type": "query",
+        "datasource": {
+          "type": "frser-sqlite-datasource",
+          "uid": "kpi-datasource"
+        },
+        "query": "SELECT COALESCE(COUNT(*), 0) FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR json_extract(metric_labels, '$.node') = '${node}') AND ('${job}' = 'All' OR json_extract(metric_labels, '$.job') = '${job}') AND ('${pod}' = 'All' OR json_extract(metric_labels, '$.pod') = '${pod}') AND ('${container}' = 'All' OR json_extract(metric_labels, '$.container') = '${container}')",
+        "includeAll": false,
+        "multi": false,
+        "current": {
+          "text": "",
+          "value": ""
+        },
+        "refresh": 1,
+        "hide": 2
+      },
+      {
+        "name": "avg_value",
+        "type": "query",
+        "datasource": {
+          "type": "frser-sqlite-datasource",
+          "uid": "kpi-datasource"
+        },
+        "query": "SELECT COALESCE(ROUND(AVG(metric_value), 6), 'N/A') FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR json_extract(metric_labels, '$.node') = '${node}') AND ('${job}' = 'All' OR json_extract(metric_labels, '$.job') = '${job}') AND ('${pod}' = 'All' OR json_extract(metric_labels, '$.pod') = '${pod}') AND ('${container}' = 'All' OR json_extract(metric_labels, '$.container') = '${container}')",
+        "includeAll": false,
+        "multi": false,
+        "current": {
+          "text": "",
+          "value": ""
+        },
+        "refresh": 1,
+        "hide": 2
+      },
+      {
+        "name": "min_value",
+        "type": "query",
+        "datasource": {
+          "type": "frser-sqlite-datasource",
+          "uid": "kpi-datasource"
+        },
+        "query": "SELECT COALESCE(ROUND(MIN(metric_value), 6), 'N/A') FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR json_extract(metric_labels, '$.node') = '${node}') AND ('${job}' = 'All' OR json_extract(metric_labels, '$.job') = '${job}') AND ('${pod}' = 'All' OR json_extract(metric_labels, '$.pod') = '${pod}') AND ('${container}' = 'All' OR json_extract(metric_labels, '$.container') = '${container}')",
+        "includeAll": false,
+        "multi": false,
+        "current": {
+          "text": "",
+          "value": ""
+        },
+        "refresh": 1,
+        "hide": 2
+      },
+      {
+        "name": "max_value",
+        "type": "query",
+        "datasource": {
+          "type": "frser-sqlite-datasource",
+          "uid": "kpi-datasource"
+        },
+        "query": "SELECT COALESCE(ROUND(MAX(metric_value), 6), 'N/A') FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR json_extract(metric_labels, '$.node') = '${node}') AND ('${job}' = 'All' OR json_extract(metric_labels, '$.job') = '${job}') AND ('${pod}' = 'All' OR json_extract(metric_labels, '$.pod') = '${pod}') AND ('${container}' = 'All' OR json_extract(metric_labels, '$.container') = '${container}')",
+        "includeAll": false,
+        "multi": false,
+        "current": {
+          "text": "",
+          "value": ""
+        },
+        "refresh": 1,
+        "hide": 2
       },
       {
         "name": "data_start",

--- a/grafana-templates/sqlite-dashboard.json
+++ b/grafana-templates/sqlite-dashboard.json
@@ -1,1 +1,781 @@
-{"annotations":{"list":[{"builtIn":1,"datasource":{"type":"grafana","uid":"-- Grafana --"},"enable":true,"hide":true,"iconColor":"rgba(0, 211, 255, 1)","name":"Annotations & Alerts","type":"dashboard"}]},"editable":true,"fiscalYearStartMonth":0,"graphTooltip":1,"id":null,"links":[],"liveNow":false,"panels":[{"id":1,"type":"timeseries","title":"Metric Values Over Time","datasource":{"type":"frser-sqlite-datasource","uid":"kpi-datasource"},"gridPos":{"h":10,"w":18,"x":0,"y":0},"fieldConfig":{"defaults":{"color":{"mode":"palette-classic"},"custom":{"axisCenteredZero":false,"axisColorMode":"text","axisLabel":"","axisPlacement":"auto","barAlignment":0,"drawStyle":"line","fillOpacity":10,"gradientMode":"none","hideFrom":{"tooltip":false,"viz":false,"legend":false},"lineInterpolation":"linear","lineWidth":2,"pointSize":5,"scaleDistribution":{"type":"linear"},"showPoints":"never","spanNulls":false,"stacking":{"group":"A","mode":"none"},"thresholdsStyle":{"mode":"off"}},"mappings":[],"thresholds":{"mode":"absolute","steps":[{"color":"green","value":null},{"color":"blue","value":null,"label":"Min"},{"color":"orange","value":null,"label":"Avg"},{"color":"red","value":null,"label":"Max"}],"showThresholdLabels":true,"showThresholdMarkers":{"mode":"off"}},"unit":"short"},"overrides":[{"matcher":{"id":"byName","options":"metric_value"},"properties":[{"id":"custom.lineWidth","value":2},{"id":"custom.lineStyle","value":{"fill":"solid"}},{"id":"custom.hideFrom","value":{"tooltip":false,"viz":false,"legend":false}}]},{"matcher":{"id":"byName","options":"Max Value"},"properties":[{"id":"custom.drawStyle","value":"line"},{"id":"custom.lineStyle","value":{"fill":"dash","dash":[6,6]}},{"id":"custom.lineWidth","value":3},{"id":"color","value":{"fixedColor":"red","mode":"fixed"}},{"id":"custom.hideFrom","value":{"tooltip":true,"viz":false,"legend":true}}]},{"matcher":{"id":"byName","options":"Min Value"},"properties":[{"id":"custom.drawStyle","value":"line"},{"id":"custom.lineStyle","value":{"fill":"dash","dash":[6,6]}},{"id":"custom.lineWidth","value":3},{"id":"color","value":{"fixedColor":"blue","mode":"fixed"}},{"id":"custom.hideFrom","value":{"tooltip":true,"viz":false,"legend":true}}]},{"matcher":{"id":"byName","options":"Average Value"},"properties":[{"id":"custom.drawStyle","value":"line"},{"id":"custom.lineStyle","value":{"fill":"dash","dash":[10,5]}},{"id":"custom.lineWidth","value":3},{"id":"color","value":{"fixedColor":"orange","mode":"fixed"}},{"id":"custom.hideFrom","value":{"tooltip":true,"viz":false,"legend":true}}]}]},"options":{"legend":{"calcs":["last","mean","min","max"],"displayMode":"table","placement":"bottom","showLegend":true},"tooltip":{"mode":"multi","sort":"desc"}},"targets":[{"queryType":"table","rawQueryText":"SELECT timestamp_value AS time, metric_value, metric_labels FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR json_extract(metric_labels, '$.node') = '${node}') AND ('${job}' = 'All' OR json_extract(metric_labels, '$.job') = '${job}') AND ('${pod}' = 'All' OR json_extract(metric_labels, '$.pod') = '${pod}') AND ('${container}' = 'All' OR json_extract(metric_labels, '$.container') = '${container}') AND timestamp_value >= $__from / 1000 AND timestamp_value < $__to / 1000 ORDER BY time ASC","refId":"A","timeColumns":["time","ts"],"legendFormat":"Node: {{node}} | Pod: {{pod}} | Job: {{job}} | Container: {{container}} | ID: {{id}}"},{"queryType":"table","rawQueryText":"SELECT 'Max Value' AS metric_labels, MAX(metric_value) AS metric_value, $__from/1000 AS time FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR json_extract(metric_labels, '$.node') = '${node}') AND ('${job}' = 'All' OR json_extract(metric_labels, '$.job') = '${job}') AND ('${pod}' = 'All' OR json_extract(metric_labels, '$.pod') = '${pod}') AND ('${container}' = 'All' OR json_extract(metric_labels, '$.container') = '${container}')","refId":"B","legendFormat":"Max Value","hide":true},{"queryType":"table","rawQueryText":"SELECT 'Min Value' AS metric_labels, MIN(metric_value) AS metric_value, $__from/1000 AS time FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR json_extract(metric_labels, '$.node') = '${node}') AND ('${job}' = 'All' OR json_extract(metric_labels, '$.job') = '${job}') AND ('${pod}' = 'All' OR json_extract(metric_labels, '$.pod') = '${pod}') AND ('${container}' = 'All' OR json_extract(metric_labels, '$.container') = '${container}')","refId":"C","legendFormat":"Min Value","hide":true},{"queryType":"table","rawQueryText":"SELECT 'Average Value' AS metric_labels, AVG(metric_value) AS metric_value, $__from/1000 AS time FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR json_extract(metric_labels, '$.node') = '${node}') AND ('${job}' = 'All' OR json_extract(metric_labels, '$.job') = '${job}') AND ('${pod}' = 'All' OR json_extract(metric_labels, '$.pod') = '${pod}') AND ('${container}' = 'All' OR json_extract(metric_labels, '$.container') = '${container}')","refId":"D","legendFormat":"Average Value","hide":true}],"transformations":[{"id":"extractFields","options":{"source":"metric_labels","format":"json","replace":false,"keepTime":true}},{"id":"organize","options":{"excludeByName":{"metric_labels":true,"undefined":true,"cpu":true,"device":true,"endpoint":true,"instance":true},"indexByName":{},"renameByName":{}}},{"id":"prepareTimeSeries","options":{"format":"multi"}}]},{"id":2,"type":"stat","title":"KPI Statistics Summary","datasource":{"type":"frser-sqlite-datasource","uid":"kpi-datasource"},"gridPos":{"h":10,"w":6,"x":18,"y":0},"fieldConfig":{"defaults":{"color":{"mode":"thresholds"},"mappings":[],"thresholds":{"mode":"absolute","steps":[{"color":"green","value":null}]}},"overrides":[]},"options":{"colorMode":"background","graphMode":"none","justifyMode":"center","orientation":"vertical","reduceOptions":{"values":false,"calcs":["lastNotNull"],"fields":""},"textMode":"value_and_name","showPercentChange":false},"targets":[{"queryType":"table","rawQueryText":"SELECT COUNT(*) as 'Samples', ROUND(AVG(metric_value), 6) as 'Average', ROUND(MIN(metric_value), 6) as 'Minimum', ROUND(MAX(metric_value), 6) as 'Maximum' FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR json_extract(metric_labels, '$.node') = '${node}') AND ('${job}' = 'All' OR json_extract(metric_labels, '$.job') = '${job}') AND ('${pod}' = 'All' OR json_extract(metric_labels, '$.pod') = '${pod}') AND ('${container}' = 'All' OR json_extract(metric_labels, '$.container') = '${container}')","refId":"A"}]},{"id":3,"type":"table","title":"Detailed Metrics with All Labels","datasource":{"type":"frser-sqlite-datasource","uid":"kpi-datasource"},"gridPos":{"h":10,"w":24,"x":0,"y":10},"fieldConfig":{"defaults":{"color":{"mode":"thresholds"},"custom":{"align":"auto","cellOptions":{"type":"auto"},"inspect":false,"filterable":true},"mappings":[],"thresholds":{"mode":"absolute","steps":[{"color":"green","value":null}]}},"overrides":[]},"options":{"showHeader":true,"cellHeight":"sm","sortBy":[{"displayName":"Avg Value","desc":true}]},"targets":[{"queryType":"table","rawQueryText":"SELECT metric_labels, ROUND(AVG(metric_value), 6) AS avg_value, ROUND(MIN(metric_value), 6) AS min_value, ROUND(MAX(metric_value), 6) AS max_value, COUNT(*) AS samples FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR json_extract(metric_labels, '$.node') = '${node}') AND ('${job}' = 'All' OR json_extract(metric_labels, '$.job') = '${job}') AND ('${pod}' = 'All' OR json_extract(metric_labels, '$.pod') = '${pod}') AND ('${container}' = 'All' OR json_extract(metric_labels, '$.container') = '${container}') GROUP BY metric_labels ORDER BY avg_value DESC LIMIT 100","refId":"A"}],"transformations":[{"id":"extractFields","options":{"source":"metric_labels","format":"json","replace":true}}]},{"id":5,"type":"barchart","title":"Query Errors by KPI","datasource":{"type":"frser-sqlite-datasource","uid":"kpi-datasource"},"gridPos":{"h":8,"w":24,"x":0,"y":20},"fieldConfig":{"defaults":{"color":{"mode":"thresholds"},"mappings":[],"thresholds":{"mode":"absolute","steps":[{"color":"green","value":null},{"color":"yellow","value":1},{"color":"red","value":5}]}},"overrides":[]},"options":{"barRadius":0,"barWidth":0.97,"fullHighlight":false,"groupWidth":0.7,"legend":{"displayMode":"list","showLegend":false},"orientation":"horizontal","showValue":"always","stacking":"none","tooltip":{"mode":"single","sort":"none"}},"targets":[{"queryType":"table","rawQueryText":"SELECT kpi_id AS metric, errors AS value FROM query_errors WHERE errors > 0 ORDER BY errors DESC;","refId":"A"}]},{"id":6,"type":"table","title":"All KPIs - Summary Statistics","datasource":{"type":"frser-sqlite-datasource","uid":"kpi-datasource"},"gridPos":{"h":9,"w":24,"x":0,"y":28},"fieldConfig":{"defaults":{"color":{"mode":"thresholds"},"custom":{"align":"auto","cellOptions":{"type":"auto"},"inspect":false},"mappings":[],"thresholds":{"mode":"absolute","steps":[{"color":"green","value":null}]}},"overrides":[]},"options":{"showHeader":true,"cellHeight":"sm","footer":{"show":false},"sortBy":[{"displayName":"KPI ID","desc":false}]},"targets":[{"queryType":"table","rawQueryText":"SELECT kpi_id, COUNT(*) AS sample_count, ROUND(AVG(metric_value), 6) AS avg_value, ROUND(MIN(metric_value), 6) AS min_value, ROUND(MAX(metric_value), 6) AS max_value, ROUND(MAX(metric_value) - MIN(metric_value), 6) AS range, COUNT(DISTINCT metric_labels) AS unique_metrics FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR json_extract(metric_labels, '$.node') = '${node}') AND ('${job}' = 'All' OR json_extract(metric_labels, '$.job') = '${job}') AND ('${pod}' = 'All' OR json_extract(metric_labels, '$.pod') = '${pod}') AND ('${container}' = 'All' OR json_extract(metric_labels, '$.container') = '${container}') GROUP BY kpi_id ORDER BY kpi_id","refId":"A"}]},{"id":7,"type":"table","title":"Cluster Monitoring Status","datasource":{"type":"frser-sqlite-datasource","uid":"kpi-datasource"},"gridPos":{"h":6,"w":24,"x":0,"y":37},"fieldConfig":{"defaults":{"color":{"mode":"thresholds"},"custom":{"align":"auto","cellOptions":{"type":"auto"},"inspect":false},"mappings":[],"thresholds":{"mode":"absolute","steps":[{"color":"green","value":null}]}},"overrides":[]},"options":{"showHeader":true,"cellHeight":"sm"},"targets":[{"queryType":"table","rawQueryText":"SELECT c.cluster_name, c.cluster_type, COUNT(DISTINCT qr.kpi_id) AS kpi_count, COUNT(*) AS total_samples, MAX(qr.created_at) AS last_collection FROM clusters c LEFT JOIN query_results qr ON c.id = qr.cluster_id WHERE ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${node}' = 'All' OR json_extract(qr.metric_labels, '$.node') = '${node}') AND ('${job}' = 'All' OR json_extract(qr.metric_labels, '$.job') = '${job}') AND ('${pod}' = 'All' OR json_extract(qr.metric_labels, '$.pod') = '${pod}') AND ('${container}' = 'All' OR json_extract(qr.metric_labels, '$.container') = '${container}') GROUP BY c.cluster_name, c.cluster_type ORDER BY c.cluster_name","refId":"A"}]}],"refresh":"10s","schemaVersion":38,"style":"dark","tags":["kpi","metrics","monitoring"],"templating":{"list":[{"name":"cluster_type","type":"query","label":"Cluster Type","datasource":{"type":"frser-sqlite-datasource","uid":"kpi-datasource"},"query":"SELECT cluster_type FROM (SELECT 'All' AS cluster_type, 1 AS sort_order UNION ALL SELECT DISTINCT cluster_type, 2 AS sort_order FROM clusters WHERE cluster_type IS NOT NULL AND cluster_type <> '') ORDER BY sort_order, cluster_type;","includeAll":false,"multi":false,"current":{"text":"All","value":"All"},"refresh":1},{"name":"cluster","type":"query","label":"Cluster","datasource":{"type":"frser-sqlite-datasource","uid":"kpi-datasource"},"query":"SELECT cluster_name FROM (SELECT DISTINCT c.cluster_name, CASE WHEN c.id = (SELECT cluster_id FROM query_results ORDER BY created_at DESC LIMIT 1) THEN 1 ELSE 3 END AS sort_order FROM clusters c WHERE c.cluster_name IS NOT NULL AND c.cluster_name <> '' AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') UNION ALL SELECT 'All', 2) ORDER BY sort_order, cluster_name;","includeAll":false,"multi":false,"current":{"text":"","value":""},"refresh":1},{"name":"kpi","type":"query","label":"KPI","datasource":{"type":"frser-sqlite-datasource","uid":"kpi-datasource"},"query":"SELECT kpi_id FROM (SELECT DISTINCT kpi_id, 1 AS sort_order FROM query_results WHERE kpi_id IS NOT NULL AND kpi_id <> '' UNION ALL SELECT 'All', 2) ORDER BY sort_order, kpi_id;","includeAll":false,"multi":false,"current":{"text":"","value":""},"refresh":1},{"name":"node","type":"query","label":"Node","datasource":{"type":"frser-sqlite-datasource","uid":"kpi-datasource"},"query":"SELECT node FROM (SELECT 'All' AS node, 1 AS sort_order UNION ALL SELECT DISTINCT json_extract(metric_labels, '$.node'), 2 FROM query_results WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND metric_labels IS NOT NULL AND json_extract(metric_labels, '$.node') IS NOT NULL AND json_extract(metric_labels, '$.node') <> '') ORDER BY sort_order, node;","includeAll":false,"multi":false,"current":{"text":"All","value":"All"},"refresh":1},{"name":"job","type":"query","label":"Job","datasource":{"type":"frser-sqlite-datasource","uid":"kpi-datasource"},"query":"SELECT job FROM (SELECT 'All' AS job, 1 AS sort_order UNION ALL SELECT DISTINCT json_extract(metric_labels, '$.job'), 2 FROM query_results WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND metric_labels IS NOT NULL AND json_extract(metric_labels, '$.job') IS NOT NULL AND json_extract(metric_labels, '$.job') <> '') ORDER BY sort_order, job;","includeAll":false,"multi":false,"current":{"text":"All","value":"All"},"refresh":1},{"name":"pod","type":"query","label":"Pod","datasource":{"type":"frser-sqlite-datasource","uid":"kpi-datasource"},"query":"SELECT pod FROM (SELECT 'All' AS pod, 1 AS sort_order UNION ALL SELECT DISTINCT json_extract(metric_labels, '$.pod'), 2 FROM query_results WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND metric_labels IS NOT NULL AND json_extract(metric_labels, '$.pod') IS NOT NULL AND json_extract(metric_labels, '$.pod') <> '') ORDER BY sort_order, pod;","includeAll":false,"multi":false,"current":{"text":"All","value":"All"},"refresh":1},{"name":"container","type":"query","label":"Container","datasource":{"type":"frser-sqlite-datasource","uid":"kpi-datasource"},"query":"SELECT container FROM (SELECT 'All' AS container, 1 AS sort_order UNION ALL SELECT DISTINCT json_extract(metric_labels, '$.container'), 2 FROM query_results WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND metric_labels IS NOT NULL AND json_extract(metric_labels, '$.container') IS NOT NULL AND json_extract(metric_labels, '$.container') <> '') ORDER BY sort_order, container;","includeAll":false,"multi":false,"current":{"text":"All","value":"All"},"refresh":1}]},"time":{"from":"now-7d","to":"now"},"timepicker":{},"timezone":"","title":"KPI Collection Tool - Dynamic Dashboard","uid":"kpi-collector-dynamic","version":3,"weekStart":""}
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "Metric Values Over Time",
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "kpi-datasource"
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 18,
+        "x": 0,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "blue",
+                "value": null,
+                "label": "Min"
+              },
+              {
+                "color": "orange",
+                "value": null,
+                "label": "Avg"
+              },
+              {
+                "color": "red",
+                "value": null,
+                "label": "Max"
+              }
+            ],
+            "showThresholdLabels": true,
+            "showThresholdMarkers": {
+              "mode": "off"
+            }
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "metric_value"
+            },
+            "properties": [
+              {
+                "id": "custom.lineWidth",
+                "value": 2
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "fill": "solid"
+                }
+              },
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "tooltip": false,
+                  "viz": false,
+                  "legend": false
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Max Value"
+            },
+            "properties": [
+              {
+                "id": "custom.drawStyle",
+                "value": "line"
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "fill": "dash",
+                  "dash": [
+                    6,
+                    6
+                  ]
+                }
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 3
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "tooltip": true,
+                  "viz": false,
+                  "legend": true
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Min Value"
+            },
+            "properties": [
+              {
+                "id": "custom.drawStyle",
+                "value": "line"
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "fill": "dash",
+                  "dash": [
+                    6,
+                    6
+                  ]
+                }
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 3
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "tooltip": true,
+                  "viz": false,
+                  "legend": true
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Average Value"
+            },
+            "properties": [
+              {
+                "id": "custom.drawStyle",
+                "value": "line"
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "fill": "dash",
+                  "dash": [
+                    10,
+                    5
+                  ]
+                }
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 3
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "tooltip": true,
+                  "viz": false,
+                  "legend": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "last",
+            "mean",
+            "min",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "queryType": "table",
+          "rawQueryText": "SELECT timestamp_value AS time, metric_value, metric_labels FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR json_extract(metric_labels, '$.node') = '${node}') AND ('${job}' = 'All' OR json_extract(metric_labels, '$.job') = '${job}') AND ('${pod}' = 'All' OR json_extract(metric_labels, '$.pod') = '${pod}') AND ('${container}' = 'All' OR json_extract(metric_labels, '$.container') = '${container}') AND timestamp_value >= $__from / 1000 AND timestamp_value < $__to / 1000 ORDER BY time ASC",
+          "refId": "A",
+          "timeColumns": [
+            "time",
+            "ts"
+          ],
+          "legendFormat": "Node: {{node}} | Pod: {{pod}} | Job: {{job}} | Container: {{container}} | ID: {{id}}"
+        },
+        {
+          "queryType": "table",
+          "rawQueryText": "SELECT 'Max Value' AS metric_labels, MAX(metric_value) AS metric_value, $__from/1000 AS time FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR json_extract(metric_labels, '$.node') = '${node}') AND ('${job}' = 'All' OR json_extract(metric_labels, '$.job') = '${job}') AND ('${pod}' = 'All' OR json_extract(metric_labels, '$.pod') = '${pod}') AND ('${container}' = 'All' OR json_extract(metric_labels, '$.container') = '${container}')",
+          "refId": "B",
+          "legendFormat": "Max Value",
+          "hide": true
+        },
+        {
+          "queryType": "table",
+          "rawQueryText": "SELECT 'Min Value' AS metric_labels, MIN(metric_value) AS metric_value, $__from/1000 AS time FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR json_extract(metric_labels, '$.node') = '${node}') AND ('${job}' = 'All' OR json_extract(metric_labels, '$.job') = '${job}') AND ('${pod}' = 'All' OR json_extract(metric_labels, '$.pod') = '${pod}') AND ('${container}' = 'All' OR json_extract(metric_labels, '$.container') = '${container}')",
+          "refId": "C",
+          "legendFormat": "Min Value",
+          "hide": true
+        },
+        {
+          "queryType": "table",
+          "rawQueryText": "SELECT 'Average Value' AS metric_labels, AVG(metric_value) AS metric_value, $__from/1000 AS time FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR json_extract(metric_labels, '$.node') = '${node}') AND ('${job}' = 'All' OR json_extract(metric_labels, '$.job') = '${job}') AND ('${pod}' = 'All' OR json_extract(metric_labels, '$.pod') = '${pod}') AND ('${container}' = 'All' OR json_extract(metric_labels, '$.container') = '${container}')",
+          "refId": "D",
+          "legendFormat": "Average Value",
+          "hide": true
+        }
+      ],
+      "transformations": [
+        {
+          "id": "extractFields",
+          "options": {
+            "source": "metric_labels",
+            "format": "json",
+            "replace": false,
+            "keepTime": true
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "metric_labels": true,
+              "undefined": true,
+              "cpu": true,
+              "device": true,
+              "endpoint": true,
+              "instance": true
+            },
+            "indexByName": {},
+            "renameByName": {}
+          }
+        },
+        {
+          "id": "prepareTimeSeries",
+          "options": {
+            "format": "multi"
+          }
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "KPI Statistics Summary",
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "kpi-datasource"
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "vertical",
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "textMode": "value_and_name",
+        "showPercentChange": false
+      },
+      "targets": [
+        {
+          "queryType": "table",
+          "rawQueryText": "SELECT COUNT(*) as 'Samples', ROUND(AVG(metric_value), 6) as 'Average', ROUND(MIN(metric_value), 6) as 'Minimum', ROUND(MAX(metric_value), 6) as 'Maximum' FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR json_extract(metric_labels, '$.node') = '${node}') AND ('${job}' = 'All' OR json_extract(metric_labels, '$.job') = '${job}') AND ('${pod}' = 'All' OR json_extract(metric_labels, '$.pod') = '${pod}') AND ('${container}' = 'All' OR json_extract(metric_labels, '$.container') = '${container}')",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "table",
+      "title": "Detailed Metrics with All Labels",
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "kpi-datasource"
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 10
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false,
+            "filterable": true
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "sortBy": [
+          {
+            "displayName": "Avg Value",
+            "desc": true
+          }
+        ]
+      },
+      "targets": [
+        {
+          "queryType": "table",
+          "rawQueryText": "SELECT metric_labels, ROUND(AVG(metric_value), 6) AS avg_value, ROUND(MIN(metric_value), 6) AS min_value, ROUND(MAX(metric_value), 6) AS max_value, COUNT(*) AS samples FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR json_extract(metric_labels, '$.node') = '${node}') AND ('${job}' = 'All' OR json_extract(metric_labels, '$.job') = '${job}') AND ('${pod}' = 'All' OR json_extract(metric_labels, '$.pod') = '${pod}') AND ('${container}' = 'All' OR json_extract(metric_labels, '$.container') = '${container}') GROUP BY metric_labels ORDER BY avg_value DESC LIMIT 100",
+          "refId": "A"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "extractFields",
+          "options": {
+            "source": "metric_labels",
+            "format": "json",
+            "replace": true
+          }
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "barchart",
+      "title": "Query Errors by KPI",
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "kpi-datasource"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 20
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "barRadius": 0,
+        "barWidth": 0.97,
+        "fullHighlight": false,
+        "groupWidth": 0.7,
+        "legend": {
+          "displayMode": "list",
+          "showLegend": false
+        },
+        "orientation": "horizontal",
+        "showValue": "always",
+        "stacking": "none",
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "queryType": "table",
+          "rawQueryText": "SELECT kpi_id AS metric, errors AS value FROM query_errors WHERE errors > 0 ORDER BY errors DESC;",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "type": "table",
+      "title": "All KPIs - Summary Statistics",
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "kpi-datasource"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 28
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false
+        },
+        "sortBy": [
+          {
+            "displayName": "KPI ID",
+            "desc": false
+          }
+        ]
+      },
+      "targets": [
+        {
+          "queryType": "table",
+          "rawQueryText": "SELECT kpi_id, COUNT(*) AS sample_count, ROUND(AVG(metric_value), 6) AS avg_value, ROUND(MIN(metric_value), 6) AS min_value, ROUND(MAX(metric_value), 6) AS max_value, ROUND(MAX(metric_value) - MIN(metric_value), 6) AS range, COUNT(DISTINCT metric_labels) AS unique_metrics FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR json_extract(metric_labels, '$.node') = '${node}') AND ('${job}' = 'All' OR json_extract(metric_labels, '$.job') = '${job}') AND ('${pod}' = 'All' OR json_extract(metric_labels, '$.pod') = '${pod}') AND ('${container}' = 'All' OR json_extract(metric_labels, '$.container') = '${container}') GROUP BY kpi_id ORDER BY kpi_id",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "type": "table",
+      "title": "Cluster Monitoring Status",
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "kpi-datasource"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 37
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm"
+      },
+      "targets": [
+        {
+          "queryType": "table",
+          "rawQueryText": "SELECT c.cluster_name, c.cluster_type, COUNT(DISTINCT qr.kpi_id) AS kpi_count, COUNT(*) AS total_samples, MAX(qr.created_at) AS last_collection FROM clusters c LEFT JOIN query_results qr ON c.id = qr.cluster_id WHERE ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${node}' = 'All' OR json_extract(qr.metric_labels, '$.node') = '${node}') AND ('${job}' = 'All' OR json_extract(qr.metric_labels, '$.job') = '${job}') AND ('${pod}' = 'All' OR json_extract(qr.metric_labels, '$.pod') = '${pod}') AND ('${container}' = 'All' OR json_extract(qr.metric_labels, '$.container') = '${container}') GROUP BY c.cluster_name, c.cluster_type ORDER BY c.cluster_name",
+          "refId": "A"
+        }
+      ]
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": [
+    "kpi",
+    "metrics",
+    "monitoring"
+  ],
+  "templating": {
+    "list": [
+      {
+        "name": "cluster_type",
+        "type": "query",
+        "label": "Cluster Type",
+        "datasource": {
+          "type": "frser-sqlite-datasource",
+          "uid": "kpi-datasource"
+        },
+        "query": "SELECT cluster_type FROM (SELECT 'All' AS cluster_type, 1 AS sort_order UNION ALL SELECT DISTINCT cluster_type, 2 AS sort_order FROM clusters WHERE cluster_type IS NOT NULL AND cluster_type <> '') ORDER BY sort_order, cluster_type;",
+        "includeAll": false,
+        "multi": false,
+        "current": {
+          "text": "All",
+          "value": "All"
+        },
+        "refresh": 1
+      },
+      {
+        "name": "cluster",
+        "type": "query",
+        "label": "Cluster",
+        "datasource": {
+          "type": "frser-sqlite-datasource",
+          "uid": "kpi-datasource"
+        },
+        "query": "SELECT cluster_name FROM (SELECT DISTINCT c.cluster_name, CASE WHEN c.id = (SELECT cluster_id FROM query_results ORDER BY created_at DESC LIMIT 1) THEN 1 ELSE 3 END AS sort_order FROM clusters c WHERE c.cluster_name IS NOT NULL AND c.cluster_name <> '' AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') UNION ALL SELECT 'All', 2) ORDER BY sort_order, cluster_name;",
+        "includeAll": false,
+        "multi": false,
+        "current": {
+          "text": "",
+          "value": ""
+        },
+        "refresh": 1
+      },
+      {
+        "name": "kpi",
+        "type": "query",
+        "label": "KPI",
+        "datasource": {
+          "type": "frser-sqlite-datasource",
+          "uid": "kpi-datasource"
+        },
+        "query": "SELECT kpi_id FROM (SELECT DISTINCT kpi_id, 1 AS sort_order FROM query_results WHERE kpi_id IS NOT NULL AND kpi_id <> '' UNION ALL SELECT 'All', 2) ORDER BY sort_order, kpi_id;",
+        "includeAll": false,
+        "multi": false,
+        "current": {
+          "text": "",
+          "value": ""
+        },
+        "refresh": 1
+      },
+      {
+        "name": "node",
+        "type": "query",
+        "label": "Node",
+        "datasource": {
+          "type": "frser-sqlite-datasource",
+          "uid": "kpi-datasource"
+        },
+        "query": "SELECT node FROM (SELECT 'All' AS node, 1 AS sort_order UNION ALL SELECT DISTINCT json_extract(metric_labels, '$.node'), 2 FROM query_results WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND metric_labels IS NOT NULL AND json_extract(metric_labels, '$.node') IS NOT NULL AND json_extract(metric_labels, '$.node') <> '') ORDER BY sort_order, node;",
+        "includeAll": false,
+        "multi": false,
+        "current": {
+          "text": "All",
+          "value": "All"
+        },
+        "refresh": 1
+      },
+      {
+        "name": "job",
+        "type": "query",
+        "label": "Job",
+        "datasource": {
+          "type": "frser-sqlite-datasource",
+          "uid": "kpi-datasource"
+        },
+        "query": "SELECT job FROM (SELECT 'All' AS job, 1 AS sort_order UNION ALL SELECT DISTINCT json_extract(metric_labels, '$.job'), 2 FROM query_results WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND metric_labels IS NOT NULL AND json_extract(metric_labels, '$.job') IS NOT NULL AND json_extract(metric_labels, '$.job') <> '') ORDER BY sort_order, job;",
+        "includeAll": false,
+        "multi": false,
+        "current": {
+          "text": "All",
+          "value": "All"
+        },
+        "refresh": 1
+      },
+      {
+        "name": "pod",
+        "type": "query",
+        "label": "Pod",
+        "datasource": {
+          "type": "frser-sqlite-datasource",
+          "uid": "kpi-datasource"
+        },
+        "query": "SELECT pod FROM (SELECT 'All' AS pod, 1 AS sort_order UNION ALL SELECT DISTINCT json_extract(metric_labels, '$.pod'), 2 FROM query_results WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND metric_labels IS NOT NULL AND json_extract(metric_labels, '$.pod') IS NOT NULL AND json_extract(metric_labels, '$.pod') <> '') ORDER BY sort_order, pod;",
+        "includeAll": false,
+        "multi": false,
+        "current": {
+          "text": "All",
+          "value": "All"
+        },
+        "refresh": 1
+      },
+      {
+        "name": "container",
+        "type": "query",
+        "label": "Container",
+        "datasource": {
+          "type": "frser-sqlite-datasource",
+          "uid": "kpi-datasource"
+        },
+        "query": "SELECT container FROM (SELECT 'All' AS container, 1 AS sort_order UNION ALL SELECT DISTINCT json_extract(metric_labels, '$.container'), 2 FROM query_results WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND metric_labels IS NOT NULL AND json_extract(metric_labels, '$.container') IS NOT NULL AND json_extract(metric_labels, '$.container') <> '') ORDER BY sort_order, container;",
+        "includeAll": false,
+        "multi": false,
+        "current": {
+          "text": "All",
+          "value": "All"
+        },
+        "refresh": 1
+      }
+    ]
+  },
+  "time": {
+    "from": "now-7d",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "KPI Collection Tool - Dynamic Dashboard",
+  "uid": "kpi-collector-dynamic",
+  "version": 3,
+  "weekStart": ""
+}

--- a/internal/commands/grafana_start.go
+++ b/internal/commands/grafana_start.go
@@ -244,6 +244,7 @@ func runGrafanaContainer(grafanaDir string) error {
 		// Mount dashboard JSON
 		"-v", fmt.Sprintf("%s:/var/lib/grafana/dashboards:ro",
 			filepath.Join(absGrafanaDir, "dashboards")),
+		"-e", "GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH=/var/lib/grafana/dashboards/dashboard.json",
 	}
 
 	// For SQLite, mount the database file


### PR DESCRIPTION
Enhance the Grafana dashboard templates and startup configuration with several UX
improvements for easier data exploration.
### Changes
- **Prettify dashboard JSON templates**: Reformatted `sqlite-dashboard.json` and
  `postgres-dashboard.json` from single-line to human-readable indented JSON for
  easier review and maintenance.
- **Disable auto-refresh**: Removed the automatic 10-second refresh interval, which
  was unnecessary for a metrics archive viewer and caused disruptive re-rendering.
- **Add "Fit to data" button** (only in sqlite dashboard): Added a dashboard link that adjusts the time picker
  to span the full range of collected data (min/max timestamps). This is backed by
  two hidden template variables (`data_start`, `data_end`) that query the time
  boundaries from the database, filtered by the currently selected KPI, cluster, and
  cluster type. Also changed the default time range from `now-7d` to `now-24h`.
- **Replace KPI Statistics panel with inline text summary**: Removed the oversized
  stat panel that sat beside the main chart. Replaced it with a compact transparent
  HTML text panel below the time series chart showing a single line with sample count,
  average, maximum, and minimum values. These values are powered by four new hidden
  dashboard variables (`samples_count`, `avg_value`, `min_value`, `max_value`). The
  main time series chart now takes the full dashboard width.
- **Auto-open KPI dashboard on login**: Added `GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH`
  environment variable to the Grafana container startup, so the KPI dashboard loads
  directly as the home page instead of the default Grafana welcome screen.

### TODO
- Replicate the "Replace KPI Statistics panel with inline text summary" in the postgres dashboard.
  
<img width="1393" height="465" alt="image" src="https://github.com/user-attachments/assets/47171a36-6168-4867-ba4b-21e4feee26ff" />
