### PR TITLE
Add category tags to KPI profiles (ran, core, hub)

### DIFF
--- a/kpi-profiles/kpis-core.yaml
+++ b/kpi-profiles/kpis-core.yaml
@@ -15,16 +15,19 @@ kpis:
   # Unit: seconds. Excludes WATCH (long-poll) requests which skew the histogram.
   - id: apiserver-request-duration-99p
     promquery: histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket{verb!="WATCH"}[5m])) by (verb, le))
+    category: apiserver
 
   # API request throughput by verb and HTTP status code.
   # Unit: requests/second.
   - id: apiserver-request-rate
     promquery: sum(rate(apiserver_request_total[5m])) by (verb, code)
+    category: apiserver
 
   # API server 5xx error rate by verb.
   # Unit: errors/second. Non-zero values indicate server-side failures.
   - id: apiserver-error-rate
     promquery: sum(rate(apiserver_request_total{code=~"5.."}[5m])) by (verb)
+    category: apiserver
 
   # --- etcd ---
 
@@ -32,11 +35,13 @@ kpis:
   # Unit: bytes. Growth over time can indicate excessive object churn or missing compaction.
   - id: etcd-db-size
     promquery: etcd_mvcc_db_total_size_in_bytes
+    category: etcd
 
   # 99th-percentile WAL fsync latency — time to flush writes to disk.
   # Unit: seconds. Values above 10 ms often correlate with disk I/O bottlenecks.
   - id: etcd-disk-wal-fsync-duration-99p
     promquery: histogram_quantile(0.99, sum(rate(etcd_disk_wal_fsync_duration_seconds_bucket[5m])) by (le))
+    category: etcd
 
   # Number of etcd leader elections in the past hour.
   # Unit: count. Frequent changes suggest network instability or slow disks.
@@ -44,6 +49,7 @@ kpis:
   - id: etcd-leader-changes
     promquery: increase(etcd_server_leader_changes_seen_total[1h])
     sample-frequency: 5m
+    category: etcd
 
   # --- CPU ---
 
@@ -51,11 +57,13 @@ kpis:
   # Unit: percentage (0–100).
   - id: cpu-node-total
     promquery: 100 - (avg by (instance) (rate(node_cpu_seconds_total{mode="idle"}[5m])) * 100)
+    category: cpu
 
   # CPU usage summed by namespace to identify noisy tenants.
   # Unit: cores. Excludes infra containers (pause/"POD").
   - id: cpu-usage-by-namespace
     promquery: sort_desc(sum(rate(container_cpu_usage_seconds_total{container!="",container!="POD"}[5m])) by (namespace))
+    category: cpu
 
   # --- Memory ---
 
@@ -63,11 +71,13 @@ kpis:
   # Unit: percentage (0–100).
   - id: memory-node-used-percentage
     promquery: 100 * (1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes))
+    category: memory
 
   # Working-set memory summed by namespace.
   # Unit: bytes. Helps find namespaces consuming the most memory.
   - id: memory-usage-by-namespace
     promquery: sort_desc(sum(container_memory_working_set_bytes{container!="",container!="POD"}) by (namespace))
+    category: memory
 
   # --- Network ---
 
@@ -75,11 +85,13 @@ kpis:
   # Unit: bytes/second. Excludes loopback, veth, bridge, and OVS virtual interfaces.
   - id: network-node-rx-bytes
     promquery: sort_desc(rate(node_network_receive_bytes_total{device!~"lo|veth.*|br.*|ovs.*"}[5m]))
+    category: network
 
   # Bytes transmitted per second on physical node interfaces.
   # Unit: bytes/second.
   - id: network-node-tx-bytes
     promquery: sort_desc(rate(node_network_transmit_bytes_total{device!~"lo|veth.*|br.*|ovs.*"}[5m]))
+    category: network
 
   # --- Ingress ---
 
@@ -88,6 +100,7 @@ kpis:
   # Requires: openshift-router (HAProxy-based, default ingress controller).
   - id: ingress-request-rate
     promquery: sum(rate(haproxy_server_http_responses_total[5m])) by (code)
+    category: network
 
   # --- Disk / Storage ---
 
@@ -95,21 +108,25 @@ kpis:
   # Unit: percentage (0–100). Monitors the / mountpoint, excludes tmpfs.
   - id: disk-usage-percentage
     promquery: 100 - ((node_filesystem_avail_bytes{mountpoint="/",fstype!="tmpfs"} / node_filesystem_size_bytes{mountpoint="/",fstype!="tmpfs"}) * 100)
+    category: disk
 
   # PersistentVolume usage as a percentage of capacity.
   # Unit: percentage (0–100). Covers all PVCs mounted by the kubelet.
   - id: pv-usage-percentage
     promquery: 100 * (1 - (kubelet_volume_stats_available_bytes / kubelet_volume_stats_capacity_bytes))
+    category: disk
 
   # Bytes read per second from physical block devices.
   # Unit: bytes/second. Excludes device-mapper (dm-*) virtual devices.
   - id: disk-io-read-bytes
     promquery: sort_desc(rate(node_disk_read_bytes_total{device!~"dm-.*"}[5m]))
+    category: disk
 
   # Bytes written per second to physical block devices.
   # Unit: bytes/second.
   - id: disk-io-write-bytes
     promquery: sort_desc(rate(node_disk_written_bytes_total{device!~"dm-.*"}[5m]))
+    category: disk
 
   # --- System Load ---
 
@@ -117,11 +134,13 @@ kpis:
   # Unit: dimensionless (approximate number of runnable + uninterruptible tasks).
   - id: node-load-1min
     promquery: node_load1
+    category: system
 
   # 5-minute load average. Smoother than the 1-min value.
   # Unit: dimensionless.
   - id: node-load-5min
     promquery: node_load5
+    category: system
 
   # --- Pod Health ---
 
@@ -129,11 +148,13 @@ kpis:
   # Unit: count (monotonically increasing). Sorted to surface crashlooping pods.
   - id: pod-restart-count
     promquery: sort_desc(sum(kube_pod_container_status_restarts_total) by (namespace, pod))
+    category: pod-health
 
   # Number of pods in Pending or Failed phase, grouped by namespace and phase.
   # Unit: count. Non-zero values indicate scheduling or runtime issues.
   - id: pod-status-not-ready
     promquery: count(kube_pod_status_phase{phase=~"Pending|Failed"}) by (namespace, phase)
+    category: pod-health
 
   # --- Cluster Info ---
 
@@ -142,3 +163,4 @@ kpis:
   - id: cluster-uptime
     promquery: max(time() - process_start_time_seconds{job="kubelet"})
     run-once: true
+    category: cluster

--- a/kpi-profiles/kpis-hub.yaml
+++ b/kpi-profiles/kpis-hub.yaml
@@ -15,16 +15,19 @@ kpis:
   # Unit: seconds. Excludes WATCH (long-poll) requests which skew the histogram.
   - id: apiserver-request-duration-99p
     promquery: histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket{verb!="WATCH"}[5m])) by (verb, le))
+    category: apiserver
 
   # API request throughput by verb and HTTP status code.
   # Unit: requests/second.
   - id: apiserver-request-rate
     promquery: sum(rate(apiserver_request_total[5m])) by (verb, code)
+    category: apiserver
 
   # API server 5xx error rate by verb.
   # Unit: errors/second. Non-zero values indicate server-side failures.
   - id: apiserver-error-rate
     promquery: sum(rate(apiserver_request_total{code=~"5.."}[5m])) by (verb)
+    category: apiserver
 
   # --- etcd ---
 
@@ -32,11 +35,13 @@ kpis:
   # Unit: bytes. Growth over time can indicate excessive object churn or missing compaction.
   - id: etcd-db-size
     promquery: etcd_mvcc_db_total_size_in_bytes
+    category: etcd
 
   # 99th-percentile WAL fsync latency — time to flush writes to disk.
   # Unit: seconds. Values above 10 ms often correlate with disk I/O bottlenecks.
   - id: etcd-disk-wal-fsync-duration-99p
     promquery: histogram_quantile(0.99, sum(rate(etcd_disk_wal_fsync_duration_seconds_bucket[5m])) by (le))
+    category: etcd
 
   # Number of etcd leader elections in the past hour.
   # Unit: count. Frequent changes suggest network instability or slow disks.
@@ -44,6 +49,7 @@ kpis:
   - id: etcd-leader-changes
     promquery: increase(etcd_server_leader_changes_seen_total[1h])
     sample-frequency: 5m
+    category: etcd
 
   # --- CPU ---
 
@@ -51,6 +57,7 @@ kpis:
   # Unit: percentage (0–100).
   - id: cpu-node-total
     promquery: 100 - (avg by (instance) (rate(node_cpu_seconds_total{mode="idle"}[5m])) * 100)
+    category: cpu
 
   # --- Memory ---
 
@@ -58,6 +65,7 @@ kpis:
   # Unit: percentage (0–100).
   - id: memory-node-used-percentage
     promquery: 100 * (1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes))
+    category: memory
 
   # --- ACM (Advanced Cluster Management) ---
   # Requires: ACM operator installed (open-cluster-management, multicluster-engine namespaces).
@@ -66,17 +74,20 @@ kpis:
   # Unit: cores. Sorted descending to surface top consumers.
   - id: acm-cpu-usage
     promquery: sort_desc(sum(rate(container_cpu_usage_seconds_total{container!="",container!="POD",namespace=~"open-cluster-management.*|multicluster-engine"}[5m])) by (namespace, pod))
+    category: acm
 
   # Working-set memory per pod in ACM and multicluster-engine namespaces.
   # Unit: bytes.
   - id: acm-memory-usage
     promquery: sort_desc(sum(container_memory_working_set_bytes{container!="",container!="POD",namespace=~"open-cluster-management.*|multicluster-engine"}) by (namespace, pod))
+    category: acm
 
   # Total number of clusters managed by ACM.
   # Unit: count. Sampled every 5 min since fleet size changes infrequently.
   - id: acm-managed-clusters
     promquery: count(acm_managed_cluster_info)
     sample-frequency: 5m
+    category: acm
 
   # Number of root governance policies in NonCompliant state.
   # Unit: count. Non-zero means one or more policies are violated.
@@ -85,6 +96,7 @@ kpis:
   - id: acm-policy-noncompliant
     promquery: count(policy_governance_info{type="root",compliant="NonCompliant"})
     sample-frequency: 5m
+    category: acm
 
   # --- GitOps ---
   # Requires: OpenShift GitOps operator installed (openshift-gitops namespace).
@@ -93,11 +105,13 @@ kpis:
   # Unit: cores.
   - id: gitops-cpu-usage
     promquery: sort_desc(sum(rate(container_cpu_usage_seconds_total{container!="",container!="POD",namespace=~"openshift-gitops.*"}[5m])) by (namespace, pod))
+    category: gitops
 
   # Working-set memory per pod in OpenShift GitOps namespaces.
   # Unit: bytes.
   - id: gitops-memory-usage
     promquery: sort_desc(sum(container_memory_working_set_bytes{container!="",container!="POD",namespace=~"openshift-gitops.*"}) by (namespace, pod))
+    category: gitops
 
   # --- Disk / Storage ---
 
@@ -105,11 +119,13 @@ kpis:
   # Unit: percentage (0–100). Monitors the / mountpoint, excludes tmpfs.
   - id: disk-usage-percentage
     promquery: 100 - ((node_filesystem_avail_bytes{mountpoint="/",fstype!="tmpfs"} / node_filesystem_size_bytes{mountpoint="/",fstype!="tmpfs"}) * 100)
+    category: disk
 
   # PersistentVolume usage as a percentage of capacity.
   # Unit: percentage (0–100). Covers all PVCs mounted by the kubelet.
   - id: pv-usage-percentage
     promquery: 100 * (1 - (kubelet_volume_stats_available_bytes / kubelet_volume_stats_capacity_bytes))
+    category: disk
 
   # --- Network ---
 
@@ -117,11 +133,13 @@ kpis:
   # Unit: bytes/second. Excludes loopback, veth, bridge, and OVS virtual interfaces.
   - id: network-node-rx-bytes
     promquery: sort_desc(rate(node_network_receive_bytes_total{device!~"lo|veth.*|br.*|ovs.*"}[5m]))
+    category: network
 
   # Bytes transmitted per second on physical node interfaces.
   # Unit: bytes/second.
   - id: network-node-tx-bytes
     promquery: sort_desc(rate(node_network_transmit_bytes_total{device!~"lo|veth.*|br.*|ovs.*"}[5m]))
+    category: network
 
   # --- System Load ---
 
@@ -129,6 +147,7 @@ kpis:
   # Unit: dimensionless (approximate number of runnable + uninterruptible tasks).
   - id: node-load-1min
     promquery: node_load1
+    category: system
 
   # --- Pod Health ---
 
@@ -136,11 +155,13 @@ kpis:
   # Unit: count (monotonically increasing). Sorted to surface crashlooping pods.
   - id: pod-restart-count
     promquery: sort_desc(sum(kube_pod_container_status_restarts_total) by (namespace, pod))
+    category: pod-health
 
   # Number of pods in Pending or Failed phase, grouped by namespace and phase.
   # Unit: count. Non-zero values indicate scheduling or runtime issues.
   - id: pod-status-not-ready
     promquery: count(kube_pod_status_phase{phase=~"Pending|Failed"}) by (namespace, phase)
+    category: pod-health
 
   # --- Cluster Info ---
 
@@ -149,3 +170,4 @@ kpis:
   - id: cluster-uptime
     promquery: max(time() - process_start_time_seconds{job="kubelet"})
     run-once: true
+    category: cluster

--- a/kpi-profiles/kpis-ran.yaml
+++ b/kpi-profiles/kpis-ran.yaml
@@ -16,33 +16,39 @@ kpis:
   # Unit: ratio 0–1 (multiply by 100 for percentage).
   - id: cpu-reserved-cores
     promquery: avg by (cpu) (rate(node_cpu_seconds_total{cpu=~"{{RESERVED_CPUS}}",mode!="idle"}[5m]))
+    category: cpu
 
   # Average per-core utilization of isolated (workload) CPUs.
   # Unit: ratio 0–1.
   - id: cpu-isolated-cores
     promquery: avg by (cpu) (rate(node_cpu_seconds_total{cpu=~"{{ISOLATED_CPUS}}",mode!="idle"}[5m]))
+    category: cpu
 
   # Overall node CPU usage averaged across all cores.
   # Unit: percentage (0–100).
   # Subtracts idle ratio from 100 to get busy percentage.
   - id: cpu-node-total
     promquery: 100 - (avg by (instance) (rate(node_cpu_seconds_total{mode="idle"}[5m])) * 100)
+    category: cpu
 
   # CPU usage of cgroup processes under /system.slice (systemd services like kubelet, crio).
   # Unit: cores (seconds/second). Sorted descending to surface top consumers.
   - id: cpu-system-slice
     promquery: sort_desc(rate(container_cpu_usage_seconds_total{id=~"/system.slice/.*"}[5m]))
+    category: cpu
 
   # CPU usage of cgroup processes under /ovs.slice (Open vSwitch daemons).
   # Unit: cores. Helps track OVS overhead on the data plane.
   # Requires: OVS running under a dedicated cgroup slice.
   - id: cpu-ovs-slice
     promquery: sort_desc(rate(container_cpu_usage_seconds_total{id=~"/ovs.slice/.*"}[5m]))
+    category: cpu
 
   # Average CPU consumed per pod over a 5-minute window.
   # Unit: cores. Uses the pre-computed recording rule pod:container_cpu_usage:sum.
   - id: cpu-pods-average
     promquery: sort_desc(avg_over_time(pod:container_cpu_usage:sum[5m]))
+    category: cpu
 
   # --- Memory ---
 
@@ -50,17 +56,20 @@ kpis:
   # Unit: percentage (0–100).
   - id: memory-node-used-percentage
     promquery: 100 * (1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes))
+    category: memory
 
   # Working-set memory per pod (RSS + cache in active use, excludes reclaimable cache).
   # Unit: bytes. Grouped by pod and namespace.
   # Filters out the pause container ("POD") and empty container names.
   - id: memory-working-set-by-pod
     promquery: sort_desc(sum(container_memory_working_set_bytes{container!="",container!="POD"}) by (pod, namespace))
+    category: memory
 
   # Resident Set Size (RSS) per pod — physical memory that cannot be reclaimed.
   # Unit: bytes. Better indicator of true memory pressure than working set.
   - id: memory-rss-by-pod
     promquery: sort_desc(sum(container_memory_rss{container!="",container!="POD"}) by (pod, namespace))
+    category: memory
 
   # --- Hugepages ---
   # Unit: count of pages. hugepagesize filter is in KiB (1048576 = 1 GiB, 2048 = 2 MiB).
@@ -69,18 +78,22 @@ kpis:
   # Free 1 GiB hugepages on each node.
   - id: hugepages-1g-free
     promquery: node_hugepages_free{hugepagesize="1048576"}
+    category: memory
 
   # Total 1 GiB hugepages allocated on each node.
   - id: hugepages-1g-total
     promquery: node_hugepages_total{hugepagesize="1048576"}
+    category: memory
 
   # Free 2 MiB hugepages on each node.
   - id: hugepages-2m-free
     promquery: node_hugepages_free{hugepagesize="2048"}
+    category: memory
 
   # Total 2 MiB hugepages allocated on each node.
   - id: hugepages-2m-total
     promquery: node_hugepages_total{hugepagesize="2048"}
+    category: memory
 
   # --- Network (node) ---
   # All node network KPIs exclude virtual interfaces (loopback, veth, bridge, OVS)
@@ -89,29 +102,35 @@ kpis:
   # Bytes received per second. Unit: bytes/second.
   - id: network-node-rx-bytes
     promquery: sort_desc(rate(node_network_receive_bytes_total{device!~"lo|veth.*|br.*|ovs.*"}[5m]))
+    category: network
 
   # Bytes transmitted per second. Unit: bytes/second.
   - id: network-node-tx-bytes
     promquery: sort_desc(rate(node_network_transmit_bytes_total{device!~"lo|veth.*|br.*|ovs.*"}[5m]))
+    category: network
 
   # Receive errors per second. Unit: errors/second.
   # Non-zero values may indicate NIC, driver, or cable issues.
   - id: network-node-rx-errors
     promquery: sort_desc(rate(node_network_receive_errs_total{device!~"lo|veth.*|br.*|ovs.*"}[5m]))
+    category: network
 
   # Transmit errors per second. Unit: errors/second.
   - id: network-node-tx-errors
     promquery: sort_desc(rate(node_network_transmit_errs_total{device!~"lo|veth.*|br.*|ovs.*"}[5m]))
+    category: network
 
   # Bytes received per second on the primary container interface (eth0).
   # Unit: bytes/second. Shows per-pod network ingress.
   - id: network-container-rx-bytes
     promquery: sort_desc(rate(container_network_receive_bytes_total{interface="eth0"}[5m]))
+    category: network
 
   # Bytes transmitted per second on the primary container interface (eth0).
   # Unit: bytes/second. Shows per-pod network egress.
   - id: network-container-tx-bytes
     promquery: sort_desc(rate(container_network_transmit_bytes_total{interface="eth0"}[5m]))
+    category: network
 
   # --- PTP (Precision Time Protocol) ---
   # Requires: ptp-operator with linuxptp daemons (ptp4l, phc2sys) running.
@@ -120,21 +139,25 @@ kpis:
   # Unit: nanoseconds. iface=CLOCK_REALTIME means system clock vs PTP hardware clock.
   - id: ptp-offset-master
     promquery: openshift_ptp_offset_ns{iface="CLOCK_REALTIME",process="phc2sys"}
+    category: ptp
 
   # Maximum PTP offset observed since the last metric reset.
   # Unit: nanoseconds. Useful for detecting worst-case clock drift.
   - id: ptp-max-offset-master
     promquery: openshift_ptp_max_offset_ns{iface="CLOCK_REALTIME",process="phc2sys"}
+    category: ptp
 
   # PTP clock synchronization state per node.
   # Unit: enum (0=FREERUN, 1=LOCKED, 2=HOLDOVER). LOCKED means synchronized.
   - id: ptp-clock-state
     promquery: openshift_ptp_clock_state
+    category: ptp
 
   # Role of each PTP-capable interface (master, slave, passive, listening).
   # Unit: enum (role label). Helps verify expected PTP topology.
   - id: ptp-interface-role
     promquery: openshift_ptp_interface_role
+    category: ptp
 
   # --- Disk I/O ---
 
@@ -142,16 +165,19 @@ kpis:
   # Unit: bytes/second. Excludes device-mapper (dm-*) virtual devices.
   - id: disk-io-read-bytes
     promquery: sort_desc(rate(node_disk_read_bytes_total{device!~"dm-.*"}[5m]))
+    category: disk
 
   # Bytes written per second to physical block devices.
   # Unit: bytes/second.
   - id: disk-io-write-bytes
     promquery: sort_desc(rate(node_disk_written_bytes_total{device!~"dm-.*"}[5m]))
+    category: disk
 
   # Root filesystem usage as a percentage.
   # Unit: percentage (0–100). Monitors the / mountpoint, excludes tmpfs.
   - id: disk-usage-percentage
     promquery: 100 - ((node_filesystem_avail_bytes{mountpoint="/",fstype!="tmpfs"} / node_filesystem_size_bytes{mountpoint="/",fstype!="tmpfs"}) * 100)
+    category: disk
 
   # --- OVN-Kubernetes ---
   # Requires: OVN-Kubernetes network plugin (default on OpenShift 4.x).
@@ -160,11 +186,13 @@ kpis:
   # Unit: cores.
   - id: ovn-controller-cpu
     promquery: rate(container_cpu_usage_seconds_total{container="ovn-controller"}[5m])
+    category: network
 
   # Working-set memory of the ovn-controller container.
   # Unit: bytes.
   - id: ovn-controller-memory
     promquery: container_memory_working_set_bytes{container="ovn-controller"}
+    category: network
 
   # --- Kernel Scheduling ---
 
@@ -172,11 +200,13 @@ kpis:
   # Unit: switches/second. High values may indicate excessive scheduling overhead.
   - id: node-context-switches
     promquery: rate(node_context_switches_total[5m])
+    category: system
 
   # Hardware and software interrupts per second.
   # Unit: interrupts/second. Spikes may correlate with network traffic or device activity.
   - id: node-interrupts
     promquery: rate(node_intr_total[5m])
+    category: system
 
   # --- Pod Health ---
 
@@ -184,3 +214,4 @@ kpis:
   # Unit: count (monotonically increasing). Sorted to surface crashlooping pods.
   - id: pod-restart-count
     promquery: sort_desc(sum(kube_pod_container_status_restarts_total) by (namespace, pod))
+    category: pod-health


### PR DESCRIPTION
Tag every KPI in the three large profiles with a category field so that collected metrics are automatically routed to per-category database tables for improved query performance.