### PR TITLE
removed pr trigger from ocp test

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,8 +1,6 @@
 name: Integration Test (OCP)
 
 on:
-  pull_request:
-    branches: [ main ]
   workflow_dispatch:
   schedule:
     - cron: '0 0 * * *'


### PR DESCRIPTION
Remove `pull_request` trigger from the OCP integration test workflow - it now runs only on nightly schedule and manual dispatch, matching the certsuite pattern. Fork PRs no longer see a failing CI job due to missing `CRC_PULL_SECRET`.
