### PR TITLE
fix: align PostgreSQL dashboard datasource UID and pin Grafana version

### DIFF
--- a/grafana-templates/postgres-dashboard.json
+++ b/grafana-templates/postgres-dashboard.json
@@ -5,7 +5,7 @@
         "builtIn": 1,
         "datasource": {
           "type": "grafana",
-          "uid": "kpi-postgres-datasource"
+          "uid": "kpi-datasource"
         },
         "enable": true,
         "hide": true,
@@ -37,7 +37,7 @@
     {
       "datasource": {
         "type": "postgres",
-        "uid": "kpi-postgres-datasource"
+        "uid": "kpi-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -238,7 +238,7 @@
         {
           "datasource": {
             "type": "postgres",
-            "uid": "kpi-postgres-datasource"
+            "uid": "kpi-datasource"
           },
           "format": "table",
           "rawSql": "SELECT to_timestamp(timestamp_value) AS time, metric_value, metric_labels FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE timestamp_value >= $__from / 1000 AND timestamp_value < $__to / 1000 AND kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) AND COALESCE(metric_labels->>'node', 'N/A') LIKE (CASE WHEN '${node}' = 'All' THEN '%%' ELSE '${node}' END) AND COALESCE(metric_labels->>'job', 'N/A') LIKE (CASE WHEN '${job}' = 'All' THEN '%%' ELSE '${job}' END) AND COALESCE(metric_labels->>'container', 'N/A') LIKE (CASE WHEN '${container}' = 'All' THEN '%%' ELSE '${container}' END) AND COALESCE(metric_labels->>'pod', 'N/A') LIKE (CASE WHEN '${pod}' = 'All' THEN '%%' ELSE '${pod}' END) ORDER BY time ASC",
@@ -251,7 +251,7 @@
         {
           "datasource": {
             "type": "postgres",
-            "uid": "kpi-postgres-datasource"
+            "uid": "kpi-datasource"
           },
           "format": "table",
           "rawSql": "SELECT 'Max Value' AS metric_labels, MAX(metric_value) AS metric_value, $__from/1000 AS time FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE timestamp_value >= $__from / 1000 AND timestamp_value < $__to / 1000 AND kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) AND COALESCE(metric_labels->>'node', 'N/A') LIKE (CASE WHEN '${node}' = 'All' THEN '%%' ELSE '${node}' END) AND COALESCE(metric_labels->>'job', 'N/A') LIKE (CASE WHEN '${job}' = 'All' THEN '%%' ELSE '${job}' END) AND COALESCE(metric_labels->>'container', 'N/A') LIKE (CASE WHEN '${container}' = 'All' THEN '%%' ELSE '${container}' END) AND COALESCE(metric_labels->>'pod', 'N/A') LIKE (CASE WHEN '${pod}' = 'All' THEN '%%' ELSE '${pod}' END)",
@@ -264,7 +264,7 @@
         {
           "datasource": {
             "type": "postgres",
-            "uid": "kpi-postgres-datasource"
+            "uid": "kpi-datasource"
           },
           "format": "table",
           "rawSql": "SELECT 'Min Value' AS metric_labels, MIN(metric_value) AS metric_value, $__from/1000 AS time FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE timestamp_value >= $__from / 1000 AND timestamp_value < $__to / 1000 AND kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) AND COALESCE(metric_labels->>'node', 'N/A') LIKE (CASE WHEN '${node}' = 'All' THEN '%%' ELSE '${node}' END) AND COALESCE(metric_labels->>'job', 'N/A') LIKE (CASE WHEN '${job}' = 'All' THEN '%%' ELSE '${job}' END) AND COALESCE(metric_labels->>'container', 'N/A') LIKE (CASE WHEN '${container}' = 'All' THEN '%%' ELSE '${container}' END) AND COALESCE(metric_labels->>'pod', 'N/A') LIKE (CASE WHEN '${pod}' = 'All' THEN '%%' ELSE '${pod}' END)",
@@ -277,7 +277,7 @@
         {
           "datasource": {
             "type": "postgres",
-            "uid": "kpi-postgres-datasource"
+            "uid": "kpi-datasource"
           },
           "format": "table",
           "rawSql": "SELECT 'Average Value' AS metric_labels, AVG(metric_value) AS metric_value, $__from/1000 AS time FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE timestamp_value >= $__from / 1000 AND timestamp_value < $__to / 1000 AND kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) AND COALESCE(metric_labels->>'node', 'N/A') LIKE (CASE WHEN '${node}' = 'All' THEN '%%' ELSE '${node}' END) AND COALESCE(metric_labels->>'job', 'N/A') LIKE (CASE WHEN '${job}' = 'All' THEN '%%' ELSE '${job}' END) AND COALESCE(metric_labels->>'container', 'N/A') LIKE (CASE WHEN '${container}' = 'All' THEN '%%' ELSE '${container}' END) AND COALESCE(metric_labels->>'pod', 'N/A') LIKE (CASE WHEN '${pod}' = 'All' THEN '%%' ELSE '${pod}' END)",
@@ -311,7 +311,7 @@
     {
       "datasource": {
         "type": "postgres",
-        "uid": "kpi-postgres-datasource"
+        "uid": "kpi-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -358,7 +358,7 @@
         {
           "datasource": {
             "type": "postgres",
-            "uid": "kpi-postgres-datasource"
+            "uid": "kpi-datasource"
           },
           "format": "table",
           "rawSql": "SELECT COUNT(*) as \"Samples\", ROUND(CAST(AVG(metric_value) AS numeric), 6) as \"Average\", ROUND(CAST(MIN(metric_value) AS numeric), 6) as \"Minimum\", ROUND(CAST(MAX(metric_value) AS numeric), 6) as \"Maximum\" FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE timestamp_value >= $__from / 1000 AND timestamp_value < $__to / 1000 AND kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) AND COALESCE(metric_labels->>'node', 'N/A') LIKE (CASE WHEN '${node}' = 'All' THEN '%%' ELSE '${node}' END) AND COALESCE(metric_labels->>'job', 'N/A') LIKE (CASE WHEN '${job}' = 'All' THEN '%%' ELSE '${job}' END) AND COALESCE(metric_labels->>'container', 'N/A') LIKE (CASE WHEN '${container}' = 'All' THEN '%%' ELSE '${container}' END) AND COALESCE(metric_labels->>'pod', 'N/A') LIKE (CASE WHEN '${pod}' = 'All' THEN '%%' ELSE '${pod}' END)",
@@ -371,7 +371,7 @@
     {
       "datasource": {
         "type": "postgres",
-        "uid": "kpi-postgres-datasource"
+        "uid": "kpi-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -429,7 +429,7 @@
         {
           "datasource": {
             "type": "postgres",
-            "uid": "kpi-postgres-datasource"
+            "uid": "kpi-datasource"
           },
           "format": "table",
           "rawSql": "SELECT metric_labels, ROUND(CAST(AVG(metric_value) AS numeric), 6) AS avg_value, ROUND(CAST(MIN(metric_value) AS numeric), 6) AS min_value, ROUND(CAST(MAX(metric_value) AS numeric), 6) AS max_value, COUNT(*) AS samples FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE timestamp_value >= $__from / 1000 AND timestamp_value < $__to / 1000 AND kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) AND COALESCE(metric_labels->>'node', 'N/A') LIKE (CASE WHEN '${node}' = 'All' THEN '%%' ELSE '${node}' END) AND COALESCE(metric_labels->>'job', 'N/A') LIKE (CASE WHEN '${job}' = 'All' THEN '%%' ELSE '${job}' END) AND COALESCE(metric_labels->>'container', 'N/A') LIKE (CASE WHEN '${container}' = 'All' THEN '%%' ELSE '${container}' END) AND COALESCE(metric_labels->>'pod', 'N/A') LIKE (CASE WHEN '${pod}' = 'All' THEN '%%' ELSE '${pod}' END) GROUP BY metric_labels ORDER BY avg_value DESC LIMIT 100",
@@ -452,7 +452,7 @@
     {
       "datasource": {
         "type": "postgres",
-        "uid": "kpi-postgres-datasource"
+        "uid": "kpi-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -530,7 +530,7 @@
         {
           "datasource": {
             "type": "postgres",
-            "uid": "kpi-postgres-datasource"
+            "uid": "kpi-datasource"
           },
           "format": "table",
           "rawSql": "SELECT kpi_id AS metric, errors AS value FROM query_errors WHERE errors > 0 ORDER BY errors DESC",
@@ -543,7 +543,7 @@
     {
       "datasource": {
         "type": "postgres",
-        "uid": "kpi-postgres-datasource"
+        "uid": "kpi-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -601,7 +601,7 @@
         {
           "datasource": {
             "type": "postgres",
-            "uid": "kpi-postgres-datasource"
+            "uid": "kpi-datasource"
           },
           "format": "table",
           "rawSql": "SELECT kpi_id, COUNT(*) AS sample_count, ROUND(CAST(AVG(metric_value) AS numeric), 6) AS avg_value, ROUND(CAST(MIN(metric_value) AS numeric), 6) AS min_value, ROUND(CAST(MAX(metric_value) AS numeric), 6) AS max_value, ROUND(CAST(MAX(metric_value) - MIN(metric_value) AS numeric), 6) AS range, COUNT(DISTINCT metric_labels) AS unique_metrics FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE timestamp_value >= $__from / 1000 AND timestamp_value < $__to / 1000 AND kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) AND COALESCE(metric_labels->>'node', 'N/A') LIKE (CASE WHEN '${node}' = 'All' THEN '%%' ELSE '${node}' END) AND COALESCE(metric_labels->>'job', 'N/A') LIKE (CASE WHEN '${job}' = 'All' THEN '%%' ELSE '${job}' END) AND COALESCE(metric_labels->>'container', 'N/A') LIKE (CASE WHEN '${container}' = 'All' THEN '%%' ELSE '${container}' END) AND COALESCE(metric_labels->>'pod', 'N/A') LIKE (CASE WHEN '${pod}' = 'All' THEN '%%' ELSE '${pod}' END) GROUP BY kpi_id ORDER BY kpi_id",
@@ -614,7 +614,7 @@
     {
       "datasource": {
         "type": "postgres",
-        "uid": "kpi-postgres-datasource"
+        "uid": "kpi-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -666,7 +666,7 @@
         {
           "datasource": {
             "type": "postgres",
-            "uid": "kpi-postgres-datasource"
+            "uid": "kpi-datasource"
           },
           "format": "table",
           "rawSql": "SELECT c.cluster_name, COALESCE(c.cluster_type, 'N/A') AS cluster_type, COUNT(DISTINCT qr.kpi_id) AS kpi_count, COUNT(qr.metric_value) AS total_samples, MAX(qr.created_at) AS last_collection FROM clusters c LEFT JOIN query_results qr ON c.id = qr.cluster_id AND qr.timestamp_value >= $__from / 1000 AND qr.timestamp_value < $__to / 1000 WHERE COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) GROUP BY c.cluster_name, COALESCE(c.cluster_type, 'N/A') ORDER BY c.cluster_name",
@@ -694,7 +694,7 @@
         },
         "datasource": {
           "type": "postgres",
-          "uid": "kpi-postgres-datasource"
+          "uid": "kpi-datasource"
         },
         "definition": "SELECT cluster_type FROM (SELECT 'All' AS cluster_type, 1 AS order_col UNION ALL SELECT DISTINCT COALESCE(cluster_type, 'N/A'), 2 AS order_col FROM clusters) AS temp_data ORDER BY order_col, cluster_type;",
         "hide": 0,
@@ -714,7 +714,7 @@
         },
         "datasource": {
           "type": "postgres",
-          "uid": "kpi-postgres-datasource"
+          "uid": "kpi-datasource"
         },
         "definition": "SELECT cluster_name FROM (SELECT c.cluster_name, CASE WHEN c.id = (SELECT cluster_id FROM query_results ORDER BY created_at DESC LIMIT 1) THEN 1 ELSE 3 END AS sort_order FROM clusters c WHERE COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) UNION ALL SELECT 'All', 2) AS t ORDER BY sort_order, cluster_name;",
         "hide": 0,
@@ -734,7 +734,7 @@
         },
         "datasource": {
           "type": "postgres",
-          "uid": "kpi-postgres-datasource"
+          "uid": "kpi-datasource"
         },
         "definition": "SELECT kpi_id FROM (SELECT DISTINCT kpi_id, 1 AS sort_order FROM query_results WHERE kpi_id IS NOT NULL AND kpi_id != '' UNION ALL SELECT 'All', 2) AS t ORDER BY sort_order, kpi_id;",
         "hide": 0,
@@ -754,7 +754,7 @@
         },
         "datasource": {
           "type": "postgres",
-          "uid": "kpi-postgres-datasource"
+          "uid": "kpi-datasource"
         },
         "definition": "SELECT node FROM (SELECT 'All' AS node, 1 AS order_col UNION ALL SELECT DISTINCT COALESCE(metric_labels->>'node', 'N/A'), 2 AS order_col FROM query_results WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND metric_labels->>'node' IS NOT NULL) AS temp_data ORDER BY order_col, node;",
         "hide": 0,
@@ -774,7 +774,7 @@
         },
         "datasource": {
           "type": "postgres",
-          "uid": "kpi-postgres-datasource"
+          "uid": "kpi-datasource"
         },
         "definition": "SELECT job FROM (SELECT 'All' AS job, 1 AS order_col UNION ALL SELECT DISTINCT COALESCE(metric_labels->>'job', 'N/A'), 2 AS order_col FROM query_results WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND metric_labels->>'job' IS NOT NULL) AS temp_data ORDER BY order_col, job;",
         "hide": 0,
@@ -794,7 +794,7 @@
         },
         "datasource": {
           "type": "postgres",
-          "uid": "kpi-postgres-datasource"
+          "uid": "kpi-datasource"
         },
         "definition": "SELECT container FROM (SELECT 'All' AS container, 1 AS order_col UNION ALL SELECT DISTINCT COALESCE(metric_labels->>'container', 'N/A'), 2 AS order_col FROM query_results WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND metric_labels->>'container' IS NOT NULL) AS temp_data ORDER BY order_col, container;",
         "hide": 0,
@@ -814,7 +814,7 @@
         },
         "datasource": {
           "type": "postgres",
-          "uid": "kpi-postgres-datasource"
+          "uid": "kpi-datasource"
         },
         "definition": "SELECT pod FROM (SELECT 'All' AS pod, 1 AS order_col UNION ALL SELECT DISTINCT COALESCE(metric_labels->>'pod', 'N/A'), 2 AS order_col FROM query_results WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND metric_labels->>'pod' IS NOT NULL) AS temp_data ORDER BY order_col, pod;",
         "hide": 0,
@@ -832,7 +832,7 @@
         "type": "query",
         "datasource": {
           "type": "postgres",
-          "uid": "kpi-postgres-datasource"
+          "uid": "kpi-datasource"
         },
         "query": "SELECT COALESCE(CAST(MIN(timestamp_value) * 1000 AS BIGINT), 0) FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END)",
         "definition": "SELECT COALESCE(CAST(MIN(timestamp_value) * 1000 AS BIGINT), 0) FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END)",
@@ -851,7 +851,7 @@
         "type": "query",
         "datasource": {
           "type": "postgres",
-          "uid": "kpi-postgres-datasource"
+          "uid": "kpi-datasource"
         },
         "query": "SELECT COALESCE(CAST(MAX(timestamp_value) * 1000 AS BIGINT), 0) FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END)",
         "definition": "SELECT COALESCE(CAST(MAX(timestamp_value) * 1000 AS BIGINT), 0) FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END)",

--- a/internal/commands/grafana_start.go
+++ b/internal/commands/grafana_start.go
@@ -278,7 +278,7 @@ func runGrafanaContainer(grafanaDir string) error {
 	}
 
 	// Add the image name
-	args = append(args, "grafana/grafana:latest")
+	args = append(args, "grafana/grafana:11.4.0")
 
 	containerRuntimeCmd := exec.Command(runtime, args...)
 	output, err := containerRuntimeCmd.CombinedOutput()


### PR DESCRIPTION
- Fixed Grafana PostgreSQL dashboard failing to load with "Datasource kpi-postgres-datasource was not found" by aligning the dashboard template's datasource UID with the one actually provisioned by `grafana start`
- Pinned Grafana container image to `11.4.0` instead of `latest` to avoid breaking changes in newer versions and prevent supply-chain security risks from uncontrolled image updates

### Changes
- `grafana-templates/postgres-dashboard.json`: Replaced all 25 occurrences of `"uid": "kpi-postgres-datasource"` with `"uid": "kpi-datasource"` (consistent with the SQLite dashboard and the provisioned datasource)
- `internal/commands/grafana_start.go`: Changed container image from `grafana/grafana:latest` to `grafana/grafana:11.4.0`
