### PR TITLE
Logger UT switched to ginkgo.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ lint: install-golangci-lint
 
 # Run all tests
 test:
-	go test ./... -v
+	go test ./... -v -ginkgo.v
 
 # Install kpi-collector to user's Go bin directory
 install:

--- a/internal/logger/logger_suite_test.go
+++ b/internal/logger/logger_suite_test.go
@@ -1,0 +1,13 @@
+package logger
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestLogger(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Logger Suite")
+}

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -3,44 +3,35 @@ package logger
 import (
 	"log"
 	"os"
-	"strings"
-	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
-func TestInitLogger(t *testing.T) {
-	tmpFile := "test_log.log"
-	defer func() {
-		if err := os.Remove(tmpFile); err != nil {
-			log.Printf("Warning: failed to remove temp file %s: %v", tmpFile, err)
-		}
-	}()
+var _ = Describe("InitLogger", func() {
+	var tmpFile string
 
-	f, err := InitLogger(tmpFile)
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
-	defer func() {
-		if err := f.Close(); err != nil {
-			log.Printf("Warning: failed to close file: %v", err)
-		}
-	}()
+	BeforeEach(func() {
+		tmpFile = "test_log.log"
+	})
 
-	// Check the file actually exists
-	info, err := os.Stat(tmpFile)
-	if err != nil {
-		t.Fatalf("log file not created: %v", err)
-	}
-	if info.Size() != 0 {
-		t.Fatalf("expected empty file, got size %d", info.Size())
-	}
+	AfterEach(func() {
+		_ = os.Remove(tmpFile)
+	})
 
-	// Write to log to verify logging works
-	log.Println("test log entry")
-	content, err := os.ReadFile(tmpFile)
-	if err != nil {
-		t.Fatalf("failed to read log file: %v", err)
-	}
-	if !strings.Contains(string(content), "test log entry") {
-		t.Fatalf("log content missing: %s", content)
-	}
-}
+	It("should create the log file and configure the logger to write to it", func() {
+		f, err := InitLogger(tmpFile)
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = f.Close() }()
+
+		info, err := os.Stat(tmpFile)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(info.Size()).To(BeZero())
+
+		log.Println("test log entry")
+
+		content, err := os.ReadFile(tmpFile)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(content)).To(ContainSubstring("test log entry"))
+	})
+})


### PR DESCRIPTION
Also, added the ginkgo verbose flag to the "make test" so we can see all the test cases that are run. Eg:
```
$ make test
...
...
Running Suite: Logger Suite -
/home/greyerof/github/kpi-collection-tool/internal/logger
=======================================================================================
Random Seed: 1778512860

Will run 1 of 1 specs
------------------------------
InitLogger should create the log file and configure the logger to write to it
/home/greyerof/github/kpi-collection-tool/internal/logger/logger_test.go:22
• [0.001 seconds]
------------------------------

Ran 1 of 1 Specs in 0.001 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestLogger (0.00s)
...
...
```