### PR TITLE
Sync PostgreSQL Grafana dashboard with SQLite and add e2e PostgreSQL test script

### DIFF
--- a/grafana-templates/postgres-dashboard.json
+++ b/grafana-templates/postgres-dashboard.json
@@ -5,7 +5,7 @@
         "builtIn": 1,
         "datasource": {
           "type": "grafana",
-          "uid": "kpi-datasource"
+          "uid": "-- Grafana --"
         },
         "enable": true,
         "hide": true,
@@ -26,7 +26,7 @@
       "keepTime": false,
       "tags": [],
       "targetBlank": false,
-      "title": "Auto Fit",
+      "title": "Fit to data",
       "tooltip": "Adjust time range to fit all available data",
       "type": "link",
       "url": "/d/kpi-collector-dynamic/?from=${data_start}&to=${data_end}"
@@ -35,9 +35,18 @@
   "liveNow": false,
   "panels": [
     {
+      "id": 1,
+      "type": "timeseries",
+      "title": "Metric Values Over Time",
       "datasource": {
         "type": "postgres",
         "uid": "kpi-datasource"
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 0
       },
       "fieldConfig": {
         "defaults": {
@@ -58,13 +67,13 @@
               "viz": false,
               "legend": false
             },
-            "lineInterpolation": "smooth",
+            "lineInterpolation": "linear",
             "lineWidth": 2,
-            "pointSize": 4,
+            "pointSize": 5,
             "scaleDistribution": {
               "type": "linear"
             },
-            "showPoints": "auto",
+            "showPoints": "never",
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -81,11 +90,57 @@
               {
                 "color": "green",
                 "value": null
+              },
+              {
+                "color": "blue",
+                "value": null,
+                "label": "Min"
+              },
+              {
+                "color": "orange",
+                "value": null,
+                "label": "Avg"
+              },
+              {
+                "color": "red",
+                "value": null,
+                "label": "Max"
               }
-            ]
-          }
+            ],
+            "showThresholdLabels": true,
+            "showThresholdMarkers": {
+              "mode": "off"
+            }
+          },
+          "unit": "short"
         },
         "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "metric_value"
+            },
+            "properties": [
+              {
+                "id": "custom.lineWidth",
+                "value": 2
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "fill": "solid"
+                }
+              },
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "tooltip": false,
+                  "viz": false,
+                  "legend": false
+                }
+              }
+            ]
+          },
           {
             "matcher": {
               "id": "byName",
@@ -122,7 +177,7 @@
                 "value": {
                   "tooltip": true,
                   "viz": false,
-                  "legend": false
+                  "legend": true
                 }
               }
             ]
@@ -154,7 +209,7 @@
               {
                 "id": "color",
                 "value": {
-                  "fixedColor": "green",
+                  "fixedColor": "blue",
                   "mode": "fixed"
                 }
               },
@@ -163,7 +218,7 @@
                 "value": {
                   "tooltip": true,
                   "viz": false,
-                  "legend": false
+                  "legend": true
                 }
               }
             ]
@@ -204,30 +259,24 @@
                 "value": {
                   "tooltip": true,
                   "viz": false,
-                  "legend": false
+                  "legend": true
                 }
               }
             ]
           }
         ]
       },
-      "gridPos": {
-        "h": 10,
-        "w": 18,
-        "x": 0,
-        "y": 0
-      },
-      "id": 1,
       "options": {
         "legend": {
-          "showLegend": true,
-          "displayMode": "table",
-          "placement": "bottom",
           "calcs": [
             "last",
             "mean",
+            "min",
             "max"
-          ]
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
           "mode": "multi",
@@ -241,12 +290,12 @@
             "uid": "kpi-datasource"
           },
           "format": "table",
-          "rawSql": "SELECT to_timestamp(timestamp_value) AS time, metric_value, metric_labels FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE timestamp_value >= $__from / 1000 AND timestamp_value < $__to / 1000 AND kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) AND COALESCE(metric_labels->>'node', metric_labels->>'instance', 'N/A') LIKE (CASE WHEN '${node}' = 'All' THEN '%%' ELSE '${node}' END) AND COALESCE(metric_labels->>'job', 'N/A') LIKE (CASE WHEN '${job}' = 'All' THEN '%%' ELSE '${job}' END) AND COALESCE(metric_labels->>'container', 'N/A') LIKE (CASE WHEN '${container}' = 'All' THEN '%%' ELSE '${container}' END) AND COALESCE(metric_labels->>'pod', 'N/A') LIKE (CASE WHEN '${pod}' = 'All' THEN '%%' ELSE '${pod}' END) ORDER BY time ASC",
+          "rawSql": "SELECT to_timestamp(timestamp_value) AS time, metric_value, metric_labels FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR metric_labels->>'node' = '${node}' OR metric_labels->>'instance' = '${node}') AND ('${job}' = 'All' OR metric_labels->>'job' = '${job}') AND ('${pod}' = 'All' OR metric_labels->>'pod' = '${pod}') AND ('${container}' = 'All' OR metric_labels->>'container' = '${container}') AND timestamp_value >= $__from / 1000 AND timestamp_value < $__to / 1000 ORDER BY time ASC",
           "refId": "A",
           "timeColumns": [
-            "time"
-          ],
-          "legendFormat": "Node: {{__field.labels.node}} | Pod: {{__field.labels.pod}} | Job: {{__field.labels.job}}"
+            "time",
+            "ts"
+          ]
         },
         {
           "datasource": {
@@ -254,12 +303,13 @@
             "uid": "kpi-datasource"
           },
           "format": "table",
-          "rawSql": "SELECT 'Max Value' AS metric_labels, MAX(metric_value) AS metric_value, $__from/1000 AS time FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE timestamp_value >= $__from / 1000 AND timestamp_value < $__to / 1000 AND kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) AND COALESCE(metric_labels->>'node', metric_labels->>'instance', 'N/A') LIKE (CASE WHEN '${node}' = 'All' THEN '%%' ELSE '${node}' END) AND COALESCE(metric_labels->>'job', 'N/A') LIKE (CASE WHEN '${job}' = 'All' THEN '%%' ELSE '${job}' END) AND COALESCE(metric_labels->>'container', 'N/A') LIKE (CASE WHEN '${container}' = 'All' THEN '%%' ELSE '${container}' END) AND COALESCE(metric_labels->>'pod', 'N/A') LIKE (CASE WHEN '${pod}' = 'All' THEN '%%' ELSE '${pod}' END)",
+          "rawSql": "SELECT 'Max Value' AS metric_labels, MAX(metric_value) AS metric_value, to_timestamp($__from/1000) AS time FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR metric_labels->>'node' = '${node}' OR metric_labels->>'instance' = '${node}') AND ('${job}' = 'All' OR metric_labels->>'job' = '${job}') AND ('${pod}' = 'All' OR metric_labels->>'pod' = '${pod}') AND ('${container}' = 'All' OR metric_labels->>'container' = '${container}')",
           "refId": "B",
           "legendFormat": "Max Value",
           "timeColumns": [
             "time"
-          ]
+          ],
+          "hide": true
         },
         {
           "datasource": {
@@ -267,12 +317,13 @@
             "uid": "kpi-datasource"
           },
           "format": "table",
-          "rawSql": "SELECT 'Min Value' AS metric_labels, MIN(metric_value) AS metric_value, $__from/1000 AS time FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE timestamp_value >= $__from / 1000 AND timestamp_value < $__to / 1000 AND kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) AND COALESCE(metric_labels->>'node', metric_labels->>'instance', 'N/A') LIKE (CASE WHEN '${node}' = 'All' THEN '%%' ELSE '${node}' END) AND COALESCE(metric_labels->>'job', 'N/A') LIKE (CASE WHEN '${job}' = 'All' THEN '%%' ELSE '${job}' END) AND COALESCE(metric_labels->>'container', 'N/A') LIKE (CASE WHEN '${container}' = 'All' THEN '%%' ELSE '${container}' END) AND COALESCE(metric_labels->>'pod', 'N/A') LIKE (CASE WHEN '${pod}' = 'All' THEN '%%' ELSE '${pod}' END)",
+          "rawSql": "SELECT 'Min Value' AS metric_labels, MIN(metric_value) AS metric_value, to_timestamp($__from/1000) AS time FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR metric_labels->>'node' = '${node}' OR metric_labels->>'instance' = '${node}') AND ('${job}' = 'All' OR metric_labels->>'job' = '${job}') AND ('${pod}' = 'All' OR metric_labels->>'pod' = '${pod}') AND ('${container}' = 'All' OR metric_labels->>'container' = '${container}')",
           "refId": "C",
           "legendFormat": "Min Value",
           "timeColumns": [
             "time"
-          ]
+          ],
+          "hide": true
         },
         {
           "datasource": {
@@ -280,16 +331,15 @@
             "uid": "kpi-datasource"
           },
           "format": "table",
-          "rawSql": "SELECT 'Average Value' AS metric_labels, AVG(metric_value) AS metric_value, $__from/1000 AS time FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE timestamp_value >= $__from / 1000 AND timestamp_value < $__to / 1000 AND kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) AND COALESCE(metric_labels->>'node', metric_labels->>'instance', 'N/A') LIKE (CASE WHEN '${node}' = 'All' THEN '%%' ELSE '${node}' END) AND COALESCE(metric_labels->>'job', 'N/A') LIKE (CASE WHEN '${job}' = 'All' THEN '%%' ELSE '${job}' END) AND COALESCE(metric_labels->>'container', 'N/A') LIKE (CASE WHEN '${container}' = 'All' THEN '%%' ELSE '${container}' END) AND COALESCE(metric_labels->>'pod', 'N/A') LIKE (CASE WHEN '${pod}' = 'All' THEN '%%' ELSE '${pod}' END)",
+          "rawSql": "SELECT 'Average Value' AS metric_labels, AVG(metric_value) AS metric_value, to_timestamp($__from/1000) AS time FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR metric_labels->>'node' = '${node}' OR metric_labels->>'instance' = '${node}') AND ('${job}' = 'All' OR metric_labels->>'job' = '${job}') AND ('${pod}' = 'All' OR metric_labels->>'pod' = '${pod}') AND ('${container}' = 'All' OR metric_labels->>'container' = '${container}')",
           "refId": "D",
           "legendFormat": "Average Value",
           "timeColumns": [
             "time"
-          ]
+          ],
+          "hide": true
         }
       ],
-      "title": "Metric Values Over Time",
-      "type": "timeseries",
       "transformations": [
         {
           "id": "extractFields",
@@ -301,6 +351,21 @@
           }
         },
         {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "metric_labels": true,
+              "undefined": true,
+              "cpu": true,
+              "device": true,
+              "endpoint": true,
+              "instance": true
+            },
+            "indexByName": {},
+            "renameByName": {}
+          }
+        },
+        {
           "id": "prepareTimeSeries",
           "options": {
             "format": "multi"
@@ -309,69 +374,34 @@
       ]
     },
     {
+      "id": 2,
+      "type": "text",
+      "title": "",
+      "gridPos": {
+        "h": 2,
+        "w": 24,
+        "x": 0,
+        "y": 10
+      },
+      "options": {
+        "mode": "html",
+        "content": "<div style=\"text-align: center; vertical-align: middle\">sample count: ${samples_count}, average value: ${avg_value}, max value: ${max_value}, min value: ${min_value}</div>"
+      },
+      "transparent": true
+    },
+    {
+      "id": 3,
+      "type": "table",
+      "title": "Detailed Metrics with All Labels",
       "datasource": {
         "type": "postgres",
         "uid": "kpi-datasource"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          }
-        },
-        "overrides": []
       },
       "gridPos": {
         "h": 10,
-        "w": 6,
-        "x": 18,
-        "y": 0
-      },
-      "id": 2,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "vertical",
-        "reduceOptions": {
-          "values": false,
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": ""
-        },
-        "textMode": "value_and_name",
-        "showPercentChange": false
-      },
-      "pluginVersion": "10.0.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "postgres",
-            "uid": "kpi-datasource"
-          },
-          "format": "table",
-          "rawSql": "SELECT COUNT(*) as \"Samples\", ROUND(CAST(AVG(metric_value) AS numeric), 6) as \"Average\", ROUND(CAST(MIN(metric_value) AS numeric), 6) as \"Minimum\", ROUND(CAST(MAX(metric_value) AS numeric), 6) as \"Maximum\" FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE timestamp_value >= $__from / 1000 AND timestamp_value < $__to / 1000 AND kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) AND COALESCE(metric_labels->>'node', metric_labels->>'instance', 'N/A') LIKE (CASE WHEN '${node}' = 'All' THEN '%%' ELSE '${node}' END) AND COALESCE(metric_labels->>'job', 'N/A') LIKE (CASE WHEN '${job}' = 'All' THEN '%%' ELSE '${job}' END) AND COALESCE(metric_labels->>'container', 'N/A') LIKE (CASE WHEN '${container}' = 'All' THEN '%%' ELSE '${container}' END) AND COALESCE(metric_labels->>'pod', 'N/A') LIKE (CASE WHEN '${pod}' = 'All' THEN '%%' ELSE '${pod}' END)",
-          "refId": "A"
-        }
-      ],
-      "title": "KPI Statistics",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "postgres",
-        "uid": "kpi-datasource"
+        "w": 24,
+        "x": 0,
+        "y": 12
       },
       "fieldConfig": {
         "defaults": {
@@ -399,24 +429,9 @@
         },
         "overrides": []
       },
-      "gridPos": {
-        "h": 10,
-        "w": 24,
-        "x": 0,
-        "y": 10
-      },
-      "id": 3,
       "options": {
         "showHeader": true,
         "cellHeight": "sm",
-        "footer": {
-          "show": false,
-          "reducer": [
-            "sum"
-          ],
-          "countRows": false,
-          "fields": ""
-        },
         "sortBy": [
           {
             "displayName": "Avg Value",
@@ -424,7 +439,6 @@
           }
         ]
       },
-      "pluginVersion": "10.0.0",
       "targets": [
         {
           "datasource": {
@@ -432,12 +446,10 @@
             "uid": "kpi-datasource"
           },
           "format": "table",
-          "rawSql": "SELECT metric_labels, ROUND(CAST(AVG(metric_value) AS numeric), 6) AS avg_value, ROUND(CAST(MIN(metric_value) AS numeric), 6) AS min_value, ROUND(CAST(MAX(metric_value) AS numeric), 6) AS max_value, COUNT(*) AS samples FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE timestamp_value >= $__from / 1000 AND timestamp_value < $__to / 1000 AND kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) AND COALESCE(metric_labels->>'node', metric_labels->>'instance', 'N/A') LIKE (CASE WHEN '${node}' = 'All' THEN '%%' ELSE '${node}' END) AND COALESCE(metric_labels->>'job', 'N/A') LIKE (CASE WHEN '${job}' = 'All' THEN '%%' ELSE '${job}' END) AND COALESCE(metric_labels->>'container', 'N/A') LIKE (CASE WHEN '${container}' = 'All' THEN '%%' ELSE '${container}' END) AND COALESCE(metric_labels->>'pod', 'N/A') LIKE (CASE WHEN '${pod}' = 'All' THEN '%%' ELSE '${pod}' END) GROUP BY metric_labels ORDER BY avg_value DESC LIMIT 100",
+          "rawSql": "SELECT metric_labels, ROUND(CAST(AVG(metric_value) AS numeric), 6) AS avg_value, ROUND(CAST(MIN(metric_value) AS numeric), 6) AS min_value, ROUND(CAST(MAX(metric_value) AS numeric), 6) AS max_value, COUNT(*) AS samples FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR metric_labels->>'node' = '${node}' OR metric_labels->>'instance' = '${node}') AND ('${job}' = 'All' OR metric_labels->>'job' = '${job}') AND ('${pod}' = 'All' OR metric_labels->>'pod' = '${pod}') AND ('${container}' = 'All' OR metric_labels->>'container' = '${container}') GROUP BY metric_labels ORDER BY avg_value DESC LIMIT 100",
           "refId": "A"
         }
       ],
-      "title": "Detailed Metrics with All Labels",
-      "type": "table",
       "transformations": [
         {
           "id": "extractFields",
@@ -450,31 +462,23 @@
       ]
     },
     {
+      "id": 5,
+      "type": "barchart",
+      "title": "Query Errors by KPI",
       "datasource": {
         "type": "postgres",
         "uid": "kpi-datasource"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 22
       },
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "fillOpacity": 80,
-            "gradientMode": "none",
-            "hideFrom": {
-              "tooltip": false,
-              "viz": false,
-              "legend": false
-            },
-            "lineWidth": 1,
-            "scaleDistribution": {
-              "type": "linear"
-            }
           },
           "mappings": [],
           "thresholds": {
@@ -497,22 +501,13 @@
         },
         "overrides": []
       },
-      "gridPos": {
-        "h": 8,
-        "w": 24,
-        "x": 0,
-        "y": 20
-      },
-      "id": 5,
       "options": {
         "barRadius": 0,
         "barWidth": 0.97,
         "fullHighlight": false,
         "groupWidth": 0.7,
         "legend": {
-          "calcs": [],
           "displayMode": "list",
-          "placement": "bottom",
           "showLegend": false
         },
         "orientation": "horizontal",
@@ -521,11 +516,8 @@
         "tooltip": {
           "mode": "single",
           "sort": "none"
-        },
-        "xTickLabelRotation": 0,
-        "xTickLabelSpacing": 0
+        }
       },
-      "pluginVersion": "10.0.0",
       "targets": [
         {
           "datasource": {
@@ -533,88 +525,24 @@
             "uid": "kpi-datasource"
           },
           "format": "table",
-          "rawSql": "SELECT kpi_id AS metric, errors AS value FROM query_errors WHERE errors > 0 ORDER BY errors DESC",
+          "rawSql": "SELECT kpi_id AS metric, errors AS value FROM query_errors WHERE errors > 0 ORDER BY errors DESC;",
           "refId": "A"
         }
-      ],
-      "title": "Query Errors by KPI (Static)",
-      "type": "barchart"
+      ]
     },
     {
+      "id": 6,
+      "type": "table",
+      "title": "All KPIs - Summary Statistics",
       "datasource": {
         "type": "postgres",
         "uid": "kpi-datasource"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {
-            "align": "auto",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "inspect": false,
-            "filterable": true
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          }
-        },
-        "overrides": []
       },
       "gridPos": {
         "h": 9,
         "w": 24,
         "x": 0,
-        "y": 28
-      },
-      "id": 6,
-      "options": {
-        "showHeader": true,
-        "cellHeight": "sm",
-        "footer": {
-          "show": false,
-          "reducer": [
-            "sum"
-          ],
-          "countRows": false,
-          "fields": ""
-        },
-        "sortBy": [
-          {
-            "displayName": "KPI ID",
-            "desc": false
-          }
-        ]
-      },
-      "pluginVersion": "10.0.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "postgres",
-            "uid": "kpi-datasource"
-          },
-          "format": "table",
-          "rawSql": "SELECT kpi_id, COUNT(*) AS sample_count, ROUND(CAST(AVG(metric_value) AS numeric), 6) AS avg_value, ROUND(CAST(MIN(metric_value) AS numeric), 6) AS min_value, ROUND(CAST(MAX(metric_value) AS numeric), 6) AS max_value, ROUND(CAST(MAX(metric_value) - MIN(metric_value) AS numeric), 6) AS range, COUNT(DISTINCT metric_labels) AS unique_metrics FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE timestamp_value >= $__from / 1000 AND timestamp_value < $__to / 1000 AND kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) AND COALESCE(metric_labels->>'node', metric_labels->>'instance', 'N/A') LIKE (CASE WHEN '${node}' = 'All' THEN '%%' ELSE '${node}' END) AND COALESCE(metric_labels->>'job', 'N/A') LIKE (CASE WHEN '${job}' = 'All' THEN '%%' ELSE '${job}' END) AND COALESCE(metric_labels->>'container', 'N/A') LIKE (CASE WHEN '${container}' = 'All' THEN '%%' ELSE '${container}' END) AND COALESCE(metric_labels->>'pod', 'N/A') LIKE (CASE WHEN '${pod}' = 'All' THEN '%%' ELSE '${pod}' END) GROUP BY kpi_id ORDER BY kpi_id",
-          "refId": "A"
-        }
-      ],
-      "title": "All KPIs - Summary Statistics",
-      "type": "table"
-    },
-    {
-      "datasource": {
-        "type": "postgres",
-        "uid": "kpi-datasource"
+        "y": 30
       },
       "fieldConfig": {
         "defaults": {
@@ -641,27 +569,19 @@
         },
         "overrides": []
       },
-      "gridPos": {
-        "h": 6,
-        "w": 24,
-        "x": 0,
-        "y": 37
-      },
-      "id": 7,
       "options": {
         "showHeader": true,
         "cellHeight": "sm",
         "footer": {
-          "show": false,
-          "reducer": [
-            "sum"
-          ],
-          "countRows": false,
-          "fields": ""
+          "show": false
         },
-        "sortBy": []
+        "sortBy": [
+          {
+            "displayName": "KPI ID",
+            "desc": false
+          }
+        ]
       },
-      "pluginVersion": "10.0.0",
       "targets": [
         {
           "datasource": {
@@ -669,12 +589,65 @@
             "uid": "kpi-datasource"
           },
           "format": "table",
-          "rawSql": "SELECT c.cluster_name, COALESCE(c.cluster_type, 'N/A') AS cluster_type, COUNT(DISTINCT qr.kpi_id) AS kpi_count, COUNT(qr.metric_value) AS total_samples, MAX(qr.created_at) AS last_collection FROM clusters c LEFT JOIN query_results qr ON c.id = qr.cluster_id AND qr.timestamp_value >= $__from / 1000 AND qr.timestamp_value < $__to / 1000 WHERE COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) GROUP BY c.cluster_name, COALESCE(c.cluster_type, 'N/A') ORDER BY c.cluster_name",
+          "rawSql": "SELECT kpi_id, COUNT(*) AS sample_count, ROUND(CAST(AVG(metric_value) AS numeric), 6) AS avg_value, ROUND(CAST(MIN(metric_value) AS numeric), 6) AS min_value, ROUND(CAST(MAX(metric_value) AS numeric), 6) AS max_value, ROUND(CAST(MAX(metric_value) - MIN(metric_value) AS numeric), 6) AS range, COUNT(DISTINCT metric_labels) AS unique_metrics FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR metric_labels->>'node' = '${node}' OR metric_labels->>'instance' = '${node}') AND ('${job}' = 'All' OR metric_labels->>'job' = '${job}') AND ('${pod}' = 'All' OR metric_labels->>'pod' = '${pod}') AND ('${container}' = 'All' OR metric_labels->>'container' = '${container}') GROUP BY kpi_id ORDER BY kpi_id",
           "refId": "A"
         }
-      ],
-      "title": "Cluster Monitoring Status (Time-Aware Counts)",
-      "type": "table"
+      ]
+    },
+    {
+      "id": 7,
+      "type": "table",
+      "title": "Cluster Monitoring Status",
+      "datasource": {
+        "type": "postgres",
+        "uid": "kpi-datasource"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 39
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "kpi-datasource"
+          },
+          "format": "table",
+          "rawSql": "SELECT c.cluster_name, c.cluster_type, COUNT(DISTINCT qr.kpi_id) AS kpi_count, COUNT(*) AS total_samples, MAX(qr.created_at) AS last_collection FROM clusters c LEFT JOIN query_results qr ON c.id = qr.cluster_id WHERE ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${node}' = 'All' OR qr.metric_labels->>'node' = '${node}' OR qr.metric_labels->>'instance' = '${node}') AND ('${job}' = 'All' OR qr.metric_labels->>'job' = '${job}') AND ('${pod}' = 'All' OR qr.metric_labels->>'pod' = '${pod}') AND ('${container}' = 'All' OR qr.metric_labels->>'container' = '${container}') GROUP BY c.cluster_name, c.cluster_type ORDER BY c.cluster_name",
+          "refId": "A"
+        }
+      ]
     }
   ],
   "refresh": "",
@@ -688,144 +661,191 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "text": "All",
-          "value": "All"
-        },
-        "datasource": {
-          "type": "postgres",
-          "uid": "kpi-datasource"
-        },
-        "definition": "SELECT cluster_type FROM (SELECT 'All' AS cluster_type, 1 AS order_col UNION ALL SELECT DISTINCT COALESCE(cluster_type, 'N/A'), 2 AS order_col FROM clusters) AS temp_data ORDER BY order_col, cluster_type;",
-        "hide": 0,
-        "includeAll": false,
-        "label": "Cluster Type",
-        "multi": false,
         "name": "cluster_type",
-        "options": [],
-        "query": "SELECT cluster_type FROM (SELECT 'All' AS cluster_type, 1 AS order_col UNION ALL SELECT DISTINCT COALESCE(cluster_type, 'N/A'), 2 AS order_col FROM clusters) AS temp_data ORDER BY order_col, cluster_type;",
-        "refresh": 1,
-        "type": "query"
-      },
-      {
-        "current": {
-          "text": "",
-          "value": ""
-        },
+        "type": "query",
+        "label": "Cluster Type",
         "datasource": {
           "type": "postgres",
           "uid": "kpi-datasource"
         },
-        "definition": "SELECT cluster_name FROM (SELECT c.cluster_name, CASE WHEN c.id = (SELECT cluster_id FROM query_results ORDER BY created_at DESC LIMIT 1) THEN 1 ELSE 3 END AS sort_order FROM clusters c WHERE COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) UNION ALL SELECT 'All', 2) AS t ORDER BY sort_order, cluster_name;",
-        "hide": 0,
+        "query": "SELECT cluster_type FROM (SELECT 'All' AS cluster_type, 1 AS sort_order UNION ALL SELECT DISTINCT cluster_type, 2 AS sort_order FROM clusters WHERE cluster_type IS NOT NULL AND cluster_type <> '') AS t ORDER BY sort_order, cluster_type;",
         "includeAll": false,
-        "label": "Cluster",
         "multi": false,
+        "current": {
+          "text": "All",
+          "value": "All"
+        },
+        "refresh": 1
+      },
+      {
         "name": "cluster",
-        "options": [],
-        "query": "SELECT cluster_name FROM (SELECT c.cluster_name, CASE WHEN c.id = (SELECT cluster_id FROM query_results ORDER BY created_at DESC LIMIT 1) THEN 1 ELSE 3 END AS sort_order FROM clusters c WHERE COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) UNION ALL SELECT 'All', 2) AS t ORDER BY sort_order, cluster_name;",
-        "refresh": 1,
-        "type": "query"
-      },
-      {
+        "type": "query",
+        "label": "Cluster",
+        "datasource": {
+          "type": "postgres",
+          "uid": "kpi-datasource"
+        },
+        "query": "SELECT cluster_name FROM (SELECT DISTINCT c.cluster_name, CASE WHEN c.id = (SELECT cluster_id FROM query_results ORDER BY created_at DESC LIMIT 1) THEN 1 ELSE 3 END AS sort_order FROM clusters c WHERE c.cluster_name IS NOT NULL AND c.cluster_name <> '' AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') UNION ALL SELECT 'All', 2) AS t ORDER BY sort_order, cluster_name;",
+        "includeAll": false,
+        "multi": false,
         "current": {
           "text": "",
           "value": ""
         },
-        "datasource": {
-          "type": "postgres",
-          "uid": "kpi-datasource"
-        },
-        "definition": "SELECT kpi_id FROM (SELECT DISTINCT kpi_id, 1 AS sort_order FROM query_results WHERE kpi_id IS NOT NULL AND kpi_id != '' UNION ALL SELECT 'All', 2) AS t ORDER BY sort_order, kpi_id;",
-        "hide": 0,
-        "includeAll": false,
-        "label": "KPI",
-        "multi": false,
+        "refresh": 1
+      },
+      {
         "name": "kpi",
-        "options": [],
-        "query": "SELECT kpi_id FROM (SELECT DISTINCT kpi_id, 1 AS sort_order FROM query_results WHERE kpi_id IS NOT NULL AND kpi_id != '' UNION ALL SELECT 'All', 2) AS t ORDER BY sort_order, kpi_id;",
-        "refresh": 1,
-        "type": "query"
-      },
-      {
-        "current": {
-          "text": "All",
-          "value": "All"
-        },
+        "type": "query",
+        "label": "KPI",
         "datasource": {
           "type": "postgres",
           "uid": "kpi-datasource"
         },
-        "definition": "SELECT node FROM (SELECT 'All' AS node, 1 AS order_col UNION ALL SELECT DISTINCT COALESCE(metric_labels->>'node', metric_labels->>'instance', 'N/A'), 2 AS order_col FROM query_results WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND COALESCE(metric_labels->>'node', metric_labels->>'instance') IS NOT NULL) AS temp_data ORDER BY order_col, node;",
-        "hide": 0,
+        "query": "SELECT kpi_id FROM (SELECT DISTINCT kpi_id, 1 AS sort_order FROM query_results WHERE kpi_id IS NOT NULL AND kpi_id <> '' UNION ALL SELECT 'All', 2) AS t ORDER BY sort_order, kpi_id;",
         "includeAll": false,
-        "label": "Node",
         "multi": false,
+        "current": {
+          "text": "",
+          "value": ""
+        },
+        "refresh": 1
+      },
+      {
         "name": "node",
-        "options": [],
-        "query": "SELECT node FROM (SELECT 'All' AS node, 1 AS order_col UNION ALL SELECT DISTINCT COALESCE(metric_labels->>'node', metric_labels->>'instance', 'N/A'), 2 AS order_col FROM query_results WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND COALESCE(metric_labels->>'node', metric_labels->>'instance') IS NOT NULL) AS temp_data ORDER BY order_col, node;",
-        "refresh": 1,
-        "type": "query"
-      },
-      {
-        "current": {
-          "text": "All",
-          "value": "All"
-        },
+        "type": "query",
+        "label": "Node",
         "datasource": {
           "type": "postgres",
           "uid": "kpi-datasource"
         },
-        "definition": "SELECT job FROM (SELECT 'All' AS job, 1 AS order_col UNION ALL SELECT DISTINCT COALESCE(metric_labels->>'job', 'N/A'), 2 AS order_col FROM query_results WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND metric_labels->>'job' IS NOT NULL) AS temp_data ORDER BY order_col, job;",
-        "hide": 0,
+        "query": "SELECT node FROM (SELECT 'All' AS node, 1 AS sort_order UNION ALL SELECT DISTINCT COALESCE(metric_labels->>'node', metric_labels->>'instance'), 2 FROM query_results WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND metric_labels IS NOT NULL AND COALESCE(metric_labels->>'node', metric_labels->>'instance') IS NOT NULL AND COALESCE(metric_labels->>'node', metric_labels->>'instance') <> '') AS t ORDER BY sort_order, node;",
         "includeAll": false,
-        "label": "Job",
         "multi": false,
+        "current": {
+          "text": "All",
+          "value": "All"
+        },
+        "refresh": 1
+      },
+      {
         "name": "job",
-        "options": [],
-        "query": "SELECT job FROM (SELECT 'All' AS job, 1 AS order_col UNION ALL SELECT DISTINCT COALESCE(metric_labels->>'job', 'N/A'), 2 AS order_col FROM query_results WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND metric_labels->>'job' IS NOT NULL) AS temp_data ORDER BY order_col, job;",
-        "refresh": 1,
-        "type": "query"
-      },
-      {
-        "current": {
-          "text": "All",
-          "value": "All"
-        },
+        "type": "query",
+        "label": "Job",
         "datasource": {
           "type": "postgres",
           "uid": "kpi-datasource"
         },
-        "definition": "SELECT container FROM (SELECT 'All' AS container, 1 AS order_col UNION ALL SELECT DISTINCT COALESCE(metric_labels->>'container', 'N/A'), 2 AS order_col FROM query_results WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND metric_labels->>'container' IS NOT NULL) AS temp_data ORDER BY order_col, container;",
-        "hide": 0,
+        "query": "SELECT job FROM (SELECT 'All' AS job, 1 AS sort_order UNION ALL SELECT DISTINCT metric_labels->>'job', 2 FROM query_results WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND metric_labels IS NOT NULL AND metric_labels->>'job' IS NOT NULL AND metric_labels->>'job' <> '') AS t ORDER BY sort_order, job;",
         "includeAll": false,
-        "label": "Container",
         "multi": false,
-        "name": "container",
-        "options": [],
-        "query": "SELECT container FROM (SELECT 'All' AS container, 1 AS order_col UNION ALL SELECT DISTINCT COALESCE(metric_labels->>'container', 'N/A'), 2 AS order_col FROM query_results WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND metric_labels->>'container' IS NOT NULL) AS temp_data ORDER BY order_col, container;",
-        "refresh": 1,
-        "type": "query"
-      },
-      {
         "current": {
           "text": "All",
           "value": "All"
         },
-        "datasource": {
-          "type": "postgres",
-          "uid": "kpi-datasource"
-        },
-        "definition": "SELECT pod FROM (SELECT 'All' AS pod, 1 AS order_col UNION ALL SELECT DISTINCT COALESCE(metric_labels->>'pod', 'N/A'), 2 AS order_col FROM query_results WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND metric_labels->>'pod' IS NOT NULL) AS temp_data ORDER BY order_col, pod;",
-        "hide": 0,
-        "includeAll": false,
-        "label": "Pod",
-        "multi": false,
+        "refresh": 1
+      },
+      {
         "name": "pod",
-        "options": [],
-        "query": "SELECT pod FROM (SELECT 'All' AS pod, 1 AS order_col UNION ALL SELECT DISTINCT COALESCE(metric_labels->>'pod', 'N/A'), 2 AS order_col FROM query_results WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND metric_labels->>'pod' IS NOT NULL) AS temp_data ORDER BY order_col, pod;",
+        "type": "query",
+        "label": "Pod",
+        "datasource": {
+          "type": "postgres",
+          "uid": "kpi-datasource"
+        },
+        "query": "SELECT pod FROM (SELECT 'All' AS pod, 1 AS sort_order UNION ALL SELECT DISTINCT metric_labels->>'pod', 2 FROM query_results WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND metric_labels IS NOT NULL AND metric_labels->>'pod' IS NOT NULL AND metric_labels->>'pod' <> '') AS t ORDER BY sort_order, pod;",
+        "includeAll": false,
+        "multi": false,
+        "current": {
+          "text": "All",
+          "value": "All"
+        },
+        "refresh": 1
+      },
+      {
+        "name": "container",
+        "type": "query",
+        "label": "Container",
+        "datasource": {
+          "type": "postgres",
+          "uid": "kpi-datasource"
+        },
+        "query": "SELECT container FROM (SELECT 'All' AS container, 1 AS sort_order UNION ALL SELECT DISTINCT metric_labels->>'container', 2 FROM query_results WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND metric_labels IS NOT NULL AND metric_labels->>'container' IS NOT NULL AND metric_labels->>'container' <> '') AS t ORDER BY sort_order, container;",
+        "includeAll": false,
+        "multi": false,
+        "current": {
+          "text": "All",
+          "value": "All"
+        },
+        "refresh": 1
+      },
+      {
+        "name": "samples_count",
+        "type": "query",
+        "datasource": {
+          "type": "postgres",
+          "uid": "kpi-datasource"
+        },
+        "query": "SELECT COALESCE(COUNT(*), 0) FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR metric_labels->>'node' = '${node}' OR metric_labels->>'instance' = '${node}') AND ('${job}' = 'All' OR metric_labels->>'job' = '${job}') AND ('${pod}' = 'All' OR metric_labels->>'pod' = '${pod}') AND ('${container}' = 'All' OR metric_labels->>'container' = '${container}')",
+        "includeAll": false,
+        "multi": false,
+        "current": {
+          "text": "",
+          "value": ""
+        },
         "refresh": 1,
-        "type": "query"
+        "hide": 2
+      },
+      {
+        "name": "avg_value",
+        "type": "query",
+        "datasource": {
+          "type": "postgres",
+          "uid": "kpi-datasource"
+        },
+        "query": "SELECT COALESCE(ROUND(CAST(AVG(metric_value) AS numeric), 6)::text, 'N/A') FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR metric_labels->>'node' = '${node}' OR metric_labels->>'instance' = '${node}') AND ('${job}' = 'All' OR metric_labels->>'job' = '${job}') AND ('${pod}' = 'All' OR metric_labels->>'pod' = '${pod}') AND ('${container}' = 'All' OR metric_labels->>'container' = '${container}')",
+        "includeAll": false,
+        "multi": false,
+        "current": {
+          "text": "",
+          "value": ""
+        },
+        "refresh": 1,
+        "hide": 2
+      },
+      {
+        "name": "min_value",
+        "type": "query",
+        "datasource": {
+          "type": "postgres",
+          "uid": "kpi-datasource"
+        },
+        "query": "SELECT COALESCE(ROUND(CAST(MIN(metric_value) AS numeric), 6)::text, 'N/A') FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR metric_labels->>'node' = '${node}' OR metric_labels->>'instance' = '${node}') AND ('${job}' = 'All' OR metric_labels->>'job' = '${job}') AND ('${pod}' = 'All' OR metric_labels->>'pod' = '${pod}') AND ('${container}' = 'All' OR metric_labels->>'container' = '${container}')",
+        "includeAll": false,
+        "multi": false,
+        "current": {
+          "text": "",
+          "value": ""
+        },
+        "refresh": 1,
+        "hide": 2
+      },
+      {
+        "name": "max_value",
+        "type": "query",
+        "datasource": {
+          "type": "postgres",
+          "uid": "kpi-datasource"
+        },
+        "query": "SELECT COALESCE(ROUND(CAST(MAX(metric_value) AS numeric), 6)::text, 'N/A') FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR metric_labels->>'node' = '${node}' OR metric_labels->>'instance' = '${node}') AND ('${job}' = 'All' OR metric_labels->>'job' = '${job}') AND ('${pod}' = 'All' OR metric_labels->>'pod' = '${pod}') AND ('${container}' = 'All' OR metric_labels->>'container' = '${container}')",
+        "includeAll": false,
+        "multi": false,
+        "current": {
+          "text": "",
+          "value": ""
+        },
+        "refresh": 1,
+        "hide": 2
       },
       {
         "name": "data_start",
@@ -834,15 +854,13 @@
           "type": "postgres",
           "uid": "kpi-datasource"
         },
-        "query": "SELECT COALESCE(CAST(MIN(timestamp_value) * 1000 AS BIGINT), 0) FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END)",
-        "definition": "SELECT COALESCE(CAST(MIN(timestamp_value) * 1000 AS BIGINT), 0) FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END)",
+        "query": "SELECT COALESCE(CAST(MIN(timestamp_value) * 1000 AS BIGINT), 0) FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}')",
         "includeAll": false,
         "multi": false,
         "current": {
           "text": "",
           "value": ""
         },
-        "options": [],
         "refresh": 1,
         "hide": 2
       },
@@ -853,15 +871,13 @@
           "type": "postgres",
           "uid": "kpi-datasource"
         },
-        "query": "SELECT COALESCE(CAST(MAX(timestamp_value) * 1000 AS BIGINT), 0) FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END)",
-        "definition": "SELECT COALESCE(CAST(MAX(timestamp_value) * 1000 AS BIGINT), 0) FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END)",
+        "query": "SELECT COALESCE(CAST(MAX(timestamp_value) * 1000 AS BIGINT), 0) FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}')",
         "includeAll": false,
         "multi": false,
         "current": {
           "text": "",
           "value": ""
         },
-        "options": [],
         "refresh": 1,
         "hide": 2
       }
@@ -871,8 +887,10 @@
     "from": "now-24h",
     "to": "now"
   },
-  "title": "KPI Collection Tool - Dynamic Dashboard (PostgreSQL)",
+  "timepicker": {},
+  "timezone": "",
+  "title": "KPI Collection Tool - Dynamic Dashboard",
   "uid": "kpi-collector-dynamic",
-  "version": 83,
+  "version": 3,
   "weekStart": ""
 }

--- a/hack/e2e-postgres.sh
+++ b/hack/e2e-postgres.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+#
+# End-to-end test: PostgreSQL + kpi-collector + Grafana
+#
+# Spins up a PostgreSQL container, runs kpi-collector against a local
+# Prometheus/Thanos endpoint with PostgreSQL as the database backend,
+# then launches Grafana pointed at that database.
+#
+# Prerequisites:
+#   - docker or podman
+#   - A kubeconfig with access to an OpenShift/K8s cluster
+#   - kpi-collector binary (built via `make build`)
+#
+# Usage:
+#   ./hack/e2e-postgres.sh                                    # defaults (~/.kube/config)
+#   KUBECONFIG=/path/to/kubeconfig ./hack/e2e-postgres.sh     # custom kubeconfig
+#   ./hack/e2e-postgres.sh --cleanup                          # tear everything down
+
+set -euo pipefail
+
+# ── Configuration (override via environment) ─────────────────────────
+PG_CONTAINER="${PG_CONTAINER:-kpi-postgres}"
+PG_PORT="${PG_PORT:-5433}"
+PG_USER="${PG_USER:-kpi}"
+PG_PASSWORD="${PG_PASSWORD:-kpi}"
+PG_DB="${PG_DB:-kpi_metrics}"
+PG_IMAGE="${PG_IMAGE:-postgres:16-alpine}"
+
+KUBECONFIG="${KUBECONFIG:-${HOME}/.kube/config}"
+CLUSTER_NAME="${CLUSTER_NAME:-e2e-test}"
+CLUSTER_TYPE="${CLUSTER_TYPE:-ran}"
+GRAFANA_PORT="${GRAFANA_PORT:-3000}"
+INSECURE_TLS="${INSECURE_TLS:-true}"
+
+PG_URL="postgresql://${PG_USER}:${PG_PASSWORD}@localhost:${PG_PORT}/${PG_DB}?sslmode=disable"
+# Grafana runs in a container — it needs a host-reachable address, not localhost
+PG_URL_GRAFANA="postgresql://${PG_USER}:${PG_PASSWORD}@host.docker.internal:${PG_PORT}/${PG_DB}?sslmode=disable"
+KPI_COLLECTOR="./kpi-collector"
+KPI_FILE="${KPI_FILE:-hack/kpis-e2e-postgres.yaml}"
+
+# ── Detect container runtime ─────────────────────────────────────────
+detect_runtime() {
+    if command -v podman &>/dev/null && podman info &>/dev/null; then
+        echo "podman"
+    elif command -v docker &>/dev/null && docker info &>/dev/null; then
+        echo "docker"
+    else
+        echo "ERROR: no working container runtime found (tried podman, docker)" >&2
+        exit 1
+    fi
+}
+
+RUNTIME="$(detect_runtime)"
+echo "Container runtime: ${RUNTIME}"
+
+# ── Cleanup mode ─────────────────────────────────────────────────────
+cleanup() {
+    echo ""
+    echo "=== Cleaning up ==="
+    ${RUNTIME} stop "${PG_CONTAINER}" 2>/dev/null || true
+    ${RUNTIME} rm -f "${PG_CONTAINER}" 2>/dev/null || true
+    ${KPI_COLLECTOR} grafana stop 2>/dev/null || true
+    echo "Done."
+}
+
+if [[ "${1:-}" == "--cleanup" ]]; then
+    cleanup
+    exit 0
+fi
+
+trap cleanup EXIT
+
+# ── Pre-flight checks ────────────────────────────────────────────────
+if [[ ! -x "${KPI_COLLECTOR}" ]]; then
+    echo "Binary not found at ${KPI_COLLECTOR} — building..."
+    make build
+fi
+
+if [[ ! -f "${KUBECONFIG}" ]]; then
+    echo "ERROR: kubeconfig not found: ${KUBECONFIG}" >&2
+    exit 1
+fi
+
+if [[ ! -f "${KPI_FILE}" ]]; then
+    echo "ERROR: KPI file not found: ${KPI_FILE}" >&2
+    exit 1
+fi
+
+# ── Step 1: Start PostgreSQL ─────────────────────────────────────────
+echo ""
+echo "=== Step 1: Starting PostgreSQL (${PG_CONTAINER}) ==="
+${RUNTIME} stop "${PG_CONTAINER}" 2>/dev/null || true
+${RUNTIME} rm -f "${PG_CONTAINER}" 2>/dev/null || true
+
+${RUNTIME} run -d \
+    --name "${PG_CONTAINER}" \
+    -p "${PG_PORT}:5432" \
+    -e "POSTGRES_USER=${PG_USER}" \
+    -e "POSTGRES_PASSWORD=${PG_PASSWORD}" \
+    -e "POSTGRES_DB=${PG_DB}" \
+    "${PG_IMAGE}"
+
+echo "Waiting for PostgreSQL to be ready..."
+for i in $(seq 1 30); do
+    if ${RUNTIME} exec "${PG_CONTAINER}" pg_isready -U "${PG_USER}" &>/dev/null; then
+        echo "PostgreSQL is ready (attempt ${i})"
+        break
+    fi
+    if [[ "${i}" -eq 30 ]]; then
+        echo "ERROR: PostgreSQL failed to start within 30 seconds" >&2
+        exit 1
+    fi
+    sleep 1
+done
+
+# ── Step 2: Collect KPIs ─────────────────────────────────────────────
+echo ""
+echo "=== Step 2: Collecting KPIs ==="
+echo "  Kubeconfig : ${KUBECONFIG}"
+echo "  Cluster    : ${CLUSTER_NAME} (${CLUSTER_TYPE})"
+echo "  Database   : PostgreSQL @ localhost:${PG_PORT}/${PG_DB}"
+echo "  KPI file   : ${KPI_FILE}"
+echo ""
+
+RUN_ARGS=(
+    --cluster-name "${CLUSTER_NAME}"
+    --cluster-type "${CLUSTER_TYPE}"
+    --kubeconfig "${KUBECONFIG}"
+    --kpis-file "${KPI_FILE}"
+    --db-type postgres
+    --postgres-url "${PG_URL}"
+    --once
+)
+
+if [[ "${INSECURE_TLS}" == "true" ]]; then
+    RUN_ARGS+=(--insecure-tls)
+fi
+
+${KPI_COLLECTOR} run "${RUN_ARGS[@]}"
+
+# ── Step 3: Verify data ──────────────────────────────────────────────
+echo ""
+echo "=== Step 3: Verifying stored data ==="
+
+echo "--- Clusters ---"
+${KPI_COLLECTOR} db show clusters \
+    --db-type postgres --postgres-url "${PG_URL}"
+
+echo ""
+echo "--- KPIs ---"
+${KPI_COLLECTOR} db show kpis \
+    --db-type postgres --postgres-url "${PG_URL}"
+
+echo ""
+echo "--- Errors ---"
+${KPI_COLLECTOR} db show errors \
+    --db-type postgres --postgres-url "${PG_URL}"
+
+# ── Step 4: Start Grafana ────────────────────────────────────────────
+echo ""
+echo "=== Step 4: Starting Grafana ==="
+${KPI_COLLECTOR} grafana start \
+    --datasource=postgres \
+    --postgres-url "${PG_URL_GRAFANA}" \
+    --port "${GRAFANA_PORT}"
+
+# ── Done ─────────────────────────────────────────────────────────────
+echo ""
+echo "============================================"
+echo "  E2E setup complete!"
+echo ""
+echo "  PostgreSQL : localhost:${PG_PORT} (${PG_USER}/${PG_PASSWORD})"
+echo "  Grafana    : http://localhost:${GRAFANA_PORT} (admin/admin)"
+echo ""
+echo "  To tear down:  ./hack/e2e-postgres.sh --cleanup"
+echo "============================================"
+
+trap - EXIT

--- a/hack/kpis-e2e-postgres.yaml
+++ b/hack/kpis-e2e-postgres.yaml
@@ -1,0 +1,19 @@
+# KPI file for e2e-postgres.sh — range queries with short time windows.
+# Results appear quickly even on freshly started clusters.
+
+kpis:
+  # CPU usage over the last 10 minutes with 1-minute resolution.
+  - id: node-cpu-usage-range
+    promquery: avg by (instance) (rate(node_cpu_seconds_total{mode!="idle"}[5m]))
+    query-type: range
+    range:
+      since: 10m
+      step: 1m
+
+  # Memory utilization over the last 5 minutes with 30-second steps.
+  - id: node-memory-range
+    promquery: 1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)
+    query-type: range
+    range:
+      since: 5m
+      step: 30s


### PR DESCRIPTION


- Synchronized the PostgreSQL Grafana dashboard (`postgres-dashboard.json`) with the SQLite dashboard so both have identical layout, panel settings, and UX.

- Added `hack/e2e-postgres.sh` - a developer script that spins up a PostgreSQL container, runs `kpi-collector` against it, and launches Grafana pointed at the database

- Added `hack/kpis-e2e-postgres.yaml` - a minimal KPI file with range queries (short time windows) for quick e2e validation
