### PR TITLE
db show kpis: filter by prom sample timestamp and allow rfc3339 ts.

### DIFF
--- a/internal/commands/commands_suite_test.go
+++ b/internal/commands/commands_suite_test.go
@@ -1,0 +1,13 @@
+package commands
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCommands(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Commands Suite")
+}

--- a/internal/commands/db_show.go
+++ b/internal/commands/db_show.go
@@ -55,6 +55,9 @@ The results can be displayed in table, JSON, or CSV format.`,
   
   # Time-based filtering
   kpi-collector db show kpis --name="cpu-system" --since="2h" --until="1h"
+
+  # Time-based filtering with RFC3339 timestamps
+  kpi-collector db show kpis --name="cpu-system" --since="2026-04-07T12:24:25Z" --until="2026-04-08T22:34:25Z"
   
   # Limit results and sort
   kpi-collector db show kpis --name="cpu-pods" --limit=100 --sort="desc"
@@ -104,13 +107,13 @@ func init() {
 	showKPIsCmd.Flags().StringVar(&kpiQueryFlags.labelsFilter, "labels-filter", "",
 		"label filters in format 'key=value,key2=value2'")
 	showKPIsCmd.Flags().StringVar(&kpiQueryFlags.since, "since", "",
-		"show metrics since (duration format: '2h', '30m', '24h')")
+		"show metrics since sample timestamp (Go duration or RFC3339, e.g. '2h' or '2026-04-07T12:24:25Z')")
 	showKPIsCmd.Flags().StringVar(&kpiQueryFlags.until, "until", "",
-		"show metrics until (duration format: '1h', '15m', '12h')")
+		"show metrics until sample timestamp (Go duration or RFC3339, e.g. '1h' or '2026-04-08T22:34:25Z')")
 	showKPIsCmd.Flags().IntVar(&kpiQueryFlags.limit, "limit", 0,
 		"limit number of results (0 = no limit)")
 	showKPIsCmd.Flags().StringVar(&kpiQueryFlags.sort, "sort", "asc",
-		"sort order by execution time: asc or desc")
+		"sort order by metric timestamp: asc or desc")
 	showKPIsCmd.Flags().BoolVar(&kpiQueryFlags.noTruncate, "no-truncate", false,
 		"show full labels without truncation")
 	showKPIsCmd.Flags().StringVarP(&kpiQueryFlags.outputFormat, "output", "o", "table",
@@ -134,21 +137,10 @@ func runShowKPIs(cmd *cobra.Command, args []string) error {
 	}
 	defer func() { _ = db.Close() }()
 
-	// Parse time filters
-	var sinceTime, untilTime *time.Time
-	if kpiQueryFlags.since != "" {
-		t, err := parseTimeFilter(kpiQueryFlags.since)
-		if err != nil {
-			return fmt.Errorf("invalid --since value: %w", err)
-		}
-		sinceTime = &t
-	}
-	if kpiQueryFlags.until != "" {
-		t, err := parseTimeFilter(kpiQueryFlags.until)
-		if err != nil {
-			return fmt.Errorf("invalid --until value: %w", err)
-		}
-		untilTime = &t
+	// Parse time filters using a single reference time to avoid drift.
+	sinceTime, untilTime, err := parseKPIQueryTimeWindow(kpiQueryFlags.since, kpiQueryFlags.until, time.Now())
+	if err != nil {
+		return err
 	}
 
 	// Parse label filters
@@ -252,13 +244,48 @@ func runShowErrors(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func parseTimeFilter(timeStr string) (time.Time, error) {
-	// Parse as duration only (e.g., "2h" = 2 hours ago)
-	duration, err := time.ParseDuration(timeStr)
-	if err != nil {
-		return time.Time{}, fmt.Errorf("invalid duration format: %s (use format like '2h', '30m', '24h')", timeStr)
+func parseKPIQueryTimeWindow(sinceInput, untilInput string, now time.Time) (*time.Time, *time.Time, error) {
+	var sinceTime, untilTime *time.Time
+
+	if strings.TrimSpace(sinceInput) != "" {
+		t, err := parseTimeFilter(sinceInput, now)
+		if err != nil {
+			return nil, nil, fmt.Errorf("invalid --since value: %w", err)
+		}
+		sinceTime = &t
 	}
-	return time.Now().Add(-duration), nil
+
+	if strings.TrimSpace(untilInput) != "" {
+		t, err := parseTimeFilter(untilInput, now)
+		if err != nil {
+			return nil, nil, fmt.Errorf("invalid --until value: %w", err)
+		}
+		untilTime = &t
+	}
+
+	if sinceTime != nil && untilTime != nil && !sinceTime.Before(*untilTime) {
+		return nil, nil, fmt.Errorf("invalid time window: --since must resolve before --until (since: %s, until: %s)",
+			sinceTime.Format(time.RFC3339), untilTime.Format(time.RFC3339))
+	}
+
+	return sinceTime, untilTime, nil
+}
+
+func parseTimeFilter(timeStr string, now time.Time) (time.Time, error) {
+	trimmed := strings.TrimSpace(timeStr)
+
+	if duration, err := time.ParseDuration(trimmed); err == nil {
+		if duration <= 0 {
+			return time.Time{}, fmt.Errorf("must be > 0 when specified as a duration")
+		}
+		return now.Add(-duration), nil
+	}
+
+	if absolute, err := time.Parse(time.RFC3339, trimmed); err == nil {
+		return absolute, nil
+	}
+
+	return time.Time{}, fmt.Errorf("must be a Go duration (e.g. \"2h\") or RFC3339 format (e.g. \"2026-04-07T12:24:25Z\")")
 }
 
 func parseLabelFilters(filterStr string) (map[string]string, error) {
@@ -319,21 +346,24 @@ func queryKPIs(db *sql.DB, dbImpl database.Database, params KPIQueryParams) ([]K
 	}
 
 	if params.Since != nil {
-		query += fmt.Sprintf(" AND qr.execution_time >= $%d", argIndex)
-		args = append(args, *params.Since)
+		query += fmt.Sprintf(" AND qr.timestamp_value >= $%d", argIndex)
+		// CLI time filters intentionally use second precision (0 milliseconds).
+		// We truncate to whole seconds, then convert to Unix epoch seconds for
+		// comparison against query_results.timestamp_value.
+		args = append(args, float64(params.Since.Truncate(time.Second).Unix()))
 		argIndex++
 	}
 
 	if params.Until != nil {
-		query += fmt.Sprintf(" AND qr.execution_time <= $%d", argIndex)
-		args = append(args, *params.Until)
+		query += fmt.Sprintf(" AND qr.timestamp_value <= $%d", argIndex)
+		args = append(args, float64(params.Until.Truncate(time.Second).Unix()))
 		argIndex++
 	}
 
 	if params.Sort == "desc" {
-		query += " ORDER BY qr.execution_time DESC"
+		query += " ORDER BY qr.timestamp_value DESC"
 	} else {
-		query += " ORDER BY qr.execution_time ASC"
+		query += " ORDER BY qr.timestamp_value ASC"
 	}
 
 	if params.Limit > 0 {

--- a/internal/commands/db_show_test.go
+++ b/internal/commands/db_show_test.go
@@ -2,86 +2,19 @@ package commands
 
 import (
 	"database/sql"
-	"strings"
-	"testing"
 	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	"github.com/redhat-best-practices-for-k8s/kpi-collection-tool/internal/database"
 	_ "modernc.org/sqlite"
 )
 
-func TestQueryKPIsSinceFiltersByMetricTimestamp(t *testing.T) {
-	db := newInMemoryKPIDB(t)
-	defer func() { _ = db.Close() }()
-
-	now := time.Now()
-	since := now.Add(-1 * time.Hour)
-
-	mustExec(t, db, "INSERT INTO clusters (id, cluster_name) VALUES (?, ?)", 1, "cluster-a")
-	mustExec(t, db,
-		"INSERT INTO query_results (kpi_id, metric_value, timestamp_value, cluster_id, execution_time, metric_labels) VALUES (?, ?, ?, ?, ?, ?)",
-		"kpi-since-hit", 10.0, float64(now.Add(-30*time.Minute).UnixNano())/1e9, 1, "2000-01-01 00:00:00", `{"instance":"a"}`,
-	)
-	mustExec(t, db,
-		"INSERT INTO query_results (kpi_id, metric_value, timestamp_value, cluster_id, execution_time, metric_labels) VALUES (?, ?, ?, ?, ?, ?)",
-		"kpi-since-miss", 20.0, float64(now.Add(-2*time.Hour).UnixNano())/1e9, 1, "2099-01-01 00:00:00", `{"instance":"b"}`,
-	)
-
-	results, err := queryKPIs(db, &database.SQLiteDB{}, KPIQueryParams{
-		Since: &since,
-		Sort:  "asc",
-	})
-	if err != nil {
-		t.Fatalf("queryKPIs returned error: %v", err)
-	}
-
-	if len(results) != 1 {
-		t.Fatalf("expected 1 result, got %d", len(results))
-	}
-	if results[0].KPIName != "kpi-since-hit" {
-		t.Fatalf("expected kpi-since-hit, got %s", results[0].KPIName)
-	}
-}
-
-func TestQueryKPIsUntilFiltersByMetricTimestamp(t *testing.T) {
-	db := newInMemoryKPIDB(t)
-	defer func() { _ = db.Close() }()
-
-	now := time.Now()
-	until := now.Add(-1 * time.Hour)
-
-	mustExec(t, db, "INSERT INTO clusters (id, cluster_name) VALUES (?, ?)", 1, "cluster-a")
-	mustExec(t, db,
-		"INSERT INTO query_results (kpi_id, metric_value, timestamp_value, cluster_id, execution_time, metric_labels) VALUES (?, ?, ?, ?, ?, ?)",
-		"kpi-until-hit", 10.0, float64(now.Add(-2*time.Hour).UnixNano())/1e9, 1, "2099-01-01 00:00:00", `{"instance":"a"}`,
-	)
-	mustExec(t, db,
-		"INSERT INTO query_results (kpi_id, metric_value, timestamp_value, cluster_id, execution_time, metric_labels) VALUES (?, ?, ?, ?, ?, ?)",
-		"kpi-until-miss", 20.0, float64(now.Add(-30*time.Minute).UnixNano())/1e9, 1, "2000-01-01 00:00:00", `{"instance":"b"}`,
-	)
-
-	results, err := queryKPIs(db, &database.SQLiteDB{}, KPIQueryParams{
-		Until: &until,
-		Sort:  "asc",
-	})
-	if err != nil {
-		t.Fatalf("queryKPIs returned error: %v", err)
-	}
-
-	if len(results) != 1 {
-		t.Fatalf("expected 1 result, got %d", len(results))
-	}
-	if results[0].KPIName != "kpi-until-hit" {
-		t.Fatalf("expected kpi-until-hit, got %s", results[0].KPIName)
-	}
-}
-
-func newInMemoryKPIDB(t *testing.T) *sql.DB {
-	t.Helper()
-
+func newInMemoryKPIDB() (*sql.DB, error) {
 	db, err := sql.Open("sqlite", ":memory:")
 	if err != nil {
-		t.Fatalf("failed to open sqlite db: %v", err)
+		return nil, err
 	}
 
 	schema := `
@@ -101,71 +34,129 @@ func newInMemoryKPIDB(t *testing.T) *sql.DB {
 	`
 	if _, err := db.Exec(schema); err != nil {
 		_ = db.Close()
-		t.Fatalf("failed to initialize schema: %v", err)
+
+		return nil, err
 	}
 
-	return db
+	return db, nil
 }
 
-func mustExec(t *testing.T, db *sql.DB, query string, args ...interface{}) {
-	t.Helper()
-	if _, err := db.Exec(query, args...); err != nil {
-		t.Fatalf("exec failed for query %q: %v", query, err)
-	}
-}
+var _ = Describe("queryKPIs", func() {
+	var db *sql.DB
 
-func TestParseTimeFilterAcceptsDuration(t *testing.T) {
-	now := time.Date(2026, 4, 8, 12, 0, 0, 0, time.UTC)
+	BeforeEach(func() {
+		var err error
+		db, err = newInMemoryKPIDB()
+		Expect(err).NotTo(HaveOccurred())
+	})
 
-	got, err := parseTimeFilter("2h", now)
-	if err != nil {
-		t.Fatalf("parseTimeFilter returned error: %v", err)
-	}
+	AfterEach(func() {
+		if db != nil {
+			_ = db.Close()
+		}
+	})
 
-	want := now.Add(-2 * time.Hour)
-	if !got.Equal(want) {
-		t.Fatalf("expected %s, got %s", want.Format(time.RFC3339), got.Format(time.RFC3339))
-	}
-}
+	Context("when filtering by --since", func() {
+		It("should return only rows whose metric timestamp is after the since threshold", func() {
+			now := time.Now()
+			since := now.Add(-1 * time.Hour)
 
-func TestParseTimeFilterAcceptsRFC3339(t *testing.T) {
-	now := time.Date(2026, 4, 8, 12, 0, 0, 0, time.UTC)
-	input := "2026-04-07T12:24:25Z"
+			_, err := db.Exec("INSERT INTO clusters (id, cluster_name) VALUES (?, ?)", 1, "cluster-a")
+			Expect(err).NotTo(HaveOccurred())
 
-	got, err := parseTimeFilter(input, now)
-	if err != nil {
-		t.Fatalf("parseTimeFilter returned error: %v", err)
-	}
+			_, err = db.Exec(
+				"INSERT INTO query_results (kpi_id, metric_value, timestamp_value, cluster_id, execution_time, metric_labels) VALUES (?, ?, ?, ?, ?, ?)",
+				"kpi-since-hit", 10.0, float64(now.Add(-30*time.Minute).UnixNano())/1e9, 1, "2000-01-01 00:00:00", `{"instance":"a"}`,
+			)
+			Expect(err).NotTo(HaveOccurred())
 
-	want, err := time.Parse(time.RFC3339, input)
-	if err != nil {
-		t.Fatalf("failed to parse expected RFC3339 value: %v", err)
-	}
-	if !got.Equal(want) {
-		t.Fatalf("expected %s, got %s", want.Format(time.RFC3339), got.Format(time.RFC3339))
-	}
-}
+			_, err = db.Exec(
+				"INSERT INTO query_results (kpi_id, metric_value, timestamp_value, cluster_id, execution_time, metric_labels) VALUES (?, ?, ?, ?, ?, ?)",
+				"kpi-since-miss", 20.0, float64(now.Add(-2*time.Hour).UnixNano())/1e9, 1, "2099-01-01 00:00:00", `{"instance":"b"}`,
+			)
+			Expect(err).NotTo(HaveOccurred())
 
-func TestParseTimeFilterRejectsNonPositiveDuration(t *testing.T) {
-	now := time.Date(2026, 4, 8, 12, 0, 0, 0, time.UTC)
+			results, err := queryKPIs(db, &database.SQLiteDB{}, KPIQueryParams{
+				Since: &since,
+				Sort:  "asc",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(results).To(HaveLen(1))
+			Expect(results[0].KPIName).To(Equal("kpi-since-hit"))
+		})
+	})
 
-	_, err := parseTimeFilter("0s", now)
-	if err == nil {
-		t.Fatalf("expected error for non-positive duration")
-	}
-	if !strings.Contains(err.Error(), "must be > 0") {
-		t.Fatalf("expected positive-duration validation error, got: %v", err)
-	}
-}
+	Context("when filtering by --until", func() {
+		It("should return only rows whose metric timestamp is before the until threshold", func() {
+			now := time.Now()
+			until := now.Add(-1 * time.Hour)
 
-func TestParseKPIQueryTimeWindowRejectsInvalidOrder(t *testing.T) {
-	now := time.Date(2026, 4, 8, 12, 0, 0, 0, time.UTC)
+			_, err := db.Exec("INSERT INTO clusters (id, cluster_name) VALUES (?, ?)", 1, "cluster-a")
+			Expect(err).NotTo(HaveOccurred())
 
-	_, _, err := parseKPIQueryTimeWindow("1h", "2h", now)
-	if err == nil {
-		t.Fatalf("expected error when --since resolves after --until")
-	}
-	if !strings.Contains(err.Error(), "must resolve before --until") {
-		t.Fatalf("expected since-before-until validation error, got: %v", err)
-	}
-}
+			_, err = db.Exec(
+				"INSERT INTO query_results (kpi_id, metric_value, timestamp_value, cluster_id, execution_time, metric_labels) VALUES (?, ?, ?, ?, ?, ?)",
+				"kpi-until-hit", 10.0, float64(now.Add(-2*time.Hour).UnixNano())/1e9, 1, "2099-01-01 00:00:00", `{"instance":"a"}`,
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = db.Exec(
+				"INSERT INTO query_results (kpi_id, metric_value, timestamp_value, cluster_id, execution_time, metric_labels) VALUES (?, ?, ?, ?, ?, ?)",
+				"kpi-until-miss", 20.0, float64(now.Add(-30*time.Minute).UnixNano())/1e9, 1, "2000-01-01 00:00:00", `{"instance":"b"}`,
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			results, err := queryKPIs(db, &database.SQLiteDB{}, KPIQueryParams{
+				Until: &until,
+				Sort:  "asc",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(results).To(HaveLen(1))
+			Expect(results[0].KPIName).To(Equal("kpi-until-hit"))
+		})
+	})
+})
+
+var _ = Describe("parseTimeFilter", func() {
+	var now time.Time
+
+	BeforeEach(func() {
+		now = time.Date(2026, 4, 8, 12, 0, 0, 0, time.UTC)
+	})
+
+	It("should accept a Go duration string and return now minus that duration", func() {
+		got, err := parseTimeFilter("2h", now)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(got).To(BeTemporally("~", now.Add(-2*time.Hour)))
+	})
+
+	It("should accept an RFC 3339 timestamp", func() {
+		input := "2026-04-07T12:24:25Z"
+		got, err := parseTimeFilter(input, now)
+		Expect(err).NotTo(HaveOccurred())
+
+		want, err := time.Parse(time.RFC3339, input)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(got).To(BeTemporally("~", want))
+	})
+
+	It("should reject a non-positive duration", func() {
+		_, err := parseTimeFilter("0s", now)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("must be > 0"))
+	})
+})
+
+var _ = Describe("parseKPIQueryTimeWindow", func() {
+	var now time.Time
+
+	BeforeEach(func() {
+		now = time.Date(2026, 4, 8, 12, 0, 0, 0, time.UTC)
+	})
+
+	It("should reject when --since resolves after --until", func() {
+		_, _, err := parseKPIQueryTimeWindow("1h", "2h", now)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("must resolve before --until"))
+	})
+})

--- a/internal/commands/db_show_test.go
+++ b/internal/commands/db_show_test.go
@@ -1,0 +1,171 @@
+package commands
+
+import (
+	"database/sql"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/redhat-best-practices-for-k8s/kpi-collection-tool/internal/database"
+	_ "modernc.org/sqlite"
+)
+
+func TestQueryKPIsSinceFiltersByMetricTimestamp(t *testing.T) {
+	db := newInMemoryKPIDB(t)
+	defer func() { _ = db.Close() }()
+
+	now := time.Now()
+	since := now.Add(-1 * time.Hour)
+
+	mustExec(t, db, "INSERT INTO clusters (id, cluster_name) VALUES (?, ?)", 1, "cluster-a")
+	mustExec(t, db,
+		"INSERT INTO query_results (kpi_id, metric_value, timestamp_value, cluster_id, execution_time, metric_labels) VALUES (?, ?, ?, ?, ?, ?)",
+		"kpi-since-hit", 10.0, float64(now.Add(-30*time.Minute).UnixNano())/1e9, 1, "2000-01-01 00:00:00", `{"instance":"a"}`,
+	)
+	mustExec(t, db,
+		"INSERT INTO query_results (kpi_id, metric_value, timestamp_value, cluster_id, execution_time, metric_labels) VALUES (?, ?, ?, ?, ?, ?)",
+		"kpi-since-miss", 20.0, float64(now.Add(-2*time.Hour).UnixNano())/1e9, 1, "2099-01-01 00:00:00", `{"instance":"b"}`,
+	)
+
+	results, err := queryKPIs(db, &database.SQLiteDB{}, KPIQueryParams{
+		Since: &since,
+		Sort:  "asc",
+	})
+	if err != nil {
+		t.Fatalf("queryKPIs returned error: %v", err)
+	}
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].KPIName != "kpi-since-hit" {
+		t.Fatalf("expected kpi-since-hit, got %s", results[0].KPIName)
+	}
+}
+
+func TestQueryKPIsUntilFiltersByMetricTimestamp(t *testing.T) {
+	db := newInMemoryKPIDB(t)
+	defer func() { _ = db.Close() }()
+
+	now := time.Now()
+	until := now.Add(-1 * time.Hour)
+
+	mustExec(t, db, "INSERT INTO clusters (id, cluster_name) VALUES (?, ?)", 1, "cluster-a")
+	mustExec(t, db,
+		"INSERT INTO query_results (kpi_id, metric_value, timestamp_value, cluster_id, execution_time, metric_labels) VALUES (?, ?, ?, ?, ?, ?)",
+		"kpi-until-hit", 10.0, float64(now.Add(-2*time.Hour).UnixNano())/1e9, 1, "2099-01-01 00:00:00", `{"instance":"a"}`,
+	)
+	mustExec(t, db,
+		"INSERT INTO query_results (kpi_id, metric_value, timestamp_value, cluster_id, execution_time, metric_labels) VALUES (?, ?, ?, ?, ?, ?)",
+		"kpi-until-miss", 20.0, float64(now.Add(-30*time.Minute).UnixNano())/1e9, 1, "2000-01-01 00:00:00", `{"instance":"b"}`,
+	)
+
+	results, err := queryKPIs(db, &database.SQLiteDB{}, KPIQueryParams{
+		Until: &until,
+		Sort:  "asc",
+	})
+	if err != nil {
+		t.Fatalf("queryKPIs returned error: %v", err)
+	}
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].KPIName != "kpi-until-hit" {
+		t.Fatalf("expected kpi-until-hit, got %s", results[0].KPIName)
+	}
+}
+
+func newInMemoryKPIDB(t *testing.T) *sql.DB {
+	t.Helper()
+
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("failed to open sqlite db: %v", err)
+	}
+
+	schema := `
+	CREATE TABLE clusters (
+		id INTEGER PRIMARY KEY,
+		cluster_name TEXT NOT NULL
+	);
+	CREATE TABLE query_results (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		kpi_id TEXT NOT NULL,
+		metric_value REAL,
+		timestamp_value REAL,
+		cluster_id INTEGER NOT NULL,
+		execution_time TIMESTAMP,
+		metric_labels TEXT
+	);
+	`
+	if _, err := db.Exec(schema); err != nil {
+		_ = db.Close()
+		t.Fatalf("failed to initialize schema: %v", err)
+	}
+
+	return db
+}
+
+func mustExec(t *testing.T, db *sql.DB, query string, args ...interface{}) {
+	t.Helper()
+	if _, err := db.Exec(query, args...); err != nil {
+		t.Fatalf("exec failed for query %q: %v", query, err)
+	}
+}
+
+func TestParseTimeFilterAcceptsDuration(t *testing.T) {
+	now := time.Date(2026, 4, 8, 12, 0, 0, 0, time.UTC)
+
+	got, err := parseTimeFilter("2h", now)
+	if err != nil {
+		t.Fatalf("parseTimeFilter returned error: %v", err)
+	}
+
+	want := now.Add(-2 * time.Hour)
+	if !got.Equal(want) {
+		t.Fatalf("expected %s, got %s", want.Format(time.RFC3339), got.Format(time.RFC3339))
+	}
+}
+
+func TestParseTimeFilterAcceptsRFC3339(t *testing.T) {
+	now := time.Date(2026, 4, 8, 12, 0, 0, 0, time.UTC)
+	input := "2026-04-07T12:24:25Z"
+
+	got, err := parseTimeFilter(input, now)
+	if err != nil {
+		t.Fatalf("parseTimeFilter returned error: %v", err)
+	}
+
+	want, err := time.Parse(time.RFC3339, input)
+	if err != nil {
+		t.Fatalf("failed to parse expected RFC3339 value: %v", err)
+	}
+	if !got.Equal(want) {
+		t.Fatalf("expected %s, got %s", want.Format(time.RFC3339), got.Format(time.RFC3339))
+	}
+}
+
+func TestParseTimeFilterRejectsNonPositiveDuration(t *testing.T) {
+	now := time.Date(2026, 4, 8, 12, 0, 0, 0, time.UTC)
+
+	_, err := parseTimeFilter("0s", now)
+	if err == nil {
+		t.Fatalf("expected error for non-positive duration")
+	}
+	if !strings.Contains(err.Error(), "must be > 0") {
+		t.Fatalf("expected positive-duration validation error, got: %v", err)
+	}
+}
+
+func TestParseKPIQueryTimeWindowRejectsInvalidOrder(t *testing.T) {
+	now := time.Date(2026, 4, 8, 12, 0, 0, 0, time.UTC)
+
+	_, _, err := parseKPIQueryTimeWindow("1h", "2h", now)
+	if err == nil {
+		t.Fatalf("expected error when --since resolves after --until")
+	}
+	if !strings.Contains(err.Error(), "must resolve before --until") {
+		t.Fatalf("expected since-before-until validation error, got: %v", err)
+	}
+}

--- a/internal/commands/db_show_test.go
+++ b/internal/commands/db_show_test.go
@@ -130,7 +130,7 @@ var _ = Describe("parseTimeFilter", func() {
 		Expect(got).To(BeTemporally("~", now.Add(-2*time.Hour)))
 	})
 
-	It("should accept an RFC 3339 timestamp", func() {
+	It("should accept an RFC 3339 timestamp in UTC", func() {
 		input := "2026-04-07T12:24:25Z"
 		got, err := parseTimeFilter(input, now)
 		Expect(err).NotTo(HaveOccurred())
@@ -138,6 +138,22 @@ var _ = Describe("parseTimeFilter", func() {
 		want, err := time.Parse(time.RFC3339, input)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(got).To(BeTemporally("~", want))
+	})
+
+	It("should accept an RFC 3339 timestamp with timezone offset", func() {
+		input := "2026-04-07T12:24:25+02:00"
+		got, err := parseTimeFilter(input, now)
+		Expect(err).NotTo(HaveOccurred())
+
+		want, err := time.Parse(time.RFC3339, input)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(got).To(BeTemporally("~", want))
+	})
+
+	It("should reject a timestamp that is not a valid duration nor RFC 3339", func() {
+		_, err := parseTimeFilter("2026-04-07-12:24:25", now)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("must be a Go duration"))
 	})
 
 	It("should reject a non-positive duration", func() {


### PR DESCRIPTION
The db show kpis was using the execution timestamp instead of the sample timestamp for the --since and --until flags.

Also, both --since and --until times are truncated to second precision and rfc3339 timestamps are now allowed.