### PR TITLE
fix: postgres SQL placeholders in db commands and propagate query failures

### DIFF
--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/signal"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/redhat-best-practices-for-k8s/kpi-collection-tool/internal/config"
@@ -25,20 +26,26 @@ const durationBuffer = 100 * time.Millisecond
 
 // RunOnce executes every KPI query exactly once and returns.
 // It ignores frequency and duration settings entirely.
-func RunOnce(kpis config.KPIs, flags config.InputFlags) {
+// Returns an error if any queries failed.
+func RunOnce(kpis config.KPIs, flags config.InputFlags) error {
 	fmt.Printf("\nKPI Collection Started - Single run mode\n")
 
 	log.Printf("Single run: executing %d KPIs", len(kpis.Queries))
 
-	if err := prometheus.RunQueries(kpis, flags, 1, 1, 0); err != nil {
+	err := prometheus.RunQueries(kpis, flags, 1, 1, 0)
+	if err != nil {
 		log.Printf("RunQueries failed in single-run mode: %v", err)
 	}
 
 	output.PrintShutdown("Single run completed")
+	return err
 }
 
 // Run executes the KPI collection loop until duration expires or interrupted.
-func Run(kpis config.KPIs, flags config.InputFlags) {
+// Returns an error if any query failures occurred during collection.
+func Run(kpis config.KPIs, flags config.InputFlags) error {
+	var hadFailures atomic.Bool
+
 	runOnceKPIs, repeatingKPIs := splitRunOnceQueries(kpis)
 
 	// Execute run-once queries immediately before starting the loop
@@ -48,12 +55,16 @@ func Run(kpis config.KPIs, flags config.InputFlags) {
 
 		if err := prometheus.RunQueries(runOnceKPIs, flags, 1, 1, 0); err != nil {
 			log.Printf("RunQueries failed for run-once KPIs: %v", err)
+			hadFailures.Store(true)
 		}
 	}
 
 	if len(repeatingKPIs.Queries) == 0 {
 		output.PrintShutdown("All queries are run-once, collection complete")
-		return
+		if hadFailures.Load() {
+			return fmt.Errorf("some queries failed during collection")
+		}
+		return nil
 	}
 
 	durationTimer := time.NewTimer(flags.Duration + durationBuffer)
@@ -65,7 +76,7 @@ func Run(kpis config.KPIs, flags config.InputFlags) {
 	output.PrintStartup(flags.Duration.String(), time.Now().Add(flags.Duration).Format(time.RFC3339))
 
 	// Start repeating KPI goroutines grouped by frequency
-	cancel, wg := startKPIGoroutines(repeatingKPIs, flags)
+	cancel, wg := startKPIGoroutines(repeatingKPIs, flags, &hadFailures)
 	defer cancel()
 
 	// Main goroutine only handles duration timer and interrupts
@@ -83,6 +94,11 @@ func Run(kpis config.KPIs, flags config.InputFlags) {
 	// Wait for all goroutines to finish, then print shutdown message
 	shutdown(cancel, wg)
 	output.PrintShutdown(shutdownReason)
+
+	if hadFailures.Load() {
+		return fmt.Errorf("some queries failed during collection")
+	}
+	return nil
 }
 
 // splitRunOnceQueries separates KPIs into run-once and repeating groups
@@ -122,7 +138,7 @@ func groupKPIsByFrequency(kpis config.KPIs, defaultFreq time.Duration) map[time.
 }
 
 // startKPIGoroutines starts one goroutine per unique frequency for all KPIs
-func startKPIGoroutines(kpis config.KPIs, flags config.InputFlags) (context.CancelFunc, *sync.WaitGroup) {
+func startKPIGoroutines(kpis config.KPIs, flags config.InputFlags, hadFailures *atomic.Bool) (context.CancelFunc, *sync.WaitGroup) {
 	ctx, cancel := context.WithCancel(context.Background())
 	var wg sync.WaitGroup
 
@@ -134,7 +150,7 @@ func startKPIGoroutines(kpis config.KPIs, flags config.InputFlags) (context.Canc
 		wg.Add(1)
 		go func(frequency time.Duration, kpiGroup config.KPIs) {
 			defer wg.Done()
-			runKPIGroupLoop(ctx, kpiGroup, frequency, flags)
+			runKPIGroupLoop(ctx, kpiGroup, frequency, flags, hadFailures)
 		}(freq, kpisForFreq)
 	}
 
@@ -147,7 +163,7 @@ func shutdown(cancel context.CancelFunc, wg *sync.WaitGroup) {
 }
 
 // runKPIGroupLoop runs a group of KPIs that share the same sampling frequency
-func runKPIGroupLoop(ctx context.Context, kpis config.KPIs, frequency time.Duration, flags config.InputFlags) {
+func runKPIGroupLoop(ctx context.Context, kpis config.KPIs, frequency time.Duration, flags config.InputFlags, hadFailures *atomic.Bool) {
 	ticker := time.NewTicker(frequency)
 	defer ticker.Stop()
 
@@ -156,13 +172,13 @@ func runKPIGroupLoop(ctx context.Context, kpis config.KPIs, frequency time.Durat
 	log.Printf("Starting goroutine for %d KPIs with frequency %s (total samples: %d)", len(kpis.Queries), frequency, totalSamples)
 	// Run immediately on start
 	sampleCount++
-	runKPIs(kpis, flags, sampleCount, totalSamples, frequency)
+	runKPIs(kpis, flags, sampleCount, totalSamples, frequency, hadFailures)
 
 	for {
 		select {
 		case <-ticker.C:
 			sampleCount++
-			runKPIs(kpis, flags, sampleCount, totalSamples, frequency)
+			runKPIs(kpis, flags, sampleCount, totalSamples, frequency, hadFailures)
 
 		case <-ctx.Done():
 			log.Printf("KPI group (frequency %s) stopped after %d samples", frequency, sampleCount)
@@ -172,7 +188,7 @@ func runKPIGroupLoop(ctx context.Context, kpis config.KPIs, frequency time.Durat
 }
 
 // runKPIs executes a group of KPIs and logs the results
-func runKPIs(kpis config.KPIs, flags config.InputFlags, sampleNumber int, totalSamples int, frequency time.Duration) {
+func runKPIs(kpis config.KPIs, flags config.InputFlags, sampleNumber int, totalSamples int, frequency time.Duration, hadFailures *atomic.Bool) {
 	if len(kpis.Queries) == 0 {
 		return
 	}
@@ -181,6 +197,7 @@ func runKPIs(kpis config.KPIs, flags config.InputFlags, sampleNumber int, totalS
 
 	if err := prometheus.RunQueries(kpis, flags, sampleNumber, totalSamples, frequency); err != nil {
 		log.Printf("RunQueries failed for frequency %s KPIs: %v", frequency, err)
+		hadFailures.Store(true)
 	}
 }
 

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"sync/atomic"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -197,14 +198,15 @@ var _ = Describe("Collector", func() {
 
 		Context("when there are KPIs with various frequencies", func() {
 			It("should return cancel function and WaitGroup", func() {
-				kpis := config.KPIs{
-					Queries: []config.Query{
-						{ID: "kpi-1", PromQuery: "query1", SampleFrequency: durationPtr(5 * time.Second)},
-						{ID: "kpi-2", PromQuery: "query2"}, // default frequency
-					},
-				}
+			kpis := config.KPIs{
+				Queries: []config.Query{
+					{ID: "kpi-1", PromQuery: "query1", SampleFrequency: durationPtr(5 * time.Second)},
+					{ID: "kpi-2", PromQuery: "query2"}, // default frequency
+				},
+			}
 
-				cancel, wg := startKPIGoroutines(kpis, flags)
+				var hadFailures atomic.Bool
+				cancel, wg := startKPIGoroutines(kpis, flags, &hadFailures)
 
 				Expect(cancel).NotTo(BeNil())
 				Expect(wg).NotTo(BeNil())
@@ -224,7 +226,8 @@ var _ = Describe("Collector", func() {
 					},
 				}
 
-				cancel, wg := startKPIGoroutines(kpis, flags)
+				var hadFailures atomic.Bool
+				cancel, wg := startKPIGoroutines(kpis, flags, &hadFailures)
 
 				Expect(cancel).NotTo(BeNil())
 				Expect(wg).NotTo(BeNil())
@@ -239,7 +242,8 @@ var _ = Describe("Collector", func() {
 			It("should return cancel function and empty WaitGroup", func() {
 				kpis := config.KPIs{Queries: []config.Query{}}
 
-				cancel, wg := startKPIGoroutines(kpis, flags)
+				var hadFailures atomic.Bool
+				cancel, wg := startKPIGoroutines(kpis, flags, &hadFailures)
 
 				Expect(cancel).NotTo(BeNil())
 				Expect(wg).NotTo(BeNil())

--- a/internal/commands/db_remove.go
+++ b/internal/commands/db_remove.go
@@ -4,6 +4,8 @@ import (
 	"database/sql"
 	"fmt"
 
+	"github.com/redhat-best-practices-for-k8s/kpi-collection-tool/internal/database"
+
 	"github.com/dustin/go-humanize"
 	"github.com/spf13/cobra"
 )
@@ -83,22 +85,23 @@ func init() {
 }
 
 func runRemoveClusters(cmd *cobra.Command, args []string) error {
-	db, _, err := connectToDB()
+	db, dbImpl, err := connectToDB()
 	if err != nil {
 		return fmt.Errorf("failed to connect to DB: %w", err)
 	}
 	defer func() { _ = db.Close() }()
 
-	// Delete metrics first
-	// Sending empty string because we delete cluster entry, not specific kpi
-	// So we delete all kpis from that cluster
-	cluster, metricsDeleted, err := deleteClusterMetrics(db, removeClusterName, "")
+	cluster, metricsDeleted, err := deleteClusterMetrics(db, dbImpl, removeClusterName, "")
 	if err != nil {
 		return err
 	}
 
-	// Delete cluster
-	_, err = db.Exec("DELETE FROM clusters WHERE id = ?", cluster.ID)
+	deleteQuery := "DELETE FROM clusters WHERE id = $1"
+	if _, ok := dbImpl.(*database.SQLiteDB); ok {
+		deleteQuery = convertPostgresToSQLitePlaceholders(deleteQuery)
+	}
+
+	_, err = db.Exec(deleteQuery, cluster.ID)
 	if err != nil {
 		return fmt.Errorf("failed to delete cluster: %w", err)
 	}
@@ -109,14 +112,13 @@ func runRemoveClusters(cmd *cobra.Command, args []string) error {
 }
 
 func runRemoveKPIs(cmd *cobra.Command, args []string) error {
-	db, _, err := connectToDB()
+	db, dbImpl, err := connectToDB()
 	if err != nil {
 		return fmt.Errorf("failed to connect to DB: %w", err)
 	}
 	defer func() { _ = db.Close() }()
 
-	// Delete metrics
-	_, deleted, err := deleteClusterMetrics(db, removeClusterName, removeKPIName)
+	_, deleted, err := deleteClusterMetrics(db, dbImpl, removeClusterName, removeKPIName)
 	if err != nil {
 		return err
 	}
@@ -131,7 +133,7 @@ func runRemoveKPIs(cmd *cobra.Command, args []string) error {
 }
 
 func runRemoveErrors(cmd *cobra.Command, args []string) error {
-	db, _, err := connectToDB()
+	db, dbImpl, err := connectToDB()
 	if err != nil {
 		return fmt.Errorf("failed to connect to DB: %w", err)
 	}
@@ -143,10 +145,14 @@ func runRemoveErrors(cmd *cobra.Command, args []string) error {
 	if removeAll {
 		query = "DELETE FROM query_errors"
 	} else if removeKPIName != "" {
-		query = "DELETE FROM query_errors WHERE kpi_id = ?"
+		query = "DELETE FROM query_errors WHERE kpi_id = $1"
 		queryArgs = append(queryArgs, removeKPIName)
 	} else {
 		return fmt.Errorf("must specify either --name or --all")
+	}
+
+	if _, ok := dbImpl.(*database.SQLiteDB); ok {
+		query = convertPostgresToSQLitePlaceholders(query)
 	}
 
 	result, err := db.Exec(query, queryArgs...)
@@ -164,8 +170,8 @@ func runRemoveErrors(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func deleteClusterMetrics(db *sql.DB, clusterName, kpiName string) (*ClusterInfo, int64, error) {
-	clusters, err := listClusters(db, clusterName)
+func deleteClusterMetrics(db *sql.DB, dbImpl database.Database, clusterName, kpiName string) (*ClusterInfo, int64, error) {
+	clusters, err := listClusters(db, dbImpl, clusterName)
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to query cluster: %w", err)
 	}
@@ -174,12 +180,16 @@ func deleteClusterMetrics(db *sql.DB, clusterName, kpiName string) (*ClusterInfo
 	}
 	cluster := clusters[0]
 
-	query := "DELETE FROM query_results WHERE cluster_id = ?"
+	query := "DELETE FROM query_results WHERE cluster_id = $1"
 	queryArgs := []interface{}{cluster.ID}
 
 	if kpiName != "" {
-		query += " AND kpi_id = ?"
+		query += " AND kpi_id = $2"
 		queryArgs = append(queryArgs, kpiName)
+	}
+
+	if _, ok := dbImpl.(*database.SQLiteDB); ok {
+		query = convertPostgresToSQLitePlaceholders(query)
 	}
 
 	result, err := db.Exec(query, queryArgs...)

--- a/internal/commands/db_show.go
+++ b/internal/commands/db_show.go
@@ -191,13 +191,13 @@ func runShowKPIs(cmd *cobra.Command, args []string) error {
 }
 
 func runShowClusters(cmd *cobra.Command, args []string) error {
-	db, _, err := connectToDB()
+	db, dbImpl, err := connectToDB()
 	if err != nil {
 		return fmt.Errorf("failed to connect to DB: %w", err)
 	}
 	defer func() { _ = db.Close() }()
 
-	clusters, err := listClusters(db, clusterQueryFlags.clusterName)
+	clusters, err := listClusters(db, dbImpl, clusterQueryFlags.clusterName)
 	if err != nil {
 		return fmt.Errorf("failed to list clusters: %w", err)
 	}
@@ -396,7 +396,7 @@ type ClusterInfo struct {
 	TotalMetrics int64
 }
 
-func listClusters(db *sql.DB, clusterName string) ([]ClusterInfo, error) {
+func listClusters(db *sql.DB, dbImpl database.Database, clusterName string) ([]ClusterInfo, error) {
 	query := `
 		SELECT c.id, c.cluster_name, c.created_at, COUNT(qr.id) as total_metrics
 		FROM clusters c
@@ -405,11 +405,15 @@ func listClusters(db *sql.DB, clusterName string) ([]ClusterInfo, error) {
 	args := []interface{}{}
 
 	if clusterName != "" {
-		query += " WHERE c.cluster_name = ?"
+		query += " WHERE c.cluster_name = $1"
 		args = append(args, clusterName)
 	}
 
 	query += " GROUP BY c.id, c.cluster_name, c.created_at ORDER BY c.created_at DESC"
+
+	if _, ok := dbImpl.(*database.SQLiteDB); ok {
+		query = convertPostgresToSQLitePlaceholders(query)
+	}
 
 	rows, err := db.Query(query, args...)
 	if err != nil {

--- a/internal/commands/run.go
+++ b/internal/commands/run.go
@@ -189,18 +189,22 @@ func runCollect(cmd *cobra.Command, args []string) error {
 	}
 
 	// Run collection
+	var collectionErr error
 	if flags.SingleRun {
-		collector.RunOnce(kpis, flags)
+		collectionErr = collector.RunOnce(kpis, flags)
 	} else {
-		collector.Run(kpis, flags)
+		collectionErr = collector.Run(kpis, flags)
 	}
 
 	absOutputDir, err := filepath.Abs(database.OutputDir)
 	if err != nil {
 		absOutputDir = database.OutputDir
 	}
-	fmt.Println("All queries completed successfully!")
+
 	fmt.Printf("Artifacts stored in: %s\n", absOutputDir)
+	if collectionErr != nil {
+		return fmt.Errorf("collection completed with errors: %w", collectionErr)
+	}
 
 	return nil
 }

--- a/internal/prometheus/client.go
+++ b/internal/prometheus/client.go
@@ -86,6 +86,7 @@ func RunQueries(kpisToRun config.KPIs, flags config.InputFlags, sampleNumber int
 	ctx, cancel := context.WithTimeout(context.Background(), totalTimeout)
 	defer cancel()
 
+	var failedCount int
 	for _, query := range kpisToRun.Queries {
 		queryInfo := output.QueryInfo{
 			QueryID:      query.ID,
@@ -109,14 +110,21 @@ func RunQueries(kpisToRun config.KPIs, flags config.InputFlags, sampleNumber int
 				queryInfo.Until = now
 			}
 		}
-		executeQuery(ctx, v1api, db, dbImpl, clusterID, queryInfo)
+		if !executeQuery(ctx, v1api, db, dbImpl, clusterID, queryInfo) {
+			failedCount++
+		}
+	}
+
+	if failedCount > 0 {
+		return fmt.Errorf("%d of %d queries failed", failedCount, len(kpisToRun.Queries))
 	}
 
 	return nil
 }
 
-// executeQuery executes a single Prometheus query and handles the result
-func executeQuery(ctx context.Context, v1api promv1.API, db *sql.DB, dbImpl database.Database, clusterID int64, info output.QueryInfo) {
+// executeQuery executes a single Prometheus query, handles the result,
+// and returns true if the query succeeded.
+func executeQuery(ctx context.Context, v1api promv1.API, db *sql.DB, dbImpl database.Database, clusterID int64, info output.QueryInfo) bool {
 	now := time.Now()
 
 	var (
@@ -148,7 +156,7 @@ func executeQuery(ctx context.Context, v1api promv1.API, db *sql.DB, dbImpl data
 		if storeErr := dbImpl.IncrementQueryError(db, info.QueryID); storeErr != nil {
 			fmt.Fprintf(os.Stderr, "Failed to increment error count: %v\n", storeErr)
 		}
-		return
+		return false
 	}
 
 	// Filter out NaN/Inf values
@@ -166,7 +174,7 @@ func executeQuery(ctx context.Context, v1api promv1.API, db *sql.DB, dbImpl data
 			fmt.Printf("  Warning: query returned no data (metric may not exist on this cluster)\n")
 			log.Printf("[%s] Query returned no data: %s", info.QueryID, info.PromQuery)
 		}
-		return
+		return true
 	}
 
 	// Store results
@@ -175,7 +183,7 @@ func executeQuery(ctx context.Context, v1api promv1.API, db *sql.DB, dbImpl data
 		queryResult.Success = false
 		queryResult.Error = fmt.Errorf("failed to store: %v", err)
 		output.PrintQueryResult(info, queryResult)
-		return
+		return false
 	}
 
 	queryResult.Success = true
@@ -184,6 +192,7 @@ func executeQuery(ctx context.Context, v1api promv1.API, db *sql.DB, dbImpl data
 		fmt.Printf("  Note: skipped %d NaN value(s)\n", nanCount)
 		log.Printf("[%s] Skipped %d NaN/Inf value(s): %s", info.QueryID, nanCount, info.PromQuery)
 	}
+	return true
 }
 
 // isEmptyResult checks whether a Prometheus query returned no data points.


### PR DESCRIPTION
**1. PostgreSQL placeholders in `db show clusters` / `db remove`**
`listClusters`, `deleteClusterMetrics`, `runRemoveClusters`, and `runRemoveErrors` used `?` placeholders which only work with SQLite. PostgreSQL requires `$1`, `$2`, etc. These commands now use Postgres-style placeholders with `convertPostgresToSQLitePlaceholders` applied for SQLite, matching the pattern already used in `queryKPIs`.

**2. `run` command now returns non-zero exit code on query failures**
Previously, `RunQueries` swallowed individual query errors and `run` always exited 0 with "All queries completed successfully!". Now `executeQuery` reports success/failure, `RunQueries` returns an error when queries fail, and the collector propagates this up so `run` exits with a proper error code.