### PR TITLE
fix: use per-query timeouts, increase --once token duration, and add query timing logs

### DIFF
--- a/internal/commands/run.go
+++ b/internal/commands/run.go
@@ -219,14 +219,18 @@ func databaseLocation(flags config.InputFlags) string {
 }
 
 // tokenDurationForCollection returns the token expiration to use when creating
-// a service-account token via kubeconfig.  In single-run mode the token
-// is short-lived (10 min); otherwise it matches the collection duration
-// plus a 10-minute buffer so it won't expire mid-collection.
+// a service-account token via kubeconfig.
+//
+// For periodic collection the token covers the full duration plus a buffer.
+// For single-run mode a fixed 1-hour window is used — generous enough for
+// heavy range queries while still short-lived.
 func tokenDurationForCollection(isSingleRun bool, collectionDuration time.Duration) time.Duration {
+	const buffer = 10 * time.Minute
+
 	if isSingleRun {
-		return 10 * time.Minute
+		return 1 * time.Hour
 	}
-	return collectionDuration + 10*time.Minute
+	return collectionDuration + buffer
 }
 
 // substituteCPUsIfNeeded checks if queries contain CPU placeholders and if so,

--- a/internal/prometheus/client.go
+++ b/internal/prometheus/client.go
@@ -26,9 +26,11 @@ import (
 )
 
 const (
-	// queryTimeoutPerKPI is the maximum time allowed for each individual KPI query.
-	// The total context timeout is calculated as: numberOfQueries * queryTimeoutPerKPI
-	queryTimeoutPerKPI = 5 * time.Second
+	// Instant queries are lightweight — 30 seconds is generous.
+	instantQueryTimeout = 30 * time.Second
+	// Range queries can scan hours of data; allow up to 10 minutes for the
+	// Prometheus/Thanos HTTP call. Database storage runs separately without a timeout.
+	rangeQueryTimeout = 10 * time.Minute
 )
 
 // setupPromClient creates and configures a Prometheus API client.
@@ -81,11 +83,6 @@ func RunQueries(kpisToRun config.KPIs, flags config.InputFlags, sampleNumber int
 		return fmt.Errorf("failed to create client: %v", err)
 	}
 
-	// Execute queries with a timeout proportional to the number of queries
-	totalTimeout := time.Duration(len(kpisToRun.Queries)) * queryTimeoutPerKPI
-	ctx, cancel := context.WithTimeout(context.Background(), totalTimeout)
-	defer cancel()
-
 	var failedCount int
 	for _, query := range kpisToRun.Queries {
 		queryInfo := output.QueryInfo{
@@ -110,9 +107,17 @@ func RunQueries(kpisToRun config.KPIs, flags config.InputFlags, sampleNumber int
 				queryInfo.Until = now
 			}
 		}
-		if !executeQuery(ctx, v1api, db, dbImpl, clusterID, queryInfo) {
+
+		timeout := instantQueryTimeout
+		if queryInfo.QueryType == "range" {
+			timeout = rangeQueryTimeout
+		}
+		queryCtx, queryCancel := context.WithTimeout(context.Background(), timeout)
+
+		if !executeQuery(queryCtx, v1api, db, dbImpl, clusterID, queryInfo) {
 			failedCount++
 		}
+		queryCancel()
 	}
 
 	if failedCount > 0 {
@@ -125,7 +130,7 @@ func RunQueries(kpisToRun config.KPIs, flags config.InputFlags, sampleNumber int
 // executeQuery executes a single Prometheus query, handles the result,
 // and returns true if the query succeeded.
 func executeQuery(ctx context.Context, v1api promv1.API, db *sql.DB, dbImpl database.Database, clusterID int64, info output.QueryInfo) bool {
-	now := time.Now()
+	queryStart := time.Now()
 
 	var (
 		result   model.Value
@@ -133,7 +138,8 @@ func executeQuery(ctx context.Context, v1api promv1.API, db *sql.DB, dbImpl data
 		err      error
 	)
 
-	// Execute query using the Prometheus client library
+	log.Printf("[%s] Prometheus query starting", info.QueryID)
+
 	if info.QueryType == "range" {
 		queryRange := promv1.Range{
 			Start: info.Since,
@@ -142,8 +148,11 @@ func executeQuery(ctx context.Context, v1api promv1.API, db *sql.DB, dbImpl data
 		}
 		result, warnings, err = v1api.QueryRange(ctx, info.PromQuery, queryRange)
 	} else {
-		result, warnings, err = v1api.Query(ctx, info.PromQuery, now)
+		result, warnings, err = v1api.Query(ctx, info.PromQuery, queryStart)
 	}
+
+	promDuration := time.Since(queryStart)
+	log.Printf("[%s] Prometheus query completed in %s", info.QueryID, promDuration.Round(time.Millisecond))
 
 	queryResult := output.QueryResult{
 		Warnings: warnings,
@@ -159,11 +168,9 @@ func executeQuery(ctx context.Context, v1api promv1.API, db *sql.DB, dbImpl data
 		return false
 	}
 
-	// Filter out NaN/Inf values
 	var nanCount int
 	result, nanCount = filterNaNValues(result)
 
-	// Check if anything remains to store
 	if isEmptyResult(result) {
 		queryResult.Success = true
 		output.PrintQueryResult(info, queryResult)
@@ -177,8 +184,12 @@ func executeQuery(ctx context.Context, v1api promv1.API, db *sql.DB, dbImpl data
 		return true
 	}
 
-	// Store results
+	log.Printf("[%s] Database write starting", info.QueryID)
+	storeStart := time.Now()
 	err = dbImpl.StoreQueryResults(db, clusterID, info.QueryID, result)
+	storeDuration := time.Since(storeStart)
+	log.Printf("[%s] Database write completed in %s", info.QueryID, storeDuration.Round(time.Millisecond))
+
 	if err != nil {
 		queryResult.Success = false
 		queryResult.Error = fmt.Errorf("failed to store: %v", err)
@@ -188,6 +199,12 @@ func executeQuery(ctx context.Context, v1api promv1.API, db *sql.DB, dbImpl data
 
 	queryResult.Success = true
 	output.PrintQueryResult(info, queryResult)
+
+	totalDuration := time.Since(queryStart)
+	log.Printf("[%s] Total: %s (query=%s, store=%s)",
+		info.QueryID, totalDuration.Round(time.Millisecond),
+		promDuration.Round(time.Millisecond), storeDuration.Round(time.Millisecond))
+
 	if nanCount > 0 {
 		fmt.Printf("  Note: skipped %d NaN value(s)\n", nanCount)
 		log.Printf("[%s] Skipped %d NaN/Inf value(s): %s", info.QueryID, nanCount, info.PromQuery)


### PR DESCRIPTION
### Summary
- Replace the shared query context (5s × numQueries budget) with independent
  per-query timeouts: 30s for instant queries, 10min for range queries. A slow
  range query no longer starves subsequent queries with `context deadline exceeded`.
- Increase the `--once` mode service-account token duration from 10 minutes to
  1 hour, preventing token expiry mid-collection when running many heavy range
  queries sequentially.
- Add per-query timing logs that break down Prometheus fetch vs database write
  duration, making it easy to identify bottlenecks in heavy collection runs.

### Problems
Running `kpi-collector run --once` with many range queries (e.g., 25 KPIs over
a 20h window) failed because:
1. All queries shared a single context with a total budget of `5s * N`. One
   slow query consumed the entire budget, causing all remaining queries to fail
   with `context deadline exceeded`.
2. The 10-minute token expired before all queries could complete, causing auth
   failures that surfaced as timeout errors.
3. When a query took 19 minutes total, there was no way to tell whether the
   time was spent in the Prometheus call or the database write.