### PR TITLE
Fix SubstituteCPUPlaceholders dropping range query fields

### DIFF
--- a/internal/config/query_placeholders.go
+++ b/internal/config/query_placeholders.go
@@ -27,23 +27,19 @@ func SubstituteCPUPlaceholders(kpis KPIs, cpus *CPUPlaceholders) KPIs {
 		return kpis
 	}
 
-	substituted := KPIs{
+	resolvedKPIs := KPIs{
 		Queries: make([]Query, len(kpis.Queries)),
 	}
 
-	for i, kpi := range kpis.Queries {
-		query := kpi.PromQuery
-		query = strings.ReplaceAll(query, "{{RESERVED_CPUS}}", cpus.Reserved)
-		query = strings.ReplaceAll(query, "{{ISOLATED_CPUS}}", cpus.Isolated)
+	for i, originalQuery := range kpis.Queries {
+		resolvedPromQL := originalQuery.PromQuery
+		resolvedPromQL = strings.ReplaceAll(resolvedPromQL, "{{RESERVED_CPUS}}", cpus.Reserved)
+		resolvedPromQL = strings.ReplaceAll(resolvedPromQL, "{{ISOLATED_CPUS}}", cpus.Isolated)
 
-		substituted.Queries[i] = Query{
-			ID:              kpi.ID,
-			PromQuery:       query,
-			SampleFrequency: kpi.SampleFrequency,
-			RunOnce:         kpi.RunOnce,
-		}
+		resolvedKPIs.Queries[i] = originalQuery
+		resolvedKPIs.Queries[i].PromQuery = resolvedPromQL
 	}
 
-	return substituted
+	return resolvedKPIs
 }
 


### PR DESCRIPTION
`SubstituteCPUPlaceholders` rebuilt each `Query` struct manually, copying only `ID`, `PromQuery`, `SampleFrequency`, and `RunOnce` — silently dropping `QueryType`, `Step`, and `Range`.
Range queries with CPU placeholders were downgraded to instant queries with no warning.
Fixed by copying the full original query and only overwriting `PromQuery`.