### PR TITLE
Per-category tables: read path and uncategorized KPI warning

### DIFF
--- a/internal/commands/db_remove.go
+++ b/internal/commands/db_remove.go
@@ -13,6 +13,7 @@ import (
 var (
 	removeClusterName string
 	removeKPIName     string
+	removeCategory    string
 	removeAll         bool
 )
 
@@ -38,12 +39,18 @@ WARNING: This operation cannot be undone. All metric samples for the cluster wil
 var removeKPIsCmd = &cobra.Command{
 	Use:   "kpis",
 	Short: "Remove KPI metrics",
-	Long:  `Delete KPI metrics from the database, optionally filtered by cluster and KPI name.`,
+	Long: `Delete KPI metrics from the database, filtered by cluster, KPI name, or category.
+
+When --category is used, all data in that category table is removed along with
+the registry entries. This is independent of the --cluster-name flag.`,
 	Example: `  # Remove all KPIs from a cluster
   kpi-collector db remove kpis --cluster-name="mycluster1"
   
   # Remove specific KPI from a cluster
-  kpi-collector db remove kpis --cluster-name="mycluster1" --name="cpu-system"`,
+  kpi-collector db remove kpis --cluster-name="mycluster1" --name="cpu-system"
+
+  # Remove all data for a category
+  kpi-collector db remove kpis --category=cpu`,
 	RunE: runRemoveKPIs,
 }
 
@@ -72,10 +79,11 @@ func init() {
 
 	// Flags for 'remove kpis'
 	removeKPIsCmd.Flags().StringVar(&removeClusterName, "cluster-name", "",
-		"cluster name (required)")
+		"cluster name (required unless --category is used)")
 	removeKPIsCmd.Flags().StringVar(&removeKPIName, "name", "",
 		"KPI name to remove (optional)")
-	_ = removeKPIsCmd.MarkFlagRequired("cluster-name")
+	removeKPIsCmd.Flags().StringVar(&removeCategory, "category", "",
+		"remove all data for a category (e.g. cpu, memory)")
 
 	// Flags for 'remove errors'
 	removeErrorsCmd.Flags().StringVar(&removeKPIName, "name", "",
@@ -112,11 +120,29 @@ func runRemoveClusters(cmd *cobra.Command, args []string) error {
 }
 
 func runRemoveKPIs(cmd *cobra.Command, args []string) error {
+	// user must provide the cluster namr OR a category to remove KPIs
+	if removeCategory == "" && removeClusterName == "" {
+		return fmt.Errorf("must specify either --cluster-name or --category")
+	}
+
 	db, dbImpl, err := connectToDB()
 	if err != nil {
 		return fmt.Errorf("failed to connect to DB: %w", err)
 	}
 	defer func() { _ = db.Close() }()
+
+	if removeCategory != "" {
+		deleted, err := dbImpl.DeleteByCategory(db, removeCategory)
+		if err != nil {
+			return fmt.Errorf("failed to delete category '%s': %w", removeCategory, err)
+		}
+		if deleted == 0 {
+			fmt.Printf("No metrics found for category '%s'.\n", removeCategory)
+			return nil
+		}
+		fmt.Printf("✓ Deleted %s metric samples from category '%s'.\n", humanize.Comma(deleted), removeCategory)
+		return nil
+	}
 
 	_, deleted, err := deleteClusterMetrics(db, dbImpl, removeClusterName, removeKPIName)
 	if err != nil {
@@ -180,23 +206,33 @@ func deleteClusterMetrics(db *sql.DB, dbImpl database.Database, clusterName, kpi
 	}
 	cluster := clusters[0]
 
-	query := "DELETE FROM query_results WHERE cluster_id = $1"
-	queryArgs := []interface{}{cluster.ID}
-
-	if kpiName != "" {
-		query += " AND kpi_id = $2"
-		queryArgs = append(queryArgs, kpiName)
-	}
-
-	if _, ok := dbImpl.(*database.SQLiteDB); ok {
-		query = convertPostgresToSQLitePlaceholders(query)
-	}
-
-	result, err := db.Exec(query, queryArgs...)
+	tables, err := allCategoryTables(db, dbImpl)
 	if err != nil {
-		return nil, 0, fmt.Errorf("failed to delete metrics: %w", err)
+		return nil, 0, fmt.Errorf("list tables: %w", err)
 	}
 
-	deleted, _ := result.RowsAffected()
-	return &cluster, deleted, nil
+	var totalDeleted int64
+	for _, t := range tables {
+		query := fmt.Sprintf("DELETE FROM %s WHERE cluster_id = $1", t.TableName)
+		queryArgs := []interface{}{cluster.ID}
+
+		if kpiName != "" {
+			query += " AND kpi_id = $2"
+			queryArgs = append(queryArgs, kpiName)
+		}
+
+		if _, ok := dbImpl.(*database.SQLiteDB); ok {
+			query = convertPostgresToSQLitePlaceholders(query)
+		}
+
+		result, err := db.Exec(query, queryArgs...)
+		if err != nil {
+			return nil, totalDeleted, fmt.Errorf("failed to delete from %s: %w", t.TableName, err)
+		}
+
+		deleted, _ := result.RowsAffected()
+		totalDeleted += deleted
+	}
+
+	return &cluster, totalDeleted, nil
 }

--- a/internal/commands/db_show.go
+++ b/internal/commands/db_show.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -16,6 +17,7 @@ import (
 // kpiQueryFlags holds the flags for the 'show kpis' command
 var kpiQueryFlags struct {
 	kpiName      string
+	category     string
 	clusterName  string
 	labelsFilter string
 	since        string
@@ -40,11 +42,14 @@ var showCmd = &cobra.Command{
 var showKPIsCmd = &cobra.Command{
 	Use:   "kpis",
 	Short: "Show KPI metrics",
-	Long: `Query and display KPI metrics with optional filtering by name, cluster, labels, and time range.
+	Long: `Query and display KPI metrics with optional filtering by name, category, cluster, labels, and time range.
 
 The results can be displayed in table, JSON, or CSV format.`,
 	Example: `  # Show all metrics for a KPI
   kpi-collector db show kpis --name="cpu-system"
+  
+  # Show all metrics in a category
+  kpi-collector db show kpis --category=cpu
   
   # Filter by cluster
   kpi-collector db show kpis --name="cpu-system" --cluster-name="mycluster1"
@@ -99,6 +104,8 @@ func init() {
 	// Flags for 'show kpis'
 	showKPIsCmd.Flags().StringVar(&kpiQueryFlags.kpiName, "name", "",
 		"KPI name to filter by")
+	showKPIsCmd.Flags().StringVar(&kpiQueryFlags.category, "category", "",
+		"category to filter by (e.g. cpu, memory, network)")
 	showKPIsCmd.Flags().StringVar(&kpiQueryFlags.clusterName, "cluster-name", "",
 		"cluster name to filter by")
 	showKPIsCmd.Flags().StringVar(&kpiQueryFlags.labelsFilter, "labels-filter", "",
@@ -122,6 +129,12 @@ func init() {
 }
 
 func runShowKPIs(cmd *cobra.Command, args []string) error {
+	if kpiQueryFlags.kpiName != "" && kpiQueryFlags.category != "" {
+		return fmt.Errorf("--name and --category cannot be used together: " +
+			"--name looks up a specific KPI (auto-discovers its table), " +
+			"--category queries all KPIs in a category")
+	}
+
 	// Parse output format first (fail fast if invalid)
 	format, err := output.ParseFormat(kpiQueryFlags.outputFormat)
 	if err != nil {
@@ -163,6 +176,7 @@ func runShowKPIs(cmd *cobra.Command, args []string) error {
 	// Build query parameters
 	params := KPIQueryParams{
 		KPIName:      kpiQueryFlags.kpiName,
+		Category:     kpiQueryFlags.category,
 		ClusterName:  kpiQueryFlags.clusterName,
 		LabelFilters: labelFilters,
 		Since:        sinceTime,
@@ -277,6 +291,7 @@ func parseLabelFilters(filterStr string) (map[string]string, error) {
 type KPIResult struct {
 	ID             int64
 	KPIName        string
+	Category       string
 	ClusterName    string
 	MetricValue    float64
 	TimestampValue float64
@@ -286,6 +301,7 @@ type KPIResult struct {
 
 type KPIQueryParams struct {
 	KPIName      string
+	Category     string
 	ClusterName  string
 	LabelFilters map[string]string
 	Since        *time.Time
@@ -295,13 +311,80 @@ type KPIQueryParams struct {
 }
 
 func queryKPIs(db *sql.DB, dbImpl database.Database, params KPIQueryParams) ([]KPIResult, error) {
-	query := `
-		SELECT qr.id, qr.kpi_id, c.cluster_name, qr.metric_value, 
+	if params.KPIName != "" {
+		return queryByName(db, dbImpl, params)
+	}
+	if params.Category != "" {
+		return queryByCategory(db, dbImpl, params)
+	}
+	return queryAll(db, dbImpl, params)
+}
+
+// queryByName resolves which table holds the KPI via the registry and queries it.
+func queryByName(db *sql.DB, dbImpl database.Database, params KPIQueryParams) ([]KPIResult, error) {
+	category, tableName, err := dbImpl.LookupCategoryForKPI(db, params.KPIName)
+	if err != nil {
+		return nil, fmt.Errorf("lookup KPI %q: %w", params.KPIName, err)
+	}
+	if tableName == "" {
+		tableName = database.DefaultTableName
+	}
+	return queryFromTable(db, dbImpl, tableName, category, params)
+}
+
+// queryByCategory queries the single category-specific table.
+func queryByCategory(db *sql.DB, dbImpl database.Database, params KPIQueryParams) ([]KPIResult, error) {
+	tableName := database.CategoryTableName(params.Category)
+	return queryFromTable(db, dbImpl, tableName, params.Category, params)
+}
+
+// allCategoryTables returns the default table plus every registered category table.
+func allCategoryTables(db *sql.DB, dbImpl database.Database) ([]database.CategoryInfo, error) {
+	categories, err := dbImpl.ListCategories(db)
+	if err != nil {
+		return nil, err
+	}
+	all := make([]database.CategoryInfo, 0, 1+len(categories))
+	all = append(all, database.CategoryInfo{TableName: database.DefaultTableName})
+	all = append(all, categories...)
+	return all, nil
+}
+
+// queryAll scans every known table (default + all categories), merges, sorts, and limits.
+// Sort and limit must happen here (not in SQL) because rows come from separate tables —
+// we can't know the global ordering or which rows survive the limit until all tables are merged.
+func queryAll(db *sql.DB, dbImpl database.Database, params KPIQueryParams) ([]KPIResult, error) {
+	tables, err := allCategoryTables(db, dbImpl)
+	if err != nil {
+		return nil, fmt.Errorf("list tables: %w", err)
+	}
+
+	var results []KPIResult
+	for _, t := range tables {
+		rows, err := queryFromTable(db, dbImpl, t.TableName, t.Category, params)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, rows...)
+	}
+
+	sortResults(results, params.Sort)
+
+	if params.Limit > 0 && len(results) > params.Limit {
+		results = results[:params.Limit]
+	}
+
+	return results, nil
+}
+
+func queryFromTable(db *sql.DB, dbImpl database.Database, tableName, category string, params KPIQueryParams) ([]KPIResult, error) {
+	query := fmt.Sprintf(`
+		SELECT qr.id, qr.kpi_id, c.cluster_name, qr.metric_value,
 		       qr.timestamp_value, qr.execution_time, qr.metric_labels
-		FROM query_results qr
+		FROM %s qr
 		JOIN clusters c ON qr.cluster_id = c.id
 		WHERE 1=1
-	`
+	`, tableName)
 
 	args := []interface{}{}
 	argIndex := 1
@@ -330,18 +413,6 @@ func queryKPIs(db *sql.DB, dbImpl database.Database, params KPIQueryParams) ([]K
 		argIndex++
 	}
 
-	if params.Sort == "desc" {
-		query += " ORDER BY qr.execution_time DESC"
-	} else {
-		query += " ORDER BY qr.execution_time ASC"
-	}
-
-	if params.Limit > 0 {
-		query += fmt.Sprintf(" LIMIT $%d", argIndex)
-		args = append(args, params.Limit)
-	}
-
-	// Convert placeholders for SQLite
 	if _, ok := dbImpl.(*database.SQLiteDB); ok {
 		query = convertPostgresToSQLitePlaceholders(query)
 	}
@@ -360,18 +431,25 @@ func queryKPIs(db *sql.DB, dbImpl database.Database, params KPIQueryParams) ([]K
 		if err != nil {
 			return nil, err
 		}
+		r.Category = category
 
-		// Apply label filters
-		if len(params.LabelFilters) > 0 {
-			if !matchesLabelFilters(r.MetricLabels, params.LabelFilters) {
-				continue
-			}
+		if len(params.LabelFilters) > 0 && !matchesLabelFilters(r.MetricLabels, params.LabelFilters) {
+			continue
 		}
 
 		results = append(results, r)
 	}
 
 	return results, rows.Err()
+}
+
+func sortResults(results []KPIResult, order string) {
+	sort.Slice(results, func(i, j int) bool {
+		if order == "desc" {
+			return results[i].ExecutionTime.After(results[j].ExecutionTime)
+		}
+		return results[i].ExecutionTime.Before(results[j].ExecutionTime)
+	})
 }
 
 func matchesLabelFilters(labelsJSON string, filters map[string]string) bool {
@@ -397,41 +475,61 @@ type ClusterInfo struct {
 }
 
 func listClusters(db *sql.DB, dbImpl database.Database, clusterName string) ([]ClusterInfo, error) {
-	query := `
-		SELECT c.id, c.cluster_name, c.created_at, COUNT(qr.id) as total_metrics
-		FROM clusters c
-		LEFT JOIN query_results qr ON c.id = qr.cluster_id
-	`
-	args := []interface{}{}
-
-	if clusterName != "" {
-		query += " WHERE c.cluster_name = $1"
-		args = append(args, clusterName)
-	}
-
-	query += " GROUP BY c.id, c.cluster_name, c.created_at ORDER BY c.created_at DESC"
-
-	if _, ok := dbImpl.(*database.SQLiteDB); ok {
-		query = convertPostgresToSQLitePlaceholders(query)
-	}
-
-	rows, err := db.Query(query, args...)
+	tables, err := allCategoryTables(db, dbImpl)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("list tables: %w", err)
 	}
-	defer func() { _ = rows.Close() }()
 
-	var clusters []ClusterInfo
-	for rows.Next() {
-		var c ClusterInfo
-		err := rows.Scan(&c.ID, &c.Name, &c.CreatedAt, &c.TotalMetrics)
+	clusterMap := make(map[int64]*ClusterInfo)
+	var clusterOrder []int64
+
+	for _, t := range tables {
+		query := fmt.Sprintf(`
+			SELECT c.id, c.cluster_name, c.created_at, COUNT(qr.id) as total_metrics
+			FROM clusters c
+			LEFT JOIN %s qr ON c.id = qr.cluster_id
+		`, t.TableName)
+		args := []interface{}{}
+
+		if clusterName != "" {
+			query += " WHERE c.cluster_name = $1"
+			args = append(args, clusterName)
+		}
+		query += " GROUP BY c.id, c.cluster_name, c.created_at"
+
+		if _, ok := dbImpl.(*database.SQLiteDB); ok {
+			query = convertPostgresToSQLitePlaceholders(query)
+		}
+
+		rows, err := db.Query(query, args...)
 		if err != nil {
 			return nil, err
 		}
-		clusters = append(clusters, c)
+
+		for rows.Next() {
+			var c ClusterInfo
+			if err := rows.Scan(&c.ID, &c.Name, &c.CreatedAt, &c.TotalMetrics); err != nil {
+				_ = rows.Close()
+				return nil, err
+			}
+			if existing, ok := clusterMap[c.ID]; ok {
+				existing.TotalMetrics += c.TotalMetrics
+			} else {
+				clusterMap[c.ID] = &c
+				clusterOrder = append(clusterOrder, c.ID)
+			}
+		}
+		_ = rows.Close()
+		if err := rows.Err(); err != nil {
+			return nil, err
+		}
 	}
 
-	return clusters, rows.Err()
+	clusters := make([]ClusterInfo, 0, len(clusterOrder))
+	for _, id := range clusterOrder {
+		clusters = append(clusters, *clusterMap[id])
+	}
+	return clusters, nil
 }
 
 type ErrorInfo struct {
@@ -461,17 +559,16 @@ func listErrors(db *sql.DB) ([]ErrorInfo, error) {
 	return errors, rows.Err()
 }
 
-// convertToKPIRecords converts internal KPIResult to output.KPIRecord
 func convertToKPIRecords(results []KPIResult) []output.KPIRecord {
 	records := make([]output.KPIRecord, len(results))
 	for i, r := range results {
-		// Parse labels JSON into map
 		var labels map[string]string
 		_ = json.Unmarshal([]byte(r.MetricLabels), &labels)
 
 		records[i] = output.KPIRecord{
 			ID:            r.ID,
 			KPIName:       r.KPIName,
+			Category:      r.Category,
 			Cluster:       r.ClusterName,
 			Value:         r.MetricValue,
 			Timestamp:     r.TimestampValue,

--- a/internal/commands/run.go
+++ b/internal/commands/run.go
@@ -1,10 +1,12 @@
 package commands
 
 import (
+	"bufio"
 	"fmt"
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/redhat-best-practices-for-k8s/kpi-collection-tool/internal/collector"
@@ -95,6 +97,10 @@ func init() {
 	runCmd.Flags().BoolVar(&flags.SingleRun, "once", false,
 		"collect all KPI metrics once and exit (ignores --frequency and --duration)")
 
+	// Skip interactive prompts
+	runCmd.Flags().BoolVarP(&flags.SkipPrompts, "yes", "y", false,
+		"skip interactive prompts (e.g. category advisory)")
+
 	// Mark required flags
 	if err := runCmd.MarkFlagRequired("cluster-name"); err != nil {
 		panic(fmt.Sprintf("failed to mark cluster-name as required: %v", err))
@@ -156,6 +162,12 @@ func runCollect(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("found %d KPI validation error(s)", len(validationErrors))
 	}
 	fmt.Printf("✓ Validated %d KPI(s)\n", len(kpis.Queries))
+
+	if !flags.SkipPrompts {
+		if abort := promptIfManyUncategorized(kpis); abort {
+			return fmt.Errorf("aborted by user")
+		}
+	}
 
 	kpis, err = substituteCPUsIfNeeded(kpis, flags)
 	if err != nil {
@@ -282,6 +294,36 @@ func validateRangeFrequency(kpis config.KPIs, flags config.InputFlags) error {
 	}
 
 	return nil
+}
+
+const uncategorizedThreshold = 15
+
+// promptIfManyUncategorized asks the user for confirmation when 15+ KPIs
+// have no category set. Returns true if the user chose to abort.
+func promptIfManyUncategorized(kpis config.KPIs) bool {
+	uncategorized := 0
+	for _, q := range kpis.Queries {
+		if q.Category == "" {
+			uncategorized++
+		}
+	}
+
+	if uncategorized < uncategorizedThreshold {
+		return false
+	}
+
+	fmt.Fprintf(os.Stderr,
+		"\n⚠  %d KPIs detected without categories.\n"+
+			"   Without categories, all data is stored in a single table which\n"+
+			"   degrades query performance at scale.\n\n"+
+			"   Proceed anyway? [y/N] ",
+		uncategorized)
+
+	reader := bufio.NewReader(os.Stdin)
+	answer, _ := reader.ReadString('\n')
+	answer = strings.TrimSpace(strings.ToLower(answer))
+
+	return answer != "y" && answer != "yes"
 }
 
 // warnFrequencyExceedsDuration prints a warning if any KPI's sampling frequency

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -133,6 +133,7 @@ type InputFlags struct {
 	PostgresURL  string // PostgreSQL connection string
 	KPIsFile     string
 	SingleRun    bool // collect metrics once and exit
+	SkipPrompts  bool // skip interactive prompts (--yes/-y)
 }
 
 // Query represents a single KPI query configuration

--- a/internal/database/interface.go
+++ b/internal/database/interface.go
@@ -11,6 +11,12 @@ import (
 	"github.com/redhat-best-practices-for-k8s/kpi-collection-tool/internal/config"
 )
 
+// CategoryInfo holds metadata about a registered category.
+type CategoryInfo struct {
+	Category  string
+	TableName string
+}
+
 // Database defines the interface that all database implementations must satisfy
 type Database interface {
 	// InitDB initializes the database and creates required tables
@@ -39,4 +45,15 @@ type Database interface {
 	// changed its category compared to what is already stored in kpi_registry.
 	// Must be called after InitDB and before any collection begins.
 	ValidateCategoryConsistency(db *sql.DB, kpis []config.Query) error
+
+	// ListCategories returns all distinct categories from kpi_registry.
+	ListCategories(db *sql.DB) ([]CategoryInfo, error)
+
+	// LookupCategoryForKPI returns the category and table name for a given KPI ID.
+	// Returns empty strings if the KPI is not in the registry (uncategorized).
+	LookupCategoryForKPI(db *sql.DB, kpiID string) (category string, tableName string, err error)
+
+	// DeleteByCategory removes all metric rows from the given category table.
+	// Also removes the corresponding kpi_registry entries.
+	DeleteByCategory(db *sql.DB, category string) (int64, error)
 }

--- a/internal/database/postgres.go
+++ b/internal/database/postgres.go
@@ -120,7 +120,7 @@ func (p *PostgresDB) GetQueryErrorCount(db *sql.DB, kpiID string) (int, error) {
 // will be implemented in a future PR; all writes go to query_results for now.
 // --- TODO ---
 func (p *PostgresDB) EnsureCategoryTable(_ *sql.DB, _ string, _ string) (string, error) {
-	return "query_results", nil
+	return DefaultTableName, nil
 }
 
 // ValidateCategoryConsistency is a no-op stub for PostgreSQL until category
@@ -128,6 +128,24 @@ func (p *PostgresDB) EnsureCategoryTable(_ *sql.DB, _ string, _ string) (string,
 // --- TODO ---
 func (p *PostgresDB) ValidateCategoryConsistency(_ *sql.DB, _ []config.Query) error {
 	return nil
+}
+
+// ListCategories is a no-op stub for PostgreSQL until category support is implemented.
+// --- TODO ---
+func (p *PostgresDB) ListCategories(_ *sql.DB) ([]CategoryInfo, error) {
+	return nil, nil
+}
+
+// LookupCategoryForKPI is a no-op stub for PostgreSQL until category support is implemented.
+// --- TODO ---
+func (p *PostgresDB) LookupCategoryForKPI(_ *sql.DB, _ string) (string, string, error) {
+	return "", "", nil
+}
+
+// DeleteByCategory is a no-op stub for PostgreSQL until category support is implemented.
+// --- TODO ---
+func (p *PostgresDB) DeleteByCategory(_ *sql.DB, _ string) (int64, error) {
+	return 0, nil
 }
 
 // StoreQueryResults stores the results of a Prometheus query in the database.

--- a/internal/database/sqlite.go
+++ b/internal/database/sqlite.go
@@ -18,6 +18,8 @@ const (
 	DefaultOutputDir = "kpi-collector-artifacts"
 	// DefaultDBFileName is the SQLite database file name
 	DefaultDBFileName = "kpi_metrics.db"
+	// DefaultTableName is the legacy table used for uncategorized KPIs
+	DefaultTableName = "query_results"
 )
 
 // OutputDir is the resolved artifacts directory. It defaults to DefaultOutputDir
@@ -135,7 +137,7 @@ func (sqlite_db *SQLiteDB) GetQueryErrorCount(db *sql.DB, kpiID string) (int, er
 // StoreQueryResults stores the results of a Prometheus query in the database.
 // When category is non-empty, writes go to the per-category table (kpi_<category>).
 func (sqlite_db *SQLiteDB) StoreQueryResults(db *sql.DB, clusterID int64, queryID string, category string, result model.Value) error {
-	tableName := "query_results"
+	tableName := DefaultTableName
 	if category != "" {
 		name, err := sqlite_db.EnsureCategoryTable(db, category, queryID)
 		if err != nil {
@@ -236,6 +238,62 @@ func (sqlite_db *SQLiteDB) ValidateCategoryConsistency(db *sql.DB, kpis []config
 	}
 
 	return nil
+}
+
+// ListCategories returns all distinct categories registered in kpi_registry.
+func (sqlite_db *SQLiteDB) ListCategories(db *sql.DB) ([]CategoryInfo, error) {
+	rows, err := db.Query("SELECT DISTINCT category, table_name FROM kpi_registry ORDER BY category")
+	if err != nil {
+		return nil, fmt.Errorf("query kpi_registry: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var categories []CategoryInfo
+	for rows.Next() {
+		var ci CategoryInfo
+		if err := rows.Scan(&ci.Category, &ci.TableName); err != nil {
+			return nil, fmt.Errorf("scan kpi_registry row: %w", err)
+		}
+		categories = append(categories, ci)
+	}
+
+	return categories, rows.Err()
+}
+
+// LookupCategoryForKPI returns the category and table name for a KPI ID.
+// Returns empty strings when the KPI has no registry entry (uncategorized).
+func (sqlite_db *SQLiteDB) LookupCategoryForKPI(db *sql.DB, kpiID string) (string, string, error) {
+	var category, tableName string
+	err := db.QueryRow("SELECT category, table_name FROM kpi_registry WHERE kpi_id = ?", kpiID).
+		Scan(&category, &tableName)
+
+	if err == sql.ErrNoRows {
+		return "", "", nil
+	}
+	if err != nil {
+		return "", "", fmt.Errorf("lookup kpi_registry for '%s': %w", kpiID, err)
+	}
+
+	return category, tableName, nil
+}
+
+// DeleteByCategory removes all rows from the given category table and cleans
+// up the corresponding kpi_registry entries. Returns the number of metric rows deleted.
+func (sqlite_db *SQLiteDB) DeleteByCategory(db *sql.DB, category string) (int64, error) {
+	tableName := CategoryTableName(category)
+
+	result, err := db.Exec(fmt.Sprintf("DELETE FROM %s", tableName))
+	if err != nil {
+		return 0, fmt.Errorf("delete from %s: %w", tableName, err)
+	}
+	deleted, _ := result.RowsAffected()
+
+	_, err = db.Exec("DELETE FROM kpi_registry WHERE category = ?", category)
+	if err != nil {
+		return deleted, fmt.Errorf("clean kpi_registry for category '%s': %w", category, err)
+	}
+
+	return deleted, nil
 }
 
 func (sqlite_db *SQLiteDB) storeVectorResults(db *sql.DB, clusterID int64, queryID string, table string, vector model.Vector) error {

--- a/internal/database/sqlite_test.go
+++ b/internal/database/sqlite_test.go
@@ -252,5 +252,93 @@ var _ = Describe("Sqlite", func() {
 		})
 	})
 
+	Describe("ListCategories", func() {
+		It("should return empty list when no categories exist", func() {
+			categories, err := sqliteDB.ListCategories(db)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(categories).To(BeEmpty())
+		})
+
+		It("should return all distinct categories", func() {
+			_, err := sqliteDB.EnsureCategoryTable(db, "cpu", "node-cpu")
+			Expect(err).NotTo(HaveOccurred())
+			_, err = sqliteDB.EnsureCategoryTable(db, "cpu", "container-cpu")
+			Expect(err).NotTo(HaveOccurred())
+			_, err = sqliteDB.EnsureCategoryTable(db, "memory", "mem-usage")
+			Expect(err).NotTo(HaveOccurred())
+
+			categories, err := sqliteDB.ListCategories(db)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(categories).To(HaveLen(2))
+			Expect(categories[0].Category).To(Equal("cpu"))
+			Expect(categories[0].TableName).To(Equal("kpi_cpu"))
+			Expect(categories[1].Category).To(Equal("memory"))
+			Expect(categories[1].TableName).To(Equal("kpi_memory"))
+		})
+	})
+
+	Describe("LookupCategoryForKPI", func() {
+		It("should return empty strings for an unregistered KPI", func() {
+			cat, table, err := sqliteDB.LookupCategoryForKPI(db, "unknown-kpi")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cat).To(BeEmpty())
+			Expect(table).To(BeEmpty())
+		})
+
+		It("should return category and table for a registered KPI", func() {
+			_, err := sqliteDB.EnsureCategoryTable(db, "cpu", "node-cpu")
+			Expect(err).NotTo(HaveOccurred())
+
+			cat, table, err := sqliteDB.LookupCategoryForKPI(db, "node-cpu")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cat).To(Equal("cpu"))
+			Expect(table).To(Equal("kpi_cpu"))
+		})
+	})
+
+	Describe("DeleteByCategory", func() {
+		var clusterID int64
+
+		BeforeEach(func() {
+			var err error
+			clusterID, err = sqliteDB.GetOrCreateCluster(db, "del-cluster", "ran")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should delete all rows from the category table and clean registry", func() {
+			vector := model.Vector{
+				&model.Sample{
+					Metric:    model.Metric{"__name__": "cpu_usage"},
+					Value:     model.SampleValue(0.5),
+					Timestamp: model.Time(time.Now().Unix() * 1000),
+				},
+			}
+			err := sqliteDB.StoreQueryResults(db, clusterID, "cpu-kpi", "cpu", vector)
+			Expect(err).NotTo(HaveOccurred())
+
+			deleted, err := sqliteDB.DeleteByCategory(db, "cpu")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(deleted).To(Equal(int64(1)))
+
+			var count int
+			err = db.QueryRow("SELECT COUNT(*) FROM kpi_cpu").Scan(&count)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(count).To(Equal(0))
+
+			err = db.QueryRow("SELECT COUNT(*) FROM kpi_registry WHERE category = 'cpu'").Scan(&count)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(count).To(Equal(0))
+		})
+
+		It("should return 0 when category table is empty", func() {
+			_, err := sqliteDB.EnsureCategoryTable(db, "network", "net-kpi")
+			Expect(err).NotTo(HaveOccurred())
+
+			deleted, err := sqliteDB.DeleteByCategory(db, "network")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(deleted).To(Equal(int64(0)))
+		})
+	})
+
 	RunDatabaseInterfaceTests(func() (Database, *sql.DB) { return sqliteDB, db })
 })

--- a/internal/output/csv.go
+++ b/internal/output/csv.go
@@ -10,17 +10,16 @@ func (p *Printer) printKPIsCSV(records []KPIRecord) error {
 	w := csv.NewWriter(p.writer)
 	defer w.Flush()
 
-	// Write header
-	if err := w.Write([]string{"id", "kpi_name", "cluster", "value", "timestamp", "execution_time", "labels"}); err != nil {
+	if err := w.Write([]string{"id", "kpi_name", "category", "cluster", "value", "timestamp", "execution_time", "labels"}); err != nil {
 		return err
 	}
 
-	// Write records
 	for _, r := range records {
 		labelsJSON, _ := json.Marshal(r.Labels)
 		row := []string{
 			strconv.FormatInt(r.ID, 10),
 			r.KPIName,
+			r.Category,
 			r.Cluster,
 			strconv.FormatFloat(r.Value, 'f', 6, 64),
 			strconv.FormatFloat(r.Timestamp, 'f', 0, 64),

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -36,6 +36,7 @@ func ParseFormat(s string) (Format, error) {
 type KPIRecord struct {
 	ID            int64             `json:"id"`
 	KPIName       string            `json:"kpi_name"`
+	Category      string            `json:"category,omitempty"`
 	Cluster       string            `json:"cluster"`
 	Value         float64           `json:"value"`
 	Timestamp     float64           `json:"timestamp"`

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -12,33 +12,30 @@ func (p *Printer) printKPIsTable(records []KPIRecord) error {
 	w := tabwriter.NewWriter(p.writer, 0, 0, 2, ' ', 0)
 
 	if p.noTruncate {
-		// Display without labels column, print pretty JSON below each entry
-		_, _ = fmt.Fprintln(w, "ID\tKPI_NAME\tCLUSTER\tVALUE\tTIMESTAMP\tEXECUTION_TIME")
-		_, _ = fmt.Fprintln(w, "---\t---\t---\t---\t---\t---")
+		_, _ = fmt.Fprintln(w, "ID\tKPI_NAME\tCATEGORY\tCLUSTER\tVALUE\tTIMESTAMP\tEXECUTION_TIME")
+		_, _ = fmt.Fprintln(w, "---\t---\t---\t---\t---\t---\t---")
 
 		for _, r := range records {
-			_, _ = fmt.Fprintf(w, "%d\t%s\t%s\t%.6f\t%.0f\t%s\n",
-				r.ID, r.KPIName, r.Cluster, r.Value,
+			_, _ = fmt.Fprintf(w, "%d\t%s\t%s\t%s\t%.6f\t%.0f\t%s\n",
+				r.ID, r.KPIName, categoryDisplay(r.Category), r.Cluster, r.Value,
 				r.Timestamp, r.ExecutionTime.Format("2006-01-02 15:04:05"))
 			_ = w.Flush()
 
-			// Print pretty labels below the entry
 			_, _ = fmt.Fprintln(p.writer, "  Labels:")
 			p.printPrettyLabels(r.Labels)
 			_, _ = fmt.Fprintln(p.writer)
 		}
 	} else {
-		// Default: display with truncated labels in table
-		_, _ = fmt.Fprintln(w, "ID\tKPI_NAME\tCLUSTER\tVALUE\tTIMESTAMP\tEXECUTION_TIME\tLABELS")
-		_, _ = fmt.Fprintln(w, "---\t---\t---\t---\t---\t---\t---")
+		_, _ = fmt.Fprintln(w, "ID\tKPI_NAME\tCATEGORY\tCLUSTER\tVALUE\tTIMESTAMP\tEXECUTION_TIME\tLABELS")
+		_, _ = fmt.Fprintln(w, "---\t---\t---\t---\t---\t---\t---\t---")
 
 		for _, r := range records {
 			labels := r.LabelsRaw
 			if len(labels) > 50 {
 				labels = labels[:47] + "..."
 			}
-			_, _ = fmt.Fprintf(w, "%d\t%s\t%s\t%.6f\t%.0f\t%s\t%s\n",
-				r.ID, r.KPIName, r.Cluster, r.Value,
+			_, _ = fmt.Fprintf(w, "%d\t%s\t%s\t%s\t%.6f\t%.0f\t%s\t%s\n",
+				r.ID, r.KPIName, categoryDisplay(r.Category), r.Cluster, r.Value,
 				r.Timestamp, r.ExecutionTime.Format("2006-01-02 15:04:05"), labels)
 		}
 		_ = w.Flush()
@@ -46,6 +43,13 @@ func (p *Printer) printKPIsTable(records []KPIRecord) error {
 
 	_, _ = fmt.Fprintf(p.writer, "\nTotal results: %d\n", len(records))
 	return nil
+}
+
+func categoryDisplay(category string) string {
+	if category == "" {
+		return "-"
+	}
+	return category
 }
 
 func (p *Printer) printPrettyLabels(labels map[string]string) {


### PR DESCRIPTION
follow-up PR to #109. Adds category-aware read and delete paths, and an interactive prompt for 15+ uncategorized KPIs.

### Changes
- `db show kpis --category`: query a specific category table; `--name` auto-discovers the table via `kpi_registry`; `--name` and `--category` are mutually exclusive
- `db remove kpis --category`: delete all data and registry entries for a category; cluster-scoped deletion now spans all tables
- `run`: when 15+ KPIs in the config file have no `category` field, an interactive prompt warns that all data will land in a single table — which degrades query performance at scale — and asks the user to confirm before proceeding. The prompt can be bypassed with `-y`/`--yes` for CI and scripted workflows. It fires after KPI validation but before collection starts
- Database interface: added `ListCategories`, `LookupCategoryForKPI`, `DeleteByCategory` (SQLite implemented, PostgreSQL stubbed for Phase 4)
- Category column always shown in table/JSON/CSV output (`-` for uncategorized)
### TODO
- [x] Grafana dashboard support with category-aware panels
- [x] PostgreSQL implementation of category methods
- [x] Gracefully handle `--category` referencing a non-existent table