### PR TITLE
Per-category database tables - SQLite write path

### DIFF
--- a/internal/config/kpis_loader.go
+++ b/internal/config/kpis_loader.go
@@ -3,12 +3,17 @@ package config
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 
 	"github.com/prometheus/prometheus/promql/parser"
 	"gopkg.in/yaml.v3"
 )
+
+const maxCategoryLength = 32
+
+var categoryCleanRE = regexp.MustCompile(`[^a-z0-9_]`)
 
 // LoadKPIs loads Prometheus queries from a YAML kpis file
 func LoadKPIs(filepath string) (KPIs, error) {
@@ -55,6 +60,7 @@ func ValidateKPIs(kpis KPIs) []error {
 			errors = append(errors, fmt.Errorf("KPI '%s': invalid PromQL syntax - %w", kpi.ID, err))
 		}
 
+		errors = append(errors, validateCategory(kpi)...)
 		errors = append(errors, validateQueryType(kpi)...)
 	}
 
@@ -141,6 +147,41 @@ func validateRangeWindow(kpi Query) []error {
 func validateTimeRefPositive(kpiID, field string, timeRef *TimeRef) error {
 	if timeRef.IsDuration() && timeRef.DurationValue() <= 0 {
 		return fmt.Errorf("KPI '%s': range.%s must be > 0 when specified as a duration", kpiID, field)
+	}
+
+	return nil
+}
+
+// SanitizeCategory normalises a user-supplied category string into a safe,
+// lowercase, underscore-separated identifier suitable for use as a SQL table
+// name suffix. Returns an error if the sanitised result exceeds 32 characters
+// or is empty.
+func SanitizeCategory(raw string) (string, error) {
+	s := strings.ToLower(strings.TrimSpace(raw))
+	s = strings.ReplaceAll(s, " ", "_")
+	s = strings.ReplaceAll(s, "-", "_")
+	s = categoryCleanRE.ReplaceAllString(s, "")
+	s = strings.Trim(s, "_")
+
+	if s == "" {
+		return "", fmt.Errorf("category %q is empty after sanitisation", raw)
+	}
+
+	if len(s) > maxCategoryLength {
+		return "", fmt.Errorf("category %q exceeds %d characters after sanitisation (%d chars: %q)",
+			raw, maxCategoryLength, len(s), s)
+	}
+
+	return s, nil
+}
+
+func validateCategory(kpi Query) []error {
+	if kpi.Category == "" {
+		return nil
+	}
+
+	if _, err := SanitizeCategory(kpi.Category); err != nil {
+		return []error{fmt.Errorf("KPI '%s': %w", kpi.ID, err)}
 	}
 
 	return nil

--- a/internal/config/kpis_loader.go
+++ b/internal/config/kpis_loader.go
@@ -36,7 +36,9 @@ func ValidateKPIs(kpis KPIs) []error {
 	var errors []error
 	seenIDs := make(map[string]bool)
 
-	for _, kpi := range kpis.Queries {
+	for i := range kpis.Queries {
+		kpi := &kpis.Queries[i]
+
 		// Check for empty KPI ID
 		if strings.TrimSpace(kpi.ID) == "" {
 			errors = append(errors, fmt.Errorf("KPI has empty ID"))
@@ -61,7 +63,7 @@ func ValidateKPIs(kpis KPIs) []error {
 		}
 
 		errors = append(errors, validateCategory(kpi)...)
-		errors = append(errors, validateQueryType(kpi)...)
+		errors = append(errors, validateQueryType(*kpi)...)
 	}
 
 	return errors
@@ -175,12 +177,13 @@ func SanitizeCategory(raw string) (string, error) {
 	return s, nil
 }
 
-func validateCategory(kpi Query) []error {
+func validateCategory(kpi *Query) []error {
 	if kpi.Category == "" {
 		return nil
 	}
 
-	if _, err := SanitizeCategory(kpi.Category); err != nil {
+	var err error
+	if kpi.Category, err = SanitizeCategory(kpi.Category); err != nil {
 		return []error{fmt.Errorf("KPI '%s': %w", kpi.ID, err)}
 	}
 

--- a/internal/config/kpis_loader_test.go
+++ b/internal/config/kpis_loader_test.go
@@ -1036,6 +1036,17 @@ var _ = Describe("KPIs Loader", func() {
 			Expect(errors[0].Error()).To(ContainSubstring("bad-cat"))
 			Expect(errors[0].Error()).To(ContainSubstring("empty after sanitisation"))
 		})
+
+		It("should sanitize category with hyphens", func() {
+			kpis := KPIs{
+				Queries: []Query{
+					{ID: "test", PromQuery: "up", Category: "node-cpu"},
+				},
+			}
+			errors := ValidateKPIs(kpis)
+			Expect(errors).To(BeEmpty())
+			Expect(kpis.Queries[0].Category).To(Equal("node_cpu"))
+		})
 	})
 
 	Describe("validateTimestampPositive", func() {

--- a/internal/config/kpis_loader_test.go
+++ b/internal/config/kpis_loader_test.go
@@ -119,6 +119,26 @@ var _ = Describe("KPIs Loader", func() {
 				Expect(kpis.Queries).To(BeEmpty())
 			})
 
+			It("should load KPIs with category field", func() {
+				kpisYAML := `kpis:
+  - id: node-cpu
+    promquery: avg(rate(node_cpu_seconds_total[5m]))
+    category: cpu
+  - id: cluster-up
+    promquery: up
+`
+				kpisPath := filepath.Join(tmpDir, "kpis-cat.yaml")
+				err := os.WriteFile(kpisPath, []byte(kpisYAML), 0644)
+				Expect(err).NotTo(HaveOccurred())
+
+				kpis, err := LoadKPIs(kpisPath)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(kpis.Queries).To(HaveLen(2))
+				Expect(kpis.Queries[0].Category).To(Equal("cpu"))
+				Expect(kpis.Queries[1].Category).To(BeEmpty())
+			})
+
 			It("should load PromQL queries with double quotes without escaping", func() {
 				kpisYAML := `kpis:
   - id: cpu-system-slice
@@ -940,6 +960,81 @@ var _ = Describe("KPIs Loader", func() {
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("failed to decode kpis file"))
 			})
+		})
+	})
+
+	Describe("SanitizeCategory", func() {
+		It("should lowercase and replace spaces/hyphens with underscores", func() {
+			result, err := SanitizeCategory("CPU Usage")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal("cpu_usage"))
+		})
+
+		It("should strip special characters", func() {
+			result, err := SanitizeCategory("mem@ory!!")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal("memory"))
+		})
+
+		It("should trim leading/trailing underscores", func() {
+			result, err := SanitizeCategory("_network_")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal("network"))
+		})
+
+		It("should return error for empty result after sanitisation", func() {
+			_, err := SanitizeCategory("@!#$")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("empty after sanitisation"))
+		})
+
+		It("should return error when exceeding 32 characters", func() {
+			long := "this_is_a_very_long_category_name_that_exceeds_limit"
+			_, err := SanitizeCategory(long)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("exceeds 32 characters"))
+		})
+
+		It("should accept exactly 32 characters", func() {
+			exact := "abcdefghijklmnopqrstuvwxyz012345"
+			Expect(len(exact)).To(Equal(32))
+			result, err := SanitizeCategory(exact)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(exact))
+		})
+	})
+
+	Describe("Category validation in ValidateKPIs", func() {
+		It("should accept KPIs with valid category", func() {
+			kpis := KPIs{
+				Queries: []Query{
+					{ID: "cpu-usage", PromQuery: "up", Category: "cpu"},
+				},
+			}
+			errors := ValidateKPIs(kpis)
+			Expect(errors).To(BeEmpty())
+		})
+
+		It("should accept KPIs without category", func() {
+			kpis := KPIs{
+				Queries: []Query{
+					{ID: "up-check", PromQuery: "up"},
+				},
+			}
+			errors := ValidateKPIs(kpis)
+			Expect(errors).To(BeEmpty())
+		})
+
+		It("should reject KPIs with invalid category", func() {
+			kpis := KPIs{
+				Queries: []Query{
+					{ID: "bad-cat", PromQuery: "up", Category: "@#$"},
+				},
+			}
+			errors := ValidateKPIs(kpis)
+			Expect(errors).To(HaveLen(1))
+			Expect(errors[0].Error()).To(ContainSubstring("bad-cat"))
+			Expect(errors[0].Error()).To(ContainSubstring("empty after sanitisation"))
 		})
 	})
 

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -139,6 +139,7 @@ type InputFlags struct {
 type Query struct {
 	ID              string       `yaml:"id"`
 	PromQuery       string       `yaml:"promquery"`
+	Category        string       `yaml:"category,omitempty"`
 	SampleFrequency *Duration    `yaml:"sample-frequency,omitempty"`
 	QueryType       string       `yaml:"query-type,omitempty"`
 	Range           *RangeWindow `yaml:"range,omitempty"`

--- a/internal/database/db_interface_test.go
+++ b/internal/database/db_interface_test.go
@@ -186,7 +186,7 @@ func RunDatabaseInterfaceTests(getImpl func() (Database, *sql.DB)) {
 					},
 				}
 
-				err := dbImpl.StoreQueryResults(db, clusterID, "test-query-1", vector)
+				err := dbImpl.StoreQueryResults(db, clusterID, "test-query-1", "", vector)
 				Expect(err).NotTo(HaveOccurred())
 
 				var count int
@@ -223,7 +223,7 @@ func RunDatabaseInterfaceTests(getImpl func() (Database, *sql.DB)) {
 						Timestamp: model.Time(time.Now().Unix() * 1000),
 					},
 				}
-				err := dbImpl.StoreQueryResults(db, clusterID, "test-query-3", vector)
+				err := dbImpl.StoreQueryResults(db, clusterID, "test-query-3", "", vector)
 				Expect(err).NotTo(HaveOccurred())
 
 				var metricLabels string
@@ -244,7 +244,7 @@ func RunDatabaseInterfaceTests(getImpl func() (Database, *sql.DB)) {
 						Timestamp: model.Time(time.Now().Unix() * 1000),
 					},
 				}
-				err := dbImpl.StoreQueryResults(db, clusterID, "test-query-4", vector)
+				err := dbImpl.StoreQueryResults(db, clusterID, "test-query-4", "", vector)
 				Expect(err).NotTo(HaveOccurred())
 
 				var executionTime, createdAt string
@@ -279,7 +279,7 @@ func RunDatabaseInterfaceTests(getImpl func() (Database, *sql.DB)) {
 					},
 				}
 
-				err := dbImpl.StoreQueryResults(db, clusterID, "test-query-2", vector)
+				err := dbImpl.StoreQueryResults(db, clusterID, "test-query-2", "", vector)
 				Expect(err).NotTo(HaveOccurred())
 
 				var count int
@@ -315,10 +315,10 @@ func RunDatabaseInterfaceTests(getImpl func() (Database, *sql.DB)) {
 					},
 				}
 
-				err := dbImpl.StoreQueryResults(db, clusterID, "query-cluster-1", vector1)
+				err := dbImpl.StoreQueryResults(db, clusterID, "query-cluster-1", "", vector1)
 				Expect(err).NotTo(HaveOccurred())
 
-				err = dbImpl.StoreQueryResults(db, clusterID2, "query-cluster-2", vector2)
+				err = dbImpl.StoreQueryResults(db, clusterID2, "query-cluster-2", "", vector2)
 				Expect(err).NotTo(HaveOccurred())
 
 				var storedClusterID int64

--- a/internal/database/interface.go
+++ b/internal/database/interface.go
@@ -25,6 +25,12 @@ type Database interface {
 	GetQueryErrorCount(db *sql.DB, kpiID string) (int, error)
 
 	// StoreQueryResults stores the results of a Prometheus query in the database.
+	// When category is non-empty, data is written to a category-specific table
+	// (e.g. kpi_cpu); otherwise it goes to the default query_results table.
 	// Supports model.Vector (from instant queries) and model.Matrix (from range queries).
-	StoreQueryResults(db *sql.DB, clusterID int64, queryID string, result model.Value) error
+	StoreQueryResults(db *sql.DB, clusterID int64, queryID string, category string, result model.Value) error
+
+	// EnsureCategoryTable creates the per-category table and dedup index if they
+	// don't already exist, and registers the KPI→category mapping in kpi_registry.
+	EnsureCategoryTable(db *sql.DB, category string, kpiID string) (string, error)
 }

--- a/internal/database/interface.go
+++ b/internal/database/interface.go
@@ -8,6 +8,7 @@ import (
 	"database/sql"
 
 	"github.com/prometheus/common/model"
+	"github.com/redhat-best-practices-for-k8s/kpi-collection-tool/internal/config"
 )
 
 // Database defines the interface that all database implementations must satisfy
@@ -33,4 +34,9 @@ type Database interface {
 	// EnsureCategoryTable creates the per-category table and dedup index if they
 	// don't already exist, and registers the KPI→category mapping in kpi_registry.
 	EnsureCategoryTable(db *sql.DB, category string, kpiID string) (string, error)
+
+	// ValidateCategoryConsistency checks that no KPI in the incoming config has
+	// changed its category compared to what is already stored in kpi_registry.
+	// Must be called after InitDB and before any collection begins.
+	ValidateCategoryConsistency(db *sql.DB, kpis []config.Query) error
 }

--- a/internal/database/postgres.go
+++ b/internal/database/postgres.go
@@ -7,6 +7,7 @@ import (
 
 	_ "github.com/lib/pq"
 	"github.com/prometheus/common/model"
+	"github.com/redhat-best-practices-for-k8s/kpi-collection-tool/internal/config"
 )
 
 // PostgresDB implements the Database interface for PostgreSQL
@@ -120,6 +121,13 @@ func (p *PostgresDB) GetQueryErrorCount(db *sql.DB, kpiID string) (int, error) {
 // --- TODO ---
 func (p *PostgresDB) EnsureCategoryTable(_ *sql.DB, _ string, _ string) (string, error) {
 	return "query_results", nil
+}
+
+// ValidateCategoryConsistency is a no-op stub for PostgreSQL until category
+// table support is implemented.
+// --- TODO ---
+func (p *PostgresDB) ValidateCategoryConsistency(_ *sql.DB, _ []config.Query) error {
+	return nil
 }
 
 // StoreQueryResults stores the results of a Prometheus query in the database.

--- a/internal/database/postgres.go
+++ b/internal/database/postgres.go
@@ -115,8 +115,18 @@ func (p *PostgresDB) GetQueryErrorCount(db *sql.DB, kpiID string) (int, error) {
 	return count, err
 }
 
-// StoreQueryResults stores the results of a Prometheus query in the database
-func (p *PostgresDB) StoreQueryResults(db *sql.DB, clusterID int64, queryID string, result model.Value) error {
+// EnsureCategoryTable is a no-op stub for PostgreSQL. Category table support
+// will be implemented in a future PR; all writes go to query_results for now.
+// --- TODO ---
+func (p *PostgresDB) EnsureCategoryTable(_ *sql.DB, _ string, _ string) (string, error) {
+	return "query_results", nil
+}
+
+// StoreQueryResults stores the results of a Prometheus query in the database.
+// The category parameter is accepted for interface compatibility but ignored —
+// all data is written to the default query_results table until PostgreSQL
+// category support is implemented.
+func (p *PostgresDB) StoreQueryResults(db *sql.DB, clusterID int64, queryID string, _ string, result model.Value) error {
 	switch values := result.(type) {
 	case model.Vector:
 		return p.storeVectorResults(db, clusterID, queryID, values)

--- a/internal/database/sqlite.go
+++ b/internal/database/sqlite.go
@@ -6,9 +6,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 
-	_ "modernc.org/sqlite"
 	"github.com/prometheus/common/model"
+	_ "modernc.org/sqlite"
 )
 
 const (
@@ -22,7 +23,13 @@ const (
 // and can be overridden via the --artifacts-dir flag.
 var OutputDir = DefaultOutputDir
 
-type SQLiteDB struct{}
+type SQLiteDB struct {
+	// knownTables caches which category tables have been created during this
+	// process lifetime. It resets on every invocation (including --once), which
+	// is fine because EnsureCategoryTable uses CREATE TABLE IF NOT EXISTS as the
+	// fallback — the cache only avoids redundant DDL within a long-running run.
+	knownTables sync.Map
+}
 
 // NewSQLiteDB creates a new SQLite database instance
 func NewSQLiteDB() *SQLiteDB {
@@ -70,7 +77,14 @@ func (sqlite_db *SQLiteDB) InitDB() (*sql.DB, error) {
 	);
 
 	CREATE UNIQUE INDEX IF NOT EXISTS idx_query_results_dedup
-	ON query_results(kpi_id, cluster_id, timestamp_value, metric_labels)
+	ON query_results(kpi_id, cluster_id, timestamp_value, metric_labels);
+
+	CREATE TABLE IF NOT EXISTS kpi_registry (
+		kpi_id TEXT PRIMARY KEY,
+		category TEXT NOT NULL,
+		table_name TEXT NOT NULL,
+		created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+	)
     `
 
 	_, err = db.Exec(schema)
@@ -117,19 +131,74 @@ func (sqlite_db *SQLiteDB) GetQueryErrorCount(db *sql.DB, kpiID string) (int, er
 	return count, err
 }
 
-// StoreQueryResults stores the results of a Prometheus query in the database
-func (sqlite_db *SQLiteDB) StoreQueryResults(db *sql.DB, clusterID int64, queryID string, result model.Value) error {
+// StoreQueryResults stores the results of a Prometheus query in the database.
+// When category is non-empty, writes go to the per-category table (kpi_<category>).
+func (sqlite_db *SQLiteDB) StoreQueryResults(db *sql.DB, clusterID int64, queryID string, category string, result model.Value) error {
+	tableName := "query_results"
+	if category != "" {
+		name, err := sqlite_db.EnsureCategoryTable(db, category, queryID)
+		if err != nil {
+			return fmt.Errorf("ensure category table for '%s': %w", category, err)
+		}
+		tableName = name
+	}
+
 	switch values := result.(type) {
 	case model.Vector:
-		return sqlite_db.storeVectorResults(db, clusterID, queryID, values)
+		return sqlite_db.storeVectorResults(db, clusterID, queryID, tableName, values)
 	case model.Matrix:
-		return sqlite_db.storeMatrixResults(db, clusterID, queryID, values)
+		return sqlite_db.storeMatrixResults(db, clusterID, queryID, tableName, values)
 	default:
 		return fmt.Errorf("unsupported Prometheus result type for KPI '%s': %T", queryID, result)
 	}
 }
 
-func (sqlite_db *SQLiteDB) storeVectorResults(db *sql.DB, clusterID int64, queryID string, vector model.Vector) error {
+// CategoryTableName returns the physical table name for a given sanitised category.
+func CategoryTableName(category string) string {
+	return "kpi_" + category
+}
+
+// EnsureCategoryTable lazily creates the per-category table and registers the
+// KPI→category mapping. The DDL is idempotent and only executed once per
+// process lifetime thanks to the in-memory knownTables cache.
+func (sqlite_db *SQLiteDB) EnsureCategoryTable(db *sql.DB, category string, kpiID string) (string, error) {
+	tableName := CategoryTableName(category)
+
+	if _, ok := sqlite_db.knownTables.Load(tableName); !ok {
+		ddl := fmt.Sprintf(`
+			CREATE TABLE IF NOT EXISTS %s (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				kpi_id TEXT NOT NULL,
+				metric_value REAL,
+				timestamp_value REAL,
+				cluster_id INTEGER NOT NULL REFERENCES clusters(id),
+				execution_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+				created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+				metric_labels TEXT
+			);
+			CREATE UNIQUE INDEX IF NOT EXISTS idx_%s_dedup
+			ON %s(kpi_id, cluster_id, timestamp_value, metric_labels)`,
+			tableName, tableName, tableName)
+
+		if _, err := db.Exec(ddl); err != nil {
+			return "", fmt.Errorf("create table %s: %w", tableName, err)
+		}
+
+		sqlite_db.knownTables.Store(tableName, true)
+	}
+
+	_, err := db.Exec(`
+		INSERT INTO kpi_registry (kpi_id, category, table_name) VALUES (?, ?, ?)
+		ON CONFLICT(kpi_id) DO UPDATE SET category = excluded.category, table_name = excluded.table_name`,
+		kpiID, category, tableName)
+	if err != nil {
+		return "", fmt.Errorf("update kpi_registry for '%s': %w", kpiID, err)
+	}
+
+	return tableName, nil
+}
+
+func (sqlite_db *SQLiteDB) storeVectorResults(db *sql.DB, clusterID int64, queryID string, table string, vector model.Vector) error {
 	for _, sample := range vector {
 		metric := sample.Metric
 		value := float64(sample.Value)
@@ -140,11 +209,11 @@ func (sqlite_db *SQLiteDB) storeVectorResults(db *sql.DB, clusterID int64, query
 			return err
 		}
 
-		_, err = db.Exec(`
-            INSERT INTO query_results 
+		_, err = db.Exec(fmt.Sprintf(`
+            INSERT INTO %s
             (kpi_id, metric_value, timestamp_value, cluster_id, metric_labels)
             VALUES (?, ?, ?, ?, ?)
-            ON CONFLICT(kpi_id, cluster_id, timestamp_value, metric_labels) DO NOTHING`,
+            ON CONFLICT(kpi_id, cluster_id, timestamp_value, metric_labels) DO NOTHING`, table),
 			queryID, value, timestamp, clusterID, string(labelsJSON),
 		)
 		if err != nil {
@@ -154,7 +223,7 @@ func (sqlite_db *SQLiteDB) storeVectorResults(db *sql.DB, clusterID int64, query
 	return nil
 }
 
-func (sqlite_db *SQLiteDB) storeMatrixResults(db *sql.DB, clusterID int64, queryID string, matrix model.Matrix) error {
+func (sqlite_db *SQLiteDB) storeMatrixResults(db *sql.DB, clusterID int64, queryID string, table string, matrix model.Matrix) error {
 	for _, stream := range matrix {
 		metric := stream.Metric
 		labelsJSON, err := json.Marshal(metric)
@@ -166,11 +235,11 @@ func (sqlite_db *SQLiteDB) storeMatrixResults(db *sql.DB, clusterID int64, query
 			value := float64(samplePair.Value)
 			timestamp := float64(samplePair.Timestamp) / 1000
 
-			_, execErr := db.Exec(`
-                INSERT INTO query_results 
+			_, execErr := db.Exec(fmt.Sprintf(`
+                INSERT INTO %s
                 (kpi_id, metric_value, timestamp_value, cluster_id, metric_labels)
                 VALUES (?, ?, ?, ?, ?)
-                ON CONFLICT(kpi_id, cluster_id, timestamp_value, metric_labels) DO NOTHING`,
+                ON CONFLICT(kpi_id, cluster_id, timestamp_value, metric_labels) DO NOTHING`, table),
 				queryID, value, timestamp, clusterID, string(labelsJSON),
 			)
 			if execErr != nil {

--- a/internal/database/sqlite.go
+++ b/internal/database/sqlite.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"github.com/prometheus/common/model"
+	"github.com/redhat-best-practices-for-k8s/kpi-collection-tool/internal/config"
 	_ "modernc.org/sqlite"
 )
 
@@ -189,13 +190,52 @@ func (sqlite_db *SQLiteDB) EnsureCategoryTable(db *sql.DB, category string, kpiI
 
 	_, err := db.Exec(`
 		INSERT INTO kpi_registry (kpi_id, category, table_name) VALUES (?, ?, ?)
-		ON CONFLICT(kpi_id) DO UPDATE SET category = excluded.category, table_name = excluded.table_name`,
+		ON CONFLICT(kpi_id) DO NOTHING`,
 		kpiID, category, tableName)
 	if err != nil {
-		return "", fmt.Errorf("update kpi_registry for '%s': %w", kpiID, err)
+		return "", fmt.Errorf("register kpi '%s' in kpi_registry: %w", kpiID, err)
 	}
 
 	return tableName, nil
+}
+
+// ValidateCategoryConsistency loads the existing kpi_registry and returns an
+// error if any incoming KPI has a different category than what was previously
+// recorded. This prevents silent data orphaning when a user changes categories
+// between runs.
+func (sqlite_db *SQLiteDB) ValidateCategoryConsistency(db *sql.DB, kpis []config.Query) error {
+	rows, err := db.Query("SELECT kpi_id, category FROM kpi_registry")
+	if err != nil {
+		return fmt.Errorf("query kpi_registry: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	registered := make(map[string]string)
+	for rows.Next() {
+		var kpiID, category string
+		if err := rows.Scan(&kpiID, &category); err != nil {
+			return fmt.Errorf("scan kpi_registry row: %w", err)
+		}
+		registered[kpiID] = category
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate kpi_registry: %w", err)
+	}
+
+	for i := range kpis {
+		prev, exists := registered[kpis[i].ID]
+		if !exists {
+			continue
+		}
+		if prev != kpis[i].Category {
+			return fmt.Errorf(
+				"KPI '%s' category changed from %q to %q — "+
+					"use a different --artifacts-dir or delete the existing database",
+				kpis[i].ID, prev, kpis[i].Category)
+		}
+	}
+
+	return nil
 }
 
 func (sqlite_db *SQLiteDB) storeVectorResults(db *sql.DB, clusterID int64, queryID string, table string, vector model.Vector) error {

--- a/internal/database/sqlite_test.go
+++ b/internal/database/sqlite_test.go
@@ -9,6 +9,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/prometheus/common/model"
+	"github.com/redhat-best-practices-for-k8s/kpi-collection-tool/internal/config"
 )
 
 var _ = Describe("Sqlite", func() {
@@ -188,6 +189,66 @@ var _ = Describe("Sqlite", func() {
 			err = db.QueryRow("SELECT COUNT(*) FROM kpi_memory WHERE kpi_id = 'mem-kpi'").Scan(&count)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(count).To(Equal(1))
+		})
+	})
+
+	Describe("ValidateCategoryConsistency", func() {
+		BeforeEach(func() {
+			_, err := sqliteDB.EnsureCategoryTable(db, "cpu", "node-cpu")
+			Expect(err).NotTo(HaveOccurred())
+			_, err = sqliteDB.EnsureCategoryTable(db, "memory", "mem-usage")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should pass when categories match", func() {
+			kpis := []config.Query{
+				{ID: "node-cpu", Category: "cpu"},
+				{ID: "mem-usage", Category: "memory"},
+			}
+			err := sqliteDB.ValidateCategoryConsistency(db, kpis)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should pass for new KPIs not yet in registry", func() {
+			kpis := []config.Query{
+				{ID: "node-cpu", Category: "cpu"},
+				{ID: "brand-new-kpi", Category: "network"},
+			}
+			err := sqliteDB.ValidateCategoryConsistency(db, kpis)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should error when a KPI changes category", func() {
+			kpis := []config.Query{
+				{ID: "node-cpu", Category: "networking"},
+			}
+			err := sqliteDB.ValidateCategoryConsistency(db, kpis)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("node-cpu"))
+			Expect(err.Error()).To(ContainSubstring(`"cpu"`))
+			Expect(err.Error()).To(ContainSubstring(`"networking"`))
+		})
+
+		It("should error when a categorised KPI becomes uncategorised", func() {
+			kpis := []config.Query{
+				{ID: "node-cpu", Category: ""},
+			}
+			err := sqliteDB.ValidateCategoryConsistency(db, kpis)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("node-cpu"))
+		})
+
+		It("should pass on an empty registry", func() {
+			freshDB := NewSQLiteDB()
+			freshConn, err := freshDB.InitDB()
+			Expect(err).NotTo(HaveOccurred())
+			defer func() { _ = freshConn.Close() }()
+
+			kpis := []config.Query{
+				{ID: "any-kpi", Category: "whatever"},
+			}
+			err = freshDB.ValidateCategoryConsistency(freshConn, kpis)
+			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 

--- a/internal/database/sqlite_test.go
+++ b/internal/database/sqlite_test.go
@@ -4,9 +4,11 @@ import (
 	"database/sql"
 	"os"
 	"path/filepath"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/prometheus/common/model"
 )
 
 var _ = Describe("Sqlite", func() {
@@ -78,6 +80,114 @@ var _ = Describe("Sqlite", func() {
 			dbFile := filepath.Join(tmpDir, DefaultOutputDir, DefaultDBFileName)
 			_, err := os.Stat(dbFile)
 			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Describe("Category Tables", func() {
+		var clusterID int64
+
+		BeforeEach(func() {
+			var err error
+			clusterID, err = sqliteDB.GetOrCreateCluster(db, "cat-cluster", "ran")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should create the kpi_registry table at init", func() {
+			var name string
+			err := db.QueryRow("SELECT name FROM sqlite_master WHERE type='table' AND name='kpi_registry'").Scan(&name)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(name).To(Equal("kpi_registry"))
+		})
+
+		It("should create a category table and register the KPI", func() {
+			tableName, err := sqliteDB.EnsureCategoryTable(db, "cpu", "node-cpu-usage")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(tableName).To(Equal("kpi_cpu"))
+
+			var name string
+			err = db.QueryRow("SELECT name FROM sqlite_master WHERE type='table' AND name='kpi_cpu'").Scan(&name)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(name).To(Equal("kpi_cpu"))
+
+			var kpiID, category, regTable string
+			err = db.QueryRow("SELECT kpi_id, category, table_name FROM kpi_registry WHERE kpi_id = 'node-cpu-usage'").
+				Scan(&kpiID, &category, &regTable)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(category).To(Equal("cpu"))
+			Expect(regTable).To(Equal("kpi_cpu"))
+		})
+
+		It("should be idempotent for the same category", func() {
+			_, err := sqliteDB.EnsureCategoryTable(db, "memory", "mem-usage-1")
+			Expect(err).NotTo(HaveOccurred())
+			_, err = sqliteDB.EnsureCategoryTable(db, "memory", "mem-usage-2")
+			Expect(err).NotTo(HaveOccurred())
+
+			var count int
+			err = db.QueryRow("SELECT COUNT(*) FROM kpi_registry WHERE category = 'memory'").Scan(&count)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(count).To(Equal(2))
+		})
+
+		It("should route categorised writes to the category table", func() {
+			vector := model.Vector{
+				&model.Sample{
+					Metric:    model.Metric{"__name__": "cpu_seconds"},
+					Value:     model.SampleValue(0.75),
+					Timestamp: model.Time(time.Now().Unix() * 1000),
+				},
+			}
+
+			err := sqliteDB.StoreQueryResults(db, clusterID, "node-cpu", "cpu", vector)
+			Expect(err).NotTo(HaveOccurred())
+
+			var count int
+			err = db.QueryRow("SELECT COUNT(*) FROM kpi_cpu WHERE kpi_id = 'node-cpu'").Scan(&count)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(count).To(Equal(1))
+
+			err = db.QueryRow("SELECT COUNT(*) FROM query_results WHERE kpi_id = 'node-cpu'").Scan(&count)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(count).To(Equal(0))
+		})
+
+		It("should route uncategorised writes to query_results", func() {
+			vector := model.Vector{
+				&model.Sample{
+					Metric:    model.Metric{"__name__": "up"},
+					Value:     model.SampleValue(1),
+					Timestamp: model.Time(time.Now().Unix() * 1000),
+				},
+			}
+
+			err := sqliteDB.StoreQueryResults(db, clusterID, "cluster-up", "", vector)
+			Expect(err).NotTo(HaveOccurred())
+
+			var count int
+			err = db.QueryRow("SELECT COUNT(*) FROM query_results WHERE kpi_id = 'cluster-up'").Scan(&count)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(count).To(Equal(1))
+		})
+
+		It("should enforce dedup on category tables", func() {
+			ts := model.Time(time.Now().Unix() * 1000)
+			vector := model.Vector{
+				&model.Sample{
+					Metric:    model.Metric{"__name__": "mem_bytes"},
+					Value:     model.SampleValue(1024),
+					Timestamp: ts,
+				},
+			}
+
+			err := sqliteDB.StoreQueryResults(db, clusterID, "mem-kpi", "memory", vector)
+			Expect(err).NotTo(HaveOccurred())
+			err = sqliteDB.StoreQueryResults(db, clusterID, "mem-kpi", "memory", vector)
+			Expect(err).NotTo(HaveOccurred())
+
+			var count int
+			err = db.QueryRow("SELECT COUNT(*) FROM kpi_memory WHERE kpi_id = 'mem-kpi'").Scan(&count)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(count).To(Equal(1))
 		})
 	})
 

--- a/internal/output/collection_printer.go
+++ b/internal/output/collection_printer.go
@@ -12,6 +12,7 @@ var printMutex sync.Mutex
 type QueryInfo struct {
 	QueryID      string
 	PromQuery    string
+	Category     string
 	Frequency    time.Duration
 	SampleNumber int
 	TotalSamples int
@@ -42,6 +43,9 @@ func PrintQueryResult(info QueryInfo, result QueryResult) {
 	}
 
 	fmt.Printf("  Query: %s\n", info.PromQuery)
+	if info.Category != "" {
+		fmt.Printf("  Category: %s\n", info.Category)
+	}
 	if info.QueryType == "range" {
 		fmt.Printf("  Query Type: range (step: %s, since: %s, until: %s)\n",
 			info.Step, info.Since.Format(time.RFC3339), info.Until.Format(time.RFC3339))

--- a/internal/prometheus/client.go
+++ b/internal/prometheus/client.go
@@ -91,6 +91,7 @@ func RunQueries(kpisToRun config.KPIs, flags config.InputFlags, sampleNumber int
 		queryInfo := output.QueryInfo{
 			QueryID:      query.ID,
 			PromQuery:    query.PromQuery,
+			Category:     query.Category,
 			Frequency:    frequency,
 			SampleNumber: sampleNumber,
 			TotalSamples: totalSamples,
@@ -178,7 +179,7 @@ func executeQuery(ctx context.Context, v1api promv1.API, db *sql.DB, dbImpl data
 	}
 
 	// Store results
-	err = dbImpl.StoreQueryResults(db, clusterID, info.QueryID, result)
+	err = dbImpl.StoreQueryResults(db, clusterID, info.QueryID, info.Category, result)
 	if err != nil {
 		queryResult.Success = false
 		queryResult.Error = fmt.Errorf("failed to store: %v", err)

--- a/internal/prometheus/client.go
+++ b/internal/prometheus/client.go
@@ -75,6 +75,11 @@ func RunQueries(kpisToRun config.KPIs, flags config.InputFlags, sampleNumber int
 		return fmt.Errorf("failed to get cluster ID: %v", err)
 	}
 
+	// Verify that no KPI has changed its category since the last run
+	if err := dbImpl.ValidateCategoryConsistency(db, kpisToRun.Queries); err != nil {
+		return fmt.Errorf("category consistency check failed: %w", err)
+	}
+
 	// Create Prometheus client
 	v1api, err := setupPromClient(flags.ThanosURL, flags.BearerToken, flags.InsecureTLS)
 	if err != nil {


### PR DESCRIPTION

Adds the core mechanism for routing KPI data into per-category SQLite tables instead of a single `query_results` table.

### What this does

KPIs can now declare an optional `category` field in the YAML config:

```yaml
kpis:
  - id: node-cpu-usage
    promquery: avg by (instance) (rate(node_cpu_seconds_total{mode!="idle"}[5m]))
    category: cpu
```

When a category is set, the collector writes data to a dedicated `kpi_<category>` table (e.g. `kpi_cpu`) instead of the default `query_results` table. A `kpi_registry` table tracks which KPI belongs to which category and table.

KPIs without a category continue to write to `query_results` - fully backward compatible.

Still left TODO:

- Read path: db show integration, registry lookups
- Grafana: pull data from category tables, category variable
- PostgresSQL parity
- performance improvment to db read/write, indexes