### PR TITLE
Skip integration test workflow on fork PRs

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -11,7 +11,7 @@ permissions: read-all
 
 jobs:
   integration-test:
-    if: github.repository_owner == 'redhat-best-practices-for-k8s'
+    if: github.repository_owner == 'redhat-best-practices-for-k8s' && github.event.pull_request.head.repo.fork != true
     name: KPI Collection on OCP
     runs-on: ubuntu-24.04
     timeout-minutes: 120


### PR DESCRIPTION
## Summary
- Fork PRs don't have access to repository secrets (`CRC_PULL_SECRET`), causing the integration test to always fail
- The existing `repository_owner` guard doesn't help because for `pull_request` events, `github.repository_owner` refers to the base repo, not the fork
- Added a check for `github.event.pull_request.head.repo.fork` to skip the job when the PR originates from a fork
- `schedule` and `workflow_dispatch` triggers are unaffected since the field is `null` for those events

## Test plan
- [ ] Verify the integration test still runs on PRs from the same repo
- [ ] Verify the integration test is skipped on PRs from forks