### PR TITLE
Added integration test workflow with quick-ocp

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,0 +1,111 @@
+name: Integration Test (OCP)
+
+on:
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
+
+permissions: read-all
+
+jobs:
+  integration-test:
+    if: github.repository_owner == 'redhat-best-practices-for-k8s'
+    name: KPI Collection on OCP
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120
+    env:
+      KUBECONFIG: '/home/runner/.crc/machines/crc/kubeconfig'
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Check for CRC pull secret
+        env:
+          pull_secret: ${{ secrets.CRC_PULL_SECRET }}
+        if: ${{ env.pull_secret == '' }}
+        run: |
+          echo "CRC_PULL_SECRET is not set — skipping integration test"
+          exit 1
+
+      - name: Deploy OCP cluster
+        uses: palmsoftware/quick-ocp@v0.0.32
+        with:
+          ocpPullSecret: $OCP_PULL_SECRET
+          bundleCache: true
+          enableClusterMonitoring: 'true'
+        env:
+          OCP_PULL_SECRET: ${{ secrets.CRC_PULL_SECRET }}
+
+      - name: Wait for monitoring stack
+        timeout-minutes: 30
+        run: |
+          until oc get route thanos-querier -n openshift-monitoring &>/dev/null; do
+            echo "Waiting for thanos-querier route..."
+            sleep 30
+          done
+          echo "Monitoring stack is ready"
+
+      - name: Build kpi-collector
+        run: go build -o kpi-collector ./cmd/kpi-collector
+
+      - name: Collect KPIs (quickstart profile)
+        run: |
+          ./kpi-collector run \
+            --cluster-name integration-test \
+            --cluster-type ran \
+            --kubeconfig "$KUBECONFIG" \
+            --kpis-file kpi-profiles/kpis-quickstart.json \
+            --insecure-tls \
+            --once
+
+      - name: Verify cluster was stored
+        run: |
+          output=$(./kpi-collector db show clusters)
+          echo "$output"
+          echo "$output" | grep -q "integration-test"
+
+      - name: Verify KPIs were collected
+        run: |
+          output=$(./kpi-collector db show kpis -o json)
+          echo "$output"
+
+          count=$(echo "$output" | python3 -c "import sys,json; print(len(json.load(sys.stdin)))")
+          echo "Collected $count metric(s)"
+
+          if [ "$count" -lt 1 ]; then
+            echo "FAIL: expected at least 1 metric, got $count"
+            exit 1
+          fi
+
+      - name: Verify each quickstart KPI has data
+        run: |
+          for kpi in node-cpu-usage cluster-uptime; do
+            output=$(./kpi-collector db show kpis --name "$kpi" -o json)
+            count=$(echo "$output" | python3 -c "import sys,json; print(len(json.load(sys.stdin)))")
+            echo "$kpi: $count metric(s)"
+            if [ "$count" -lt 1 ]; then
+              echo "FAIL: KPI '$kpi' has no data in the database"
+              exit 1
+            fi
+          done
+
+      - name: Verify no unexpected errors
+        run: |
+          output=$(./kpi-collector db show errors)
+          echo "$output"
+          echo "$output" | grep -q "No errors found."
+
+      - name: Upload artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: kpi-collector-artifacts
+          path: kpi-collector-artifacts/


### PR DESCRIPTION
Add an integration test workflow that validates kpi-collector end-to-end against a real OpenShift cluster provisioned via [quick-ocp](https://github.com/palmsoftware/quick-ocp).

The workflow:
1. Provisions an OCP cluster using CRC
2. Enables cluster monitoring and waits for the Thanos endpoint
3. Builds kpi-collector
4. Runs `kpi-collector run --once` with the quickstart KPI profile
5. Asserts the cluster and KPI metrics are stored in the database
6. Asserts no query errors

Triggers on PRs, nightly cron, and manual dispatch.

Using `kpis-quickstart.json` for now since it works on any cluster — can switch to a more comprehensive profile later.
