### PR TITLE
Add `--uncategorized` flag to `kpis generate` command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,7 +126,7 @@ Tests use Ginkgo/Gomega BDD framework. Test files follow the pattern `*_test.go`
 
 ### CLI Structure
 Commands are organized using Cobra:
-- `kpi-collector kpis generate --profile <profile>`: Generate a KPI file for a cluster profile (ran, core, hub)
+- `kpi-collector kpis generate --profile <profile>`: Generate a KPI file for a cluster profile (ran, core, hub). Use `--uncategorized` to omit category fields. Use `--uncategorized` to omit category fields
 - `kpi-collector run`: Collect KPI metrics (use `--once` to collect once and exit)
 - `kpi-collector db show clusters|kpis|errors`: Query stored data
 - `kpi-collector db remove clusters|kpis|errors`: Delete data

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -40,7 +40,7 @@ kpi-collector kpis generate --profile ran --all
 kpi-collector kpis generate --profile ran
 ```
 
-This creates a `ran-kpis.yaml` file in your current directory with battle-tested PromQL queries for that profile. Use `-f <path>` to write to a custom location.
+This creates a `ran-kpis.yaml` file in your current directory with battle-tested PromQL queries for that profile. Use `-f <path>` to write to a custom location. Add `--uncategorized` to omit category fields from the output.
 
 **Alternatively**, you can write a KPI file by hand. Save the following as `my-kpis.yaml` — a minimal example with two basic cluster-health queries:
 

--- a/docs/kpis-file-configuration.md
+++ b/docs/kpis-file-configuration.md
@@ -25,6 +25,7 @@ kpis:
 | `id` | Yes | - | Unique identifier used in the database and output |
 | `promquery` | Yes | - | PromQL query to execute |
 | `sample-frequency` | No | global `--frequency` | Per-query override (duration string like `2m` or seconds like `120`) |
+| `category` | No | — | Storage category; routes metrics to a dedicated `kpi_<category>` table for better query performance |
 | `run-once` | No | false | Collect this query only once, skip repeated sampling |
 | `query-type` | No | `instant` | `instant` or `range` |
 | `range` | No* | — | Object with `step`, `since`, and optionally `until` |
@@ -73,7 +74,14 @@ kpi-collector kpis generate --profile hub --all -f /path/to/hub-kpis.yaml
 
 # Overwrite an existing file
 kpi-collector kpis generate --profile ran --all --overwrite
+
+# Generate without category fields (all data stored in a single table)
+kpi-collector kpis generate --profile ran --all --uncategorized
 ```
+
+By default, generated KPIs include a `category` field that routes metrics into
+per-category database tables for better query performance at scale. Use
+`--uncategorized` to omit the `category` field from the output.
 
 Available profiles:
 

--- a/internal/commands/kpis_generate.go
+++ b/internal/commands/kpis_generate.go
@@ -34,10 +34,11 @@ var profiles = map[string]profile{
 }
 
 var kpisGenerateFlags struct {
-	profile   string
-	file      string
-	all       bool
-	overwrite bool
+	profile       string
+	file          string
+	all           bool
+	overwrite     bool
+	uncategorized bool
 }
 
 var kpisGenerateCmd = &cobra.Command{
@@ -48,7 +49,11 @@ var kpisGenerateCmd = &cobra.Command{
 Supported profiles: ran, core, hub
 
 In interactive mode (default), you will be prompted to select which KPI
-categories to include. Use --all to include all categories without prompts.`,
+categories to include. Use --all to include all categories without prompts.
+
+By default, each KPI includes a category field that routes metrics into
+per-category database tables for better query performance. Use --uncategorized
+to omit category fields and store all metrics in a single table.`,
 	Example: `  # Generate all RAN KPIs
   kpi-collector kpis generate --profile ran --all
 
@@ -56,7 +61,10 @@ categories to include. Use --all to include all categories without prompts.`,
   kpi-collector kpis generate --profile core -f core-kpis.yaml
 
   # Generate Hub KPIs to a custom path
-  kpi-collector kpis generate --profile hub --all -f /path/to/hub-kpis.yaml`,
+  kpi-collector kpis generate --profile hub --all -f /path/to/hub-kpis.yaml
+
+  # Generate without category fields (single-table storage)
+  kpi-collector kpis generate --profile ran --all --uncategorized`,
 	Args: cobra.NoArgs,
 	RunE: runKpisGenerate,
 }
@@ -72,6 +80,8 @@ func init() {
 		"include all KPI categories without prompts")
 	kpisGenerateCmd.Flags().BoolVar(&kpisGenerateFlags.overwrite, "overwrite", false,
 		"overwrite the output file if it already exists")
+	kpisGenerateCmd.Flags().BoolVar(&kpisGenerateFlags.uncategorized, "uncategorized", false,
+		"generate KPIs without category fields (all data stored in a single table)")
 
 	_ = kpisGenerateCmd.MarkFlagRequired("profile")
 }
@@ -104,6 +114,10 @@ func runKpisGenerate(_ *cobra.Command, _ []string) error {
 	if len(queries) == 0 {
 		fmt.Println("No KPI categories selected. No file generated.")
 		return nil
+	}
+
+	if kpisGenerateFlags.uncategorized {
+		queries = stripCategories(queries)
 	}
 
 	return writeKPIsFile(filePath, queries)
@@ -174,6 +188,15 @@ func writeKPIsFile(filePath string, queries []config.Query) error {
 	fmt.Println("  query-type        instant (default) or range for time-window queries")
 	fmt.Println("  range             Required when query-type is range (nested: step, since, until)")
 	return nil
+}
+
+func stripCategories(queries []config.Query) []config.Query {
+	stripped := make([]config.Query, len(queries))
+	copy(stripped, queries)
+	for i := range stripped {
+		stripped[i].Category = ""
+	}
+	return stripped
 }
 
 // ---------------------------------------------------------------------------

--- a/kpi-profiles/README.md
+++ b/kpi-profiles/README.md
@@ -88,12 +88,19 @@ kpi-collector kpis generate --profile hub --all -f /path/to/hub-kpis.yaml
 
 # Overwrite an existing file
 kpi-collector kpis generate --profile ran --all --overwrite
+
+# Generate without category fields (single-table storage)
+kpi-collector kpis generate --profile ran --all --uncategorized
 ```
 
 By default the output file is named `<profile>-kpis.yaml` in the current
 directory. If the file already exists, the command will refuse to overwrite it
 unless you pass `--overwrite`. In interactive mode (the default), you are
 prompted per category — use `--all` to skip prompts and include everything.
+
+Generated KPIs include a `category` field by default, which routes metrics into
+separate database tables for better query performance. Pass `--uncategorized`
+to omit the `category` field and store all metrics in a single table.
 
 Once generated, you can edit the file to fine-tune individual KPIs before
 passing it to the collector.


### PR DESCRIPTION
Adds a `--uncategorized` flag to `kpis generate` that strips the `category` field from all generated KPIs, so metrics are stored in a single table instead of per-category tables.


#### Usage
`kpi-collector kpis generate --profile ran --all --uncategorized`
