### PR TITLE
Skip range-frequency overlap warning in single-run mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ kpi.log
 grafana/datasource/datasource.yaml
 kpis.yaml
 minimal-performanceprofile.yaml
+docs/images/how-it-works.puml

--- a/internal/commands/run.go
+++ b/internal/commands/run.go
@@ -166,9 +166,11 @@ func runCollect(cmd *cobra.Command, args []string) error {
 		warnFrequencyExceedsDuration(kpis, flags)
 	}
 
-	// Validate range query frequency/range mismatches
-	if err := validateRangeFrequency(kpis, flags); err != nil {
-		return err
+	// Validate range query frequency/range mismatches (only relevant for periodic collection)
+	if !flags.SingleRun {
+		if err := validateRangeFrequency(kpis, flags); err != nil {
+			return err
+		}
 	}
 
 	// If kubeconfig is provided, discover Thanos URL and token


### PR DESCRIPTION
When running with `--once`, the overlap warning for range queries (e.g. "KPI 'cpu-trend-1h' has frequency 1m0s with since 1h0m0s — ~99% overlaps") was still printed even though there is no repeated execution and therefore no overlap.
This wraps `validateRangeFrequency` in the same `!flags.SingleRun` guard already used for `warnFrequencyExceedsDuration` right above it.
### Changes
- `internal/commands/run.go`: gate `validateRangeFrequency` on `!flags.SingleRun`