### PR TITLE
Add PostgreSQL category table support and Grafana integration

### DIFF
--- a/grafana-templates/postgres-dashboard.json
+++ b/grafana-templates/postgres-dashboard.json
@@ -241,7 +241,7 @@
             "uid": "kpi-datasource"
           },
           "format": "table",
-          "rawSql": "SELECT to_timestamp(timestamp_value) AS time, metric_value, metric_labels FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE timestamp_value >= $__from / 1000 AND timestamp_value < $__to / 1000 AND kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) AND COALESCE(metric_labels->>'node', metric_labels->>'instance', 'N/A') LIKE (CASE WHEN '${node}' = 'All' THEN '%%' ELSE '${node}' END) AND COALESCE(metric_labels->>'job', 'N/A') LIKE (CASE WHEN '${job}' = 'All' THEN '%%' ELSE '${job}' END) AND COALESCE(metric_labels->>'container', 'N/A') LIKE (CASE WHEN '${container}' = 'All' THEN '%%' ELSE '${container}' END) AND COALESCE(metric_labels->>'pod', 'N/A') LIKE (CASE WHEN '${pod}' = 'All' THEN '%%' ELSE '${pod}' END) ORDER BY time ASC",
+          "rawSql": "SELECT to_timestamp(timestamp_value) AS time, metric_value, metric_labels FROM ${_table} qr JOIN clusters c ON qr.cluster_id = c.id WHERE timestamp_value >= $__from / 1000 AND timestamp_value < $__to / 1000 AND kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) AND COALESCE(metric_labels->>'node', metric_labels->>'instance', 'N/A') LIKE (CASE WHEN '${node}' = 'All' THEN '%%' ELSE '${node}' END) AND COALESCE(metric_labels->>'job', 'N/A') LIKE (CASE WHEN '${job}' = 'All' THEN '%%' ELSE '${job}' END) AND COALESCE(metric_labels->>'container', 'N/A') LIKE (CASE WHEN '${container}' = 'All' THEN '%%' ELSE '${container}' END) AND COALESCE(metric_labels->>'pod', 'N/A') LIKE (CASE WHEN '${pod}' = 'All' THEN '%%' ELSE '${pod}' END) ORDER BY time ASC",
           "refId": "A",
           "timeColumns": [
             "time"
@@ -254,7 +254,7 @@
             "uid": "kpi-datasource"
           },
           "format": "table",
-          "rawSql": "SELECT 'Max Value' AS metric_labels, MAX(metric_value) AS metric_value, $__from/1000 AS time FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE timestamp_value >= $__from / 1000 AND timestamp_value < $__to / 1000 AND kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) AND COALESCE(metric_labels->>'node', metric_labels->>'instance', 'N/A') LIKE (CASE WHEN '${node}' = 'All' THEN '%%' ELSE '${node}' END) AND COALESCE(metric_labels->>'job', 'N/A') LIKE (CASE WHEN '${job}' = 'All' THEN '%%' ELSE '${job}' END) AND COALESCE(metric_labels->>'container', 'N/A') LIKE (CASE WHEN '${container}' = 'All' THEN '%%' ELSE '${container}' END) AND COALESCE(metric_labels->>'pod', 'N/A') LIKE (CASE WHEN '${pod}' = 'All' THEN '%%' ELSE '${pod}' END)",
+          "rawSql": "SELECT 'Max Value' AS metric_labels, MAX(metric_value) AS metric_value, $__from/1000 AS time FROM ${_table} qr JOIN clusters c ON qr.cluster_id = c.id WHERE timestamp_value >= $__from / 1000 AND timestamp_value < $__to / 1000 AND kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) AND COALESCE(metric_labels->>'node', metric_labels->>'instance', 'N/A') LIKE (CASE WHEN '${node}' = 'All' THEN '%%' ELSE '${node}' END) AND COALESCE(metric_labels->>'job', 'N/A') LIKE (CASE WHEN '${job}' = 'All' THEN '%%' ELSE '${job}' END) AND COALESCE(metric_labels->>'container', 'N/A') LIKE (CASE WHEN '${container}' = 'All' THEN '%%' ELSE '${container}' END) AND COALESCE(metric_labels->>'pod', 'N/A') LIKE (CASE WHEN '${pod}' = 'All' THEN '%%' ELSE '${pod}' END)",
           "refId": "B",
           "legendFormat": "Max Value",
           "timeColumns": [
@@ -267,7 +267,7 @@
             "uid": "kpi-datasource"
           },
           "format": "table",
-          "rawSql": "SELECT 'Min Value' AS metric_labels, MIN(metric_value) AS metric_value, $__from/1000 AS time FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE timestamp_value >= $__from / 1000 AND timestamp_value < $__to / 1000 AND kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) AND COALESCE(metric_labels->>'node', metric_labels->>'instance', 'N/A') LIKE (CASE WHEN '${node}' = 'All' THEN '%%' ELSE '${node}' END) AND COALESCE(metric_labels->>'job', 'N/A') LIKE (CASE WHEN '${job}' = 'All' THEN '%%' ELSE '${job}' END) AND COALESCE(metric_labels->>'container', 'N/A') LIKE (CASE WHEN '${container}' = 'All' THEN '%%' ELSE '${container}' END) AND COALESCE(metric_labels->>'pod', 'N/A') LIKE (CASE WHEN '${pod}' = 'All' THEN '%%' ELSE '${pod}' END)",
+          "rawSql": "SELECT 'Min Value' AS metric_labels, MIN(metric_value) AS metric_value, $__from/1000 AS time FROM ${_table} qr JOIN clusters c ON qr.cluster_id = c.id WHERE timestamp_value >= $__from / 1000 AND timestamp_value < $__to / 1000 AND kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) AND COALESCE(metric_labels->>'node', metric_labels->>'instance', 'N/A') LIKE (CASE WHEN '${node}' = 'All' THEN '%%' ELSE '${node}' END) AND COALESCE(metric_labels->>'job', 'N/A') LIKE (CASE WHEN '${job}' = 'All' THEN '%%' ELSE '${job}' END) AND COALESCE(metric_labels->>'container', 'N/A') LIKE (CASE WHEN '${container}' = 'All' THEN '%%' ELSE '${container}' END) AND COALESCE(metric_labels->>'pod', 'N/A') LIKE (CASE WHEN '${pod}' = 'All' THEN '%%' ELSE '${pod}' END)",
           "refId": "C",
           "legendFormat": "Min Value",
           "timeColumns": [
@@ -280,7 +280,7 @@
             "uid": "kpi-datasource"
           },
           "format": "table",
-          "rawSql": "SELECT 'Average Value' AS metric_labels, AVG(metric_value) AS metric_value, $__from/1000 AS time FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE timestamp_value >= $__from / 1000 AND timestamp_value < $__to / 1000 AND kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) AND COALESCE(metric_labels->>'node', metric_labels->>'instance', 'N/A') LIKE (CASE WHEN '${node}' = 'All' THEN '%%' ELSE '${node}' END) AND COALESCE(metric_labels->>'job', 'N/A') LIKE (CASE WHEN '${job}' = 'All' THEN '%%' ELSE '${job}' END) AND COALESCE(metric_labels->>'container', 'N/A') LIKE (CASE WHEN '${container}' = 'All' THEN '%%' ELSE '${container}' END) AND COALESCE(metric_labels->>'pod', 'N/A') LIKE (CASE WHEN '${pod}' = 'All' THEN '%%' ELSE '${pod}' END)",
+          "rawSql": "SELECT 'Average Value' AS metric_labels, AVG(metric_value) AS metric_value, $__from/1000 AS time FROM ${_table} qr JOIN clusters c ON qr.cluster_id = c.id WHERE timestamp_value >= $__from / 1000 AND timestamp_value < $__to / 1000 AND kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) AND COALESCE(metric_labels->>'node', metric_labels->>'instance', 'N/A') LIKE (CASE WHEN '${node}' = 'All' THEN '%%' ELSE '${node}' END) AND COALESCE(metric_labels->>'job', 'N/A') LIKE (CASE WHEN '${job}' = 'All' THEN '%%' ELSE '${job}' END) AND COALESCE(metric_labels->>'container', 'N/A') LIKE (CASE WHEN '${container}' = 'All' THEN '%%' ELSE '${container}' END) AND COALESCE(metric_labels->>'pod', 'N/A') LIKE (CASE WHEN '${pod}' = 'All' THEN '%%' ELSE '${pod}' END)",
           "refId": "D",
           "legendFormat": "Average Value",
           "timeColumns": [
@@ -361,7 +361,7 @@
             "uid": "kpi-datasource"
           },
           "format": "table",
-          "rawSql": "SELECT COUNT(*) as \"Samples\", ROUND(CAST(AVG(metric_value) AS numeric), 6) as \"Average\", ROUND(CAST(MIN(metric_value) AS numeric), 6) as \"Minimum\", ROUND(CAST(MAX(metric_value) AS numeric), 6) as \"Maximum\" FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE timestamp_value >= $__from / 1000 AND timestamp_value < $__to / 1000 AND kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) AND COALESCE(metric_labels->>'node', metric_labels->>'instance', 'N/A') LIKE (CASE WHEN '${node}' = 'All' THEN '%%' ELSE '${node}' END) AND COALESCE(metric_labels->>'job', 'N/A') LIKE (CASE WHEN '${job}' = 'All' THEN '%%' ELSE '${job}' END) AND COALESCE(metric_labels->>'container', 'N/A') LIKE (CASE WHEN '${container}' = 'All' THEN '%%' ELSE '${container}' END) AND COALESCE(metric_labels->>'pod', 'N/A') LIKE (CASE WHEN '${pod}' = 'All' THEN '%%' ELSE '${pod}' END)",
+          "rawSql": "SELECT COUNT(*) as \"Samples\", ROUND(CAST(AVG(metric_value) AS numeric), 6) as \"Average\", ROUND(CAST(MIN(metric_value) AS numeric), 6) as \"Minimum\", ROUND(CAST(MAX(metric_value) AS numeric), 6) as \"Maximum\" FROM ${_table} qr JOIN clusters c ON qr.cluster_id = c.id WHERE timestamp_value >= $__from / 1000 AND timestamp_value < $__to / 1000 AND kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) AND COALESCE(metric_labels->>'node', metric_labels->>'instance', 'N/A') LIKE (CASE WHEN '${node}' = 'All' THEN '%%' ELSE '${node}' END) AND COALESCE(metric_labels->>'job', 'N/A') LIKE (CASE WHEN '${job}' = 'All' THEN '%%' ELSE '${job}' END) AND COALESCE(metric_labels->>'container', 'N/A') LIKE (CASE WHEN '${container}' = 'All' THEN '%%' ELSE '${container}' END) AND COALESCE(metric_labels->>'pod', 'N/A') LIKE (CASE WHEN '${pod}' = 'All' THEN '%%' ELSE '${pod}' END)",
           "refId": "A"
         }
       ],
@@ -432,7 +432,7 @@
             "uid": "kpi-datasource"
           },
           "format": "table",
-          "rawSql": "SELECT metric_labels, ROUND(CAST(AVG(metric_value) AS numeric), 6) AS avg_value, ROUND(CAST(MIN(metric_value) AS numeric), 6) AS min_value, ROUND(CAST(MAX(metric_value) AS numeric), 6) AS max_value, COUNT(*) AS samples FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE timestamp_value >= $__from / 1000 AND timestamp_value < $__to / 1000 AND kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) AND COALESCE(metric_labels->>'node', metric_labels->>'instance', 'N/A') LIKE (CASE WHEN '${node}' = 'All' THEN '%%' ELSE '${node}' END) AND COALESCE(metric_labels->>'job', 'N/A') LIKE (CASE WHEN '${job}' = 'All' THEN '%%' ELSE '${job}' END) AND COALESCE(metric_labels->>'container', 'N/A') LIKE (CASE WHEN '${container}' = 'All' THEN '%%' ELSE '${container}' END) AND COALESCE(metric_labels->>'pod', 'N/A') LIKE (CASE WHEN '${pod}' = 'All' THEN '%%' ELSE '${pod}' END) GROUP BY metric_labels ORDER BY avg_value DESC LIMIT 100",
+          "rawSql": "SELECT metric_labels, ROUND(CAST(AVG(metric_value) AS numeric), 6) AS avg_value, ROUND(CAST(MIN(metric_value) AS numeric), 6) AS min_value, ROUND(CAST(MAX(metric_value) AS numeric), 6) AS max_value, COUNT(*) AS samples FROM ${_table} qr JOIN clusters c ON qr.cluster_id = c.id WHERE timestamp_value >= $__from / 1000 AND timestamp_value < $__to / 1000 AND kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) AND COALESCE(metric_labels->>'node', metric_labels->>'instance', 'N/A') LIKE (CASE WHEN '${node}' = 'All' THEN '%%' ELSE '${node}' END) AND COALESCE(metric_labels->>'job', 'N/A') LIKE (CASE WHEN '${job}' = 'All' THEN '%%' ELSE '${job}' END) AND COALESCE(metric_labels->>'container', 'N/A') LIKE (CASE WHEN '${container}' = 'All' THEN '%%' ELSE '${container}' END) AND COALESCE(metric_labels->>'pod', 'N/A') LIKE (CASE WHEN '${pod}' = 'All' THEN '%%' ELSE '${pod}' END) GROUP BY metric_labels ORDER BY avg_value DESC LIMIT 100",
           "refId": "A"
         }
       ],
@@ -604,7 +604,7 @@
             "uid": "kpi-datasource"
           },
           "format": "table",
-          "rawSql": "SELECT kpi_id, COUNT(*) AS sample_count, ROUND(CAST(AVG(metric_value) AS numeric), 6) AS avg_value, ROUND(CAST(MIN(metric_value) AS numeric), 6) AS min_value, ROUND(CAST(MAX(metric_value) AS numeric), 6) AS max_value, ROUND(CAST(MAX(metric_value) - MIN(metric_value) AS numeric), 6) AS range, COUNT(DISTINCT metric_labels) AS unique_metrics FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE timestamp_value >= $__from / 1000 AND timestamp_value < $__to / 1000 AND kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) AND COALESCE(metric_labels->>'node', metric_labels->>'instance', 'N/A') LIKE (CASE WHEN '${node}' = 'All' THEN '%%' ELSE '${node}' END) AND COALESCE(metric_labels->>'job', 'N/A') LIKE (CASE WHEN '${job}' = 'All' THEN '%%' ELSE '${job}' END) AND COALESCE(metric_labels->>'container', 'N/A') LIKE (CASE WHEN '${container}' = 'All' THEN '%%' ELSE '${container}' END) AND COALESCE(metric_labels->>'pod', 'N/A') LIKE (CASE WHEN '${pod}' = 'All' THEN '%%' ELSE '${pod}' END) GROUP BY kpi_id ORDER BY kpi_id",
+          "rawSql": "SELECT kpi_id, COUNT(*) AS sample_count, ROUND(CAST(AVG(metric_value) AS numeric), 6) AS avg_value, ROUND(CAST(MIN(metric_value) AS numeric), 6) AS min_value, ROUND(CAST(MAX(metric_value) AS numeric), 6) AS max_value, ROUND(CAST(MAX(metric_value) - MIN(metric_value) AS numeric), 6) AS range, COUNT(DISTINCT metric_labels) AS unique_metrics FROM ${_table} qr JOIN clusters c ON qr.cluster_id = c.id WHERE timestamp_value >= $__from / 1000 AND timestamp_value < $__to / 1000 AND kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) AND COALESCE(metric_labels->>'node', metric_labels->>'instance', 'N/A') LIKE (CASE WHEN '${node}' = 'All' THEN '%%' ELSE '${node}' END) AND COALESCE(metric_labels->>'job', 'N/A') LIKE (CASE WHEN '${job}' = 'All' THEN '%%' ELSE '${job}' END) AND COALESCE(metric_labels->>'container', 'N/A') LIKE (CASE WHEN '${container}' = 'All' THEN '%%' ELSE '${container}' END) AND COALESCE(metric_labels->>'pod', 'N/A') LIKE (CASE WHEN '${pod}' = 'All' THEN '%%' ELSE '${pod}' END) GROUP BY kpi_id ORDER BY kpi_id",
           "refId": "A"
         }
       ],
@@ -669,7 +669,7 @@
             "uid": "kpi-datasource"
           },
           "format": "table",
-          "rawSql": "SELECT c.cluster_name, COALESCE(c.cluster_type, 'N/A') AS cluster_type, COUNT(DISTINCT qr.kpi_id) AS kpi_count, COUNT(qr.metric_value) AS total_samples, MAX(qr.created_at) AS last_collection FROM clusters c LEFT JOIN query_results qr ON c.id = qr.cluster_id AND qr.timestamp_value >= $__from / 1000 AND qr.timestamp_value < $__to / 1000 WHERE COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) GROUP BY c.cluster_name, COALESCE(c.cluster_type, 'N/A') ORDER BY c.cluster_name",
+          "rawSql": "SELECT c.cluster_name, COALESCE(c.cluster_type, 'N/A') AS cluster_type, COUNT(DISTINCT qr.kpi_id) AS kpi_count, COUNT(qr.metric_value) AS total_samples, MAX(qr.created_at) AS last_collection FROM clusters c LEFT JOIN ${_table} qr ON c.id = qr.cluster_id AND qr.timestamp_value >= $__from / 1000 AND qr.timestamp_value < $__to / 1000 WHERE COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) GROUP BY c.cluster_name, COALESCE(c.cluster_type, 'N/A') ORDER BY c.cluster_name",
           "refId": "A"
         }
       ],
@@ -716,14 +716,14 @@
           "type": "postgres",
           "uid": "kpi-datasource"
         },
-        "definition": "SELECT cluster_name FROM (SELECT c.cluster_name, CASE WHEN c.id = (SELECT cluster_id FROM query_results ORDER BY created_at DESC LIMIT 1) THEN 1 ELSE 3 END AS sort_order FROM clusters c WHERE COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) UNION ALL SELECT 'All', 2) AS t ORDER BY sort_order, cluster_name;",
+        "definition": "SELECT cluster_name FROM (SELECT c.cluster_name, CASE WHEN c.id = (SELECT cluster_id FROM ${_table} ORDER BY created_at DESC LIMIT 1) THEN 1 ELSE 3 END AS sort_order FROM clusters c WHERE COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) UNION ALL SELECT 'All', 2) AS t ORDER BY sort_order, cluster_name;",
         "hide": 0,
         "includeAll": false,
         "label": "Cluster",
         "multi": false,
         "name": "cluster",
         "options": [],
-        "query": "SELECT cluster_name FROM (SELECT c.cluster_name, CASE WHEN c.id = (SELECT cluster_id FROM query_results ORDER BY created_at DESC LIMIT 1) THEN 1 ELSE 3 END AS sort_order FROM clusters c WHERE COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) UNION ALL SELECT 'All', 2) AS t ORDER BY sort_order, cluster_name;",
+        "query": "SELECT cluster_name FROM (SELECT c.cluster_name, CASE WHEN c.id = (SELECT cluster_id FROM ${_table} ORDER BY created_at DESC LIMIT 1) THEN 1 ELSE 3 END AS sort_order FROM clusters c WHERE COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) UNION ALL SELECT 'All', 2) AS t ORDER BY sort_order, cluster_name;",
         "refresh": 1,
         "type": "query"
       },
@@ -736,14 +736,54 @@
           "type": "postgres",
           "uid": "kpi-datasource"
         },
-        "definition": "SELECT kpi_id FROM (SELECT DISTINCT kpi_id, 1 AS sort_order FROM query_results WHERE kpi_id IS NOT NULL AND kpi_id != '' UNION ALL SELECT 'All', 2) AS t ORDER BY sort_order, kpi_id;",
+        "definition": "SELECT category FROM (SELECT DISTINCT category, 1 AS sort_order FROM kpi_registry WHERE category IS NOT NULL AND category <> '' UNION ALL SELECT 'default', 2) AS t ORDER BY sort_order, category;",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Category",
+        "multi": false,
+        "name": "category",
+        "options": [],
+        "query": "SELECT category FROM (SELECT DISTINCT category, 1 AS sort_order FROM kpi_registry WHERE category IS NOT NULL AND category <> '' UNION ALL SELECT 'default', 2) AS t ORDER BY sort_order, category;",
+        "refresh": 1,
+        "type": "query"
+      },
+      {
+        "name": "_table",
+        "type": "query",
+        "label": "",
+        "datasource": {
+          "type": "postgres",
+          "uid": "kpi-datasource"
+        },
+        "query": "SELECT CASE WHEN '${category}' = 'default' THEN 'query_results' ELSE 'kpi_' || '${category}' END;",
+        "definition": "SELECT CASE WHEN '${category}' = 'default' THEN 'query_results' ELSE 'kpi_' || '${category}' END;",
+        "includeAll": false,
+        "multi": false,
+        "current": {
+          "text": "",
+          "value": ""
+        },
+        "options": [],
+        "refresh": 1,
+        "hide": 2
+      },
+      {
+        "current": {
+          "text": "",
+          "value": ""
+        },
+        "datasource": {
+          "type": "postgres",
+          "uid": "kpi-datasource"
+        },
+        "definition": "SELECT kpi_id FROM (SELECT DISTINCT kpi_id, 1 AS sort_order FROM ${_table} WHERE kpi_id IS NOT NULL AND kpi_id != '' UNION ALL SELECT 'All', 2) AS t ORDER BY sort_order, kpi_id;",
         "hide": 0,
         "includeAll": false,
         "label": "KPI",
         "multi": false,
         "name": "kpi",
         "options": [],
-        "query": "SELECT kpi_id FROM (SELECT DISTINCT kpi_id, 1 AS sort_order FROM query_results WHERE kpi_id IS NOT NULL AND kpi_id != '' UNION ALL SELECT 'All', 2) AS t ORDER BY sort_order, kpi_id;",
+        "query": "SELECT kpi_id FROM (SELECT DISTINCT kpi_id, 1 AS sort_order FROM ${_table} WHERE kpi_id IS NOT NULL AND kpi_id != '' UNION ALL SELECT 'All', 2) AS t ORDER BY sort_order, kpi_id;",
         "refresh": 1,
         "type": "query"
       },
@@ -756,14 +796,14 @@
           "type": "postgres",
           "uid": "kpi-datasource"
         },
-        "definition": "SELECT node FROM (SELECT 'All' AS node, 1 AS order_col UNION ALL SELECT DISTINCT COALESCE(metric_labels->>'node', metric_labels->>'instance', 'N/A'), 2 AS order_col FROM query_results WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND COALESCE(metric_labels->>'node', metric_labels->>'instance') IS NOT NULL) AS temp_data ORDER BY order_col, node;",
+        "definition": "SELECT node FROM (SELECT 'All' AS node, 1 AS order_col UNION ALL SELECT DISTINCT COALESCE(metric_labels->>'node', metric_labels->>'instance', 'N/A'), 2 AS order_col FROM ${_table} WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND COALESCE(metric_labels->>'node', metric_labels->>'instance') IS NOT NULL) AS temp_data ORDER BY order_col, node;",
         "hide": 0,
         "includeAll": false,
         "label": "Node",
         "multi": false,
         "name": "node",
         "options": [],
-        "query": "SELECT node FROM (SELECT 'All' AS node, 1 AS order_col UNION ALL SELECT DISTINCT COALESCE(metric_labels->>'node', metric_labels->>'instance', 'N/A'), 2 AS order_col FROM query_results WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND COALESCE(metric_labels->>'node', metric_labels->>'instance') IS NOT NULL) AS temp_data ORDER BY order_col, node;",
+        "query": "SELECT node FROM (SELECT 'All' AS node, 1 AS order_col UNION ALL SELECT DISTINCT COALESCE(metric_labels->>'node', metric_labels->>'instance', 'N/A'), 2 AS order_col FROM ${_table} WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND COALESCE(metric_labels->>'node', metric_labels->>'instance') IS NOT NULL) AS temp_data ORDER BY order_col, node;",
         "refresh": 1,
         "type": "query"
       },
@@ -776,14 +816,14 @@
           "type": "postgres",
           "uid": "kpi-datasource"
         },
-        "definition": "SELECT job FROM (SELECT 'All' AS job, 1 AS order_col UNION ALL SELECT DISTINCT COALESCE(metric_labels->>'job', 'N/A'), 2 AS order_col FROM query_results WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND metric_labels->>'job' IS NOT NULL) AS temp_data ORDER BY order_col, job;",
+        "definition": "SELECT job FROM (SELECT 'All' AS job, 1 AS order_col UNION ALL SELECT DISTINCT COALESCE(metric_labels->>'job', 'N/A'), 2 AS order_col FROM ${_table} WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND metric_labels->>'job' IS NOT NULL) AS temp_data ORDER BY order_col, job;",
         "hide": 0,
         "includeAll": false,
         "label": "Job",
         "multi": false,
         "name": "job",
         "options": [],
-        "query": "SELECT job FROM (SELECT 'All' AS job, 1 AS order_col UNION ALL SELECT DISTINCT COALESCE(metric_labels->>'job', 'N/A'), 2 AS order_col FROM query_results WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND metric_labels->>'job' IS NOT NULL) AS temp_data ORDER BY order_col, job;",
+        "query": "SELECT job FROM (SELECT 'All' AS job, 1 AS order_col UNION ALL SELECT DISTINCT COALESCE(metric_labels->>'job', 'N/A'), 2 AS order_col FROM ${_table} WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND metric_labels->>'job' IS NOT NULL) AS temp_data ORDER BY order_col, job;",
         "refresh": 1,
         "type": "query"
       },
@@ -796,14 +836,14 @@
           "type": "postgres",
           "uid": "kpi-datasource"
         },
-        "definition": "SELECT container FROM (SELECT 'All' AS container, 1 AS order_col UNION ALL SELECT DISTINCT COALESCE(metric_labels->>'container', 'N/A'), 2 AS order_col FROM query_results WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND metric_labels->>'container' IS NOT NULL) AS temp_data ORDER BY order_col, container;",
+        "definition": "SELECT container FROM (SELECT 'All' AS container, 1 AS order_col UNION ALL SELECT DISTINCT COALESCE(metric_labels->>'container', 'N/A'), 2 AS order_col FROM ${_table} WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND metric_labels->>'container' IS NOT NULL) AS temp_data ORDER BY order_col, container;",
         "hide": 0,
         "includeAll": false,
         "label": "Container",
         "multi": false,
         "name": "container",
         "options": [],
-        "query": "SELECT container FROM (SELECT 'All' AS container, 1 AS order_col UNION ALL SELECT DISTINCT COALESCE(metric_labels->>'container', 'N/A'), 2 AS order_col FROM query_results WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND metric_labels->>'container' IS NOT NULL) AS temp_data ORDER BY order_col, container;",
+        "query": "SELECT container FROM (SELECT 'All' AS container, 1 AS order_col UNION ALL SELECT DISTINCT COALESCE(metric_labels->>'container', 'N/A'), 2 AS order_col FROM ${_table} WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND metric_labels->>'container' IS NOT NULL) AS temp_data ORDER BY order_col, container;",
         "refresh": 1,
         "type": "query"
       },
@@ -816,14 +856,14 @@
           "type": "postgres",
           "uid": "kpi-datasource"
         },
-        "definition": "SELECT pod FROM (SELECT 'All' AS pod, 1 AS order_col UNION ALL SELECT DISTINCT COALESCE(metric_labels->>'pod', 'N/A'), 2 AS order_col FROM query_results WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND metric_labels->>'pod' IS NOT NULL) AS temp_data ORDER BY order_col, pod;",
+        "definition": "SELECT pod FROM (SELECT 'All' AS pod, 1 AS order_col UNION ALL SELECT DISTINCT COALESCE(metric_labels->>'pod', 'N/A'), 2 AS order_col FROM ${_table} WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND metric_labels->>'pod' IS NOT NULL) AS temp_data ORDER BY order_col, pod;",
         "hide": 0,
         "includeAll": false,
         "label": "Pod",
         "multi": false,
         "name": "pod",
         "options": [],
-        "query": "SELECT pod FROM (SELECT 'All' AS pod, 1 AS order_col UNION ALL SELECT DISTINCT COALESCE(metric_labels->>'pod', 'N/A'), 2 AS order_col FROM query_results WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND metric_labels->>'pod' IS NOT NULL) AS temp_data ORDER BY order_col, pod;",
+        "query": "SELECT pod FROM (SELECT 'All' AS pod, 1 AS order_col UNION ALL SELECT DISTINCT COALESCE(metric_labels->>'pod', 'N/A'), 2 AS order_col FROM ${_table} WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND metric_labels->>'pod' IS NOT NULL) AS temp_data ORDER BY order_col, pod;",
         "refresh": 1,
         "type": "query"
       },
@@ -834,8 +874,8 @@
           "type": "postgres",
           "uid": "kpi-datasource"
         },
-        "query": "SELECT COALESCE(CAST(MIN(timestamp_value) * 1000 AS BIGINT), 0) FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END)",
-        "definition": "SELECT COALESCE(CAST(MIN(timestamp_value) * 1000 AS BIGINT), 0) FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END)",
+        "query": "SELECT COALESCE(CAST(MIN(timestamp_value) * 1000 AS BIGINT), 0) FROM ${_table} qr JOIN clusters c ON qr.cluster_id = c.id WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END)",
+        "definition": "SELECT COALESCE(CAST(MIN(timestamp_value) * 1000 AS BIGINT), 0) FROM ${_table} qr JOIN clusters c ON qr.cluster_id = c.id WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END)",
         "includeAll": false,
         "multi": false,
         "current": {
@@ -853,8 +893,8 @@
           "type": "postgres",
           "uid": "kpi-datasource"
         },
-        "query": "SELECT COALESCE(CAST(MAX(timestamp_value) * 1000 AS BIGINT), 0) FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END)",
-        "definition": "SELECT COALESCE(CAST(MAX(timestamp_value) * 1000 AS BIGINT), 0) FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END)",
+        "query": "SELECT COALESCE(CAST(MAX(timestamp_value) * 1000 AS BIGINT), 0) FROM ${_table} qr JOIN clusters c ON qr.cluster_id = c.id WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END)",
+        "definition": "SELECT COALESCE(CAST(MAX(timestamp_value) * 1000 AS BIGINT), 0) FROM ${_table} qr JOIN clusters c ON qr.cluster_id = c.id WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END)",
         "includeAll": false,
         "multi": false,
         "current": {

--- a/internal/database/db_interface_test.go
+++ b/internal/database/db_interface_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/prometheus/common/model"
+	"github.com/redhat-best-practices-for-k8s/kpi-collection-tool/internal/config"
 )
 
 // RunDatabaseInterfaceTests runs the complete test suite for any Database implementation.
@@ -329,6 +330,203 @@ func RunDatabaseInterfaceTests(getImpl func() (Database, *sql.DB)) {
 				err = db.QueryRow("SELECT cluster_id FROM query_results WHERE kpi_id = $1", "query-cluster-2").Scan(&storedClusterID)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(storedClusterID).To(Equal(clusterID2))
+			})
+		})
+	})
+
+	Describe("Category Tables", func() {
+		var clusterID int64
+
+		BeforeEach(func() {
+			var err error
+			clusterID, err = dbImpl.GetOrCreateCluster(db, "cat-cluster", "ran")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		Describe("EnsureCategoryTable", func() {
+			It("should create a table and register the KPI", func() {
+				tableName, err := dbImpl.EnsureCategoryTable(db, "cpu", "node-cpu-usage")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(tableName).To(Equal("kpi_cpu"))
+
+				cat, tn, err := dbImpl.LookupCategoryForKPI(db, "node-cpu-usage")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cat).To(Equal("cpu"))
+				Expect(tn).To(Equal("kpi_cpu"))
+			})
+
+			It("should be idempotent for the same category", func() {
+				_, err := dbImpl.EnsureCategoryTable(db, "memory", "mem-usage-1")
+				Expect(err).NotTo(HaveOccurred())
+				_, err = dbImpl.EnsureCategoryTable(db, "memory", "mem-usage-2")
+				Expect(err).NotTo(HaveOccurred())
+
+				categories, err := dbImpl.ListCategories(db)
+				Expect(err).NotTo(HaveOccurred())
+				memCount := 0
+				for _, c := range categories {
+					if c.Category == "memory" {
+						memCount++
+						Expect(c.TableName).To(Equal("kpi_memory"))
+					}
+				}
+				Expect(memCount).To(Equal(1))
+			})
+		})
+
+		Describe("StoreQueryResults with category", func() {
+			It("should route categorised writes to the category table", func() {
+				vector := model.Vector{
+					&model.Sample{
+						Metric:    model.Metric{"__name__": "cpu_seconds"},
+						Value:     model.SampleValue(0.75),
+						Timestamp: model.Time(time.Now().Unix() * 1000),
+					},
+				}
+
+				err := dbImpl.StoreQueryResults(db, clusterID, "node-cpu", "cpu", vector)
+				Expect(err).NotTo(HaveOccurred())
+
+				var count int
+				err = db.QueryRow("SELECT COUNT(*) FROM kpi_cpu WHERE kpi_id = $1", "node-cpu").Scan(&count)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(count).To(Equal(1))
+
+				err = db.QueryRow("SELECT COUNT(*) FROM query_results WHERE kpi_id = $1", "node-cpu").Scan(&count)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(count).To(Equal(0))
+			})
+
+			It("should enforce dedup on category tables", func() {
+				ts := model.Time(time.Now().Unix() * 1000)
+				vector := model.Vector{
+					&model.Sample{
+						Metric:    model.Metric{"__name__": "mem_bytes"},
+						Value:     model.SampleValue(1024),
+						Timestamp: ts,
+					},
+				}
+
+				err := dbImpl.StoreQueryResults(db, clusterID, "mem-kpi", "memory", vector)
+				Expect(err).NotTo(HaveOccurred())
+				err = dbImpl.StoreQueryResults(db, clusterID, "mem-kpi", "memory", vector)
+				Expect(err).NotTo(HaveOccurred())
+
+				var count int
+				err = db.QueryRow("SELECT COUNT(*) FROM kpi_memory WHERE kpi_id = $1", "mem-kpi").Scan(&count)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(count).To(Equal(1))
+			})
+		})
+
+		Describe("ValidateCategoryConsistency", func() {
+			BeforeEach(func() {
+				_, err := dbImpl.EnsureCategoryTable(db, "cpu", "node-cpu")
+				Expect(err).NotTo(HaveOccurred())
+				_, err = dbImpl.EnsureCategoryTable(db, "memory", "mem-usage")
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should pass when categories match", func() {
+				kpis := []config.Query{
+					{ID: "node-cpu", Category: "cpu"},
+					{ID: "mem-usage", Category: "memory"},
+				}
+				err := dbImpl.ValidateCategoryConsistency(db, kpis)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should pass for new KPIs not yet in registry", func() {
+				kpis := []config.Query{
+					{ID: "node-cpu", Category: "cpu"},
+					{ID: "brand-new-kpi", Category: "network"},
+				}
+				err := dbImpl.ValidateCategoryConsistency(db, kpis)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should error when a KPI changes category", func() {
+				kpis := []config.Query{
+					{ID: "node-cpu", Category: "networking"},
+				}
+				err := dbImpl.ValidateCategoryConsistency(db, kpis)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("node-cpu"))
+			})
+
+			It("should error when a categorised KPI becomes uncategorised", func() {
+				kpis := []config.Query{
+					{ID: "node-cpu", Category: ""},
+				}
+				err := dbImpl.ValidateCategoryConsistency(db, kpis)
+				Expect(err).To(HaveOccurred())
+			})
+		})
+
+		Describe("ListCategories", func() {
+			It("should return empty list when no categories exist", func() {
+				categories, err := dbImpl.ListCategories(db)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(categories).To(BeEmpty())
+			})
+
+			It("should return all distinct categories", func() {
+				_, err := dbImpl.EnsureCategoryTable(db, "cpu", "node-cpu")
+				Expect(err).NotTo(HaveOccurred())
+				_, err = dbImpl.EnsureCategoryTable(db, "cpu", "container-cpu")
+				Expect(err).NotTo(HaveOccurred())
+				_, err = dbImpl.EnsureCategoryTable(db, "memory", "mem-usage")
+				Expect(err).NotTo(HaveOccurred())
+
+				categories, err := dbImpl.ListCategories(db)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(categories).To(HaveLen(2))
+			})
+		})
+
+		Describe("LookupCategoryForKPI", func() {
+			It("should return empty strings for an unregistered KPI", func() {
+				cat, table, err := dbImpl.LookupCategoryForKPI(db, "unknown-kpi")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cat).To(BeEmpty())
+				Expect(table).To(BeEmpty())
+			})
+
+			It("should return category and table for a registered KPI", func() {
+				_, err := dbImpl.EnsureCategoryTable(db, "cpu", "node-cpu")
+				Expect(err).NotTo(HaveOccurred())
+
+				cat, table, err := dbImpl.LookupCategoryForKPI(db, "node-cpu")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cat).To(Equal("cpu"))
+				Expect(table).To(Equal("kpi_cpu"))
+			})
+		})
+
+		Describe("DeleteByCategory", func() {
+			It("should delete all rows from the category table and clean registry", func() {
+				vector := model.Vector{
+					&model.Sample{
+						Metric:    model.Metric{"__name__": "cpu_usage"},
+						Value:     model.SampleValue(0.5),
+						Timestamp: model.Time(time.Now().Unix() * 1000),
+					},
+				}
+				err := dbImpl.StoreQueryResults(db, clusterID, "cpu-kpi", "cpu", vector)
+				Expect(err).NotTo(HaveOccurred())
+
+				deleted, err := dbImpl.DeleteByCategory(db, "cpu")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(deleted).To(Equal(int64(1)))
+
+				var count int
+				err = db.QueryRow("SELECT COUNT(*) FROM kpi_cpu").Scan(&count)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(count).To(Equal(0))
+
+				err = db.QueryRow("SELECT COUNT(*) FROM kpi_registry WHERE category = $1", "cpu").Scan(&count)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(count).To(Equal(0))
 			})
 		})
 	})

--- a/internal/database/postgres.go
+++ b/internal/database/postgres.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"sync"
 
 	_ "github.com/lib/pq"
 	"github.com/prometheus/common/model"
@@ -13,6 +14,7 @@ import (
 // PostgresDB implements the Database interface for PostgreSQL
 type PostgresDB struct {
 	ConnectionURL string
+	knownTables   sync.Map
 }
 
 // NewPostgresDB creates a new PostgreSQL database instance
@@ -27,7 +29,6 @@ func (p *PostgresDB) InitDB() (*sql.DB, error) {
 		return nil, fmt.Errorf("failed to connect to postgres: %v", err)
 	}
 
-	// Test the connection
 	if err := db.Ping(); err != nil {
 		return nil, fmt.Errorf("failed to ping postgres: %v", err)
 	}
@@ -57,15 +58,20 @@ func (p *PostgresDB) InitDB() (*sql.DB, error) {
         errors INTEGER DEFAULT 0
     );
 
-    -- Create indexes for better query performance
     CREATE INDEX IF NOT EXISTS idx_query_results_cluster_id ON query_results(cluster_id);
     CREATE INDEX IF NOT EXISTS idx_query_results_kpi_id ON query_results(kpi_id);
     CREATE INDEX IF NOT EXISTS idx_query_results_created_at ON query_results(created_at);
     CREATE INDEX IF NOT EXISTS idx_query_results_labels ON query_results USING GIN(metric_labels);
 
-    -- Prevent duplicate data points from overlapping range query windows
     CREATE UNIQUE INDEX IF NOT EXISTS idx_query_results_dedup
     ON query_results(kpi_id, cluster_id, timestamp_value, metric_labels);
+
+    CREATE TABLE IF NOT EXISTS kpi_registry (
+        kpi_id TEXT PRIMARY KEY,
+        category TEXT NOT NULL,
+        table_name TEXT NOT NULL,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    );
     `
 
 	_, err = db.Exec(schema)
@@ -76,7 +82,6 @@ func (p *PostgresDB) InitDB() (*sql.DB, error) {
 func (p *PostgresDB) GetOrCreateCluster(db *sql.DB, clusterName string, clusterType string) (int64, error) {
 	var clusterID int64
 
-	// Try to get existing cluster
 	err := db.QueryRow("SELECT id FROM clusters WHERE cluster_name = $1", clusterName).Scan(&clusterID)
 	if err == nil {
 		if clusterType != "" {
@@ -88,7 +93,6 @@ func (p *PostgresDB) GetOrCreateCluster(db *sql.DB, clusterName string, clusterT
 		return clusterID, nil
 	}
 
-	// Insert new cluster and return ID
 	err = db.QueryRow(
 		"INSERT INTO clusters (cluster_name, cluster_type) VALUES ($1, $2) ON CONFLICT (cluster_name) DO UPDATE SET cluster_type = EXCLUDED.cluster_type RETURNING id",
 		clusterName, clusterType,
@@ -116,54 +120,161 @@ func (p *PostgresDB) GetQueryErrorCount(db *sql.DB, kpiID string) (int, error) {
 	return count, err
 }
 
-// EnsureCategoryTable is a no-op stub for PostgreSQL. Category table support
-// will be implemented in a future PR; all writes go to query_results for now.
-// --- TODO ---
-func (p *PostgresDB) EnsureCategoryTable(_ *sql.DB, _ string, _ string) (string, error) {
-	return DefaultTableName, nil
+// EnsureCategoryTable lazily creates the per-category table and registers the
+// KPI→category mapping. The DDL is idempotent and only executed once per
+// process lifetime thanks to the in-memory knownTables cache.
+func (p *PostgresDB) EnsureCategoryTable(db *sql.DB, category, kpiID string) (string, error) {
+	tableName := CategoryTableName(category)
+
+	if _, ok := p.knownTables.Load(tableName); !ok {
+		ddl := fmt.Sprintf(`
+			CREATE TABLE IF NOT EXISTS %s (
+				id SERIAL PRIMARY KEY,
+				kpi_id TEXT NOT NULL,
+				metric_value DOUBLE PRECISION,
+				timestamp_value DOUBLE PRECISION,
+				cluster_id INTEGER NOT NULL REFERENCES clusters(id),
+				execution_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+				created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+				metric_labels JSONB
+			);
+			CREATE UNIQUE INDEX IF NOT EXISTS idx_%s_dedup
+			ON %s(kpi_id, cluster_id, timestamp_value, metric_labels)`,
+			tableName, tableName, tableName)
+
+		if _, err := db.Exec(ddl); err != nil {
+			return "", fmt.Errorf("create table %s: %w", tableName, err)
+		}
+
+		p.knownTables.Store(tableName, true)
+	}
+
+	_, err := db.Exec(`
+		INSERT INTO kpi_registry (kpi_id, category, table_name) VALUES ($1, $2, $3)
+		ON CONFLICT(kpi_id) DO NOTHING`,
+		kpiID, category, tableName)
+	if err != nil {
+		return "", fmt.Errorf("register kpi '%s' in kpi_registry: %w", kpiID, err)
+	}
+
+	return tableName, nil
 }
 
-// ValidateCategoryConsistency is a no-op stub for PostgreSQL until category
-// table support is implemented.
-// --- TODO ---
-func (p *PostgresDB) ValidateCategoryConsistency(_ *sql.DB, _ []config.Query) error {
+// ValidateCategoryConsistency checks that no KPI in the incoming config has
+// changed its category compared to what is already stored in kpi_registry.
+func (p *PostgresDB) ValidateCategoryConsistency(db *sql.DB, kpis []config.Query) error {
+	rows, err := db.Query("SELECT kpi_id, category FROM kpi_registry")
+	if err != nil {
+		return fmt.Errorf("query kpi_registry: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	registered := make(map[string]string)
+	for rows.Next() {
+		var kpiID, category string
+		if err := rows.Scan(&kpiID, &category); err != nil {
+			return fmt.Errorf("scan kpi_registry row: %w", err)
+		}
+		registered[kpiID] = category
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate kpi_registry: %w", err)
+	}
+
+	for i := range kpis {
+		prev, exists := registered[kpis[i].ID]
+		if !exists {
+			continue
+		}
+		if prev != kpis[i].Category {
+			return fmt.Errorf(
+				"KPI '%s' category changed from %q to %q — "+
+					"use a different database or delete the existing one",
+				kpis[i].ID, prev, kpis[i].Category)
+		}
+	}
+
 	return nil
 }
 
-// ListCategories is a no-op stub for PostgreSQL until category support is implemented.
-// --- TODO ---
-func (p *PostgresDB) ListCategories(_ *sql.DB) ([]CategoryInfo, error) {
-	return nil, nil
+// ListCategories returns all distinct categories registered in kpi_registry.
+func (p *PostgresDB) ListCategories(db *sql.DB) ([]CategoryInfo, error) {
+	rows, err := db.Query("SELECT DISTINCT category, table_name FROM kpi_registry ORDER BY category")
+	if err != nil {
+		return nil, fmt.Errorf("query kpi_registry: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var categories []CategoryInfo
+	for rows.Next() {
+		var ci CategoryInfo
+		if err := rows.Scan(&ci.Category, &ci.TableName); err != nil {
+			return nil, fmt.Errorf("scan kpi_registry row: %w", err)
+		}
+		categories = append(categories, ci)
+	}
+
+	return categories, rows.Err()
 }
 
-// LookupCategoryForKPI is a no-op stub for PostgreSQL until category support is implemented.
-// --- TODO ---
-func (p *PostgresDB) LookupCategoryForKPI(_ *sql.DB, _ string) (string, string, error) {
-	return "", "", nil
+// LookupCategoryForKPI returns the category and table name for a KPI ID.
+// Returns empty strings when the KPI has no registry entry (uncategorized).
+func (p *PostgresDB) LookupCategoryForKPI(db *sql.DB, kpiID string) (category, tableName string, err error) {
+	err = db.QueryRow("SELECT category, table_name FROM kpi_registry WHERE kpi_id = $1", kpiID).
+		Scan(&category, &tableName)
+
+	if err == sql.ErrNoRows {
+		return "", "", nil
+	}
+	if err != nil {
+		return "", "", fmt.Errorf("lookup kpi_registry for '%s': %w", kpiID, err)
+	}
+
+	return category, tableName, nil
 }
 
-// DeleteByCategory is a no-op stub for PostgreSQL until category support is implemented.
-// --- TODO ---
-func (p *PostgresDB) DeleteByCategory(_ *sql.DB, _ string) (int64, error) {
-	return 0, nil
+// DeleteByCategory removes all rows from the given category table and cleans
+// up the corresponding kpi_registry entries. Returns the number of metric rows deleted.
+func (p *PostgresDB) DeleteByCategory(db *sql.DB, category string) (int64, error) {
+	tableName := CategoryTableName(category)
+
+	result, err := db.Exec(fmt.Sprintf("DELETE FROM %s", tableName))
+	if err != nil {
+		return 0, fmt.Errorf("delete from %s: %w", tableName, err)
+	}
+	deleted, _ := result.RowsAffected()
+
+	_, err = db.Exec("DELETE FROM kpi_registry WHERE category = $1", category)
+	if err != nil {
+		return deleted, fmt.Errorf("clean kpi_registry for category '%s': %w", category, err)
+	}
+
+	return deleted, nil
 }
 
 // StoreQueryResults stores the results of a Prometheus query in the database.
-// The category parameter is accepted for interface compatibility but ignored —
-// all data is written to the default query_results table until PostgreSQL
-// category support is implemented.
-func (p *PostgresDB) StoreQueryResults(db *sql.DB, clusterID int64, queryID string, _ string, result model.Value) error {
+// When category is non-empty, writes go to the per-category table (kpi_<category>).
+func (p *PostgresDB) StoreQueryResults(db *sql.DB, clusterID int64, queryID, category string, result model.Value) error {
+	tableName := DefaultTableName
+	if category != "" {
+		name, err := p.EnsureCategoryTable(db, category, queryID)
+		if err != nil {
+			return fmt.Errorf("ensure category table for '%s': %w", category, err)
+		}
+		tableName = name
+	}
+
 	switch values := result.(type) {
 	case model.Vector:
-		return p.storeVectorResults(db, clusterID, queryID, values)
+		return p.storeVectorResults(db, clusterID, queryID, tableName, values)
 	case model.Matrix:
-		return p.storeMatrixResults(db, clusterID, queryID, values)
+		return p.storeMatrixResults(db, clusterID, queryID, tableName, values)
 	default:
 		return fmt.Errorf("unsupported Prometheus result type for KPI '%s': %T", queryID, result)
 	}
 }
 
-func (p *PostgresDB) storeVectorResults(db *sql.DB, clusterID int64, queryID string, vector model.Vector) error {
+func (p *PostgresDB) storeVectorResults(db *sql.DB, clusterID int64, queryID, table string, vector model.Vector) error {
 	for _, sample := range vector {
 		metric := sample.Metric
 		value := float64(sample.Value)
@@ -174,11 +285,11 @@ func (p *PostgresDB) storeVectorResults(db *sql.DB, clusterID int64, queryID str
 			return err
 		}
 
-		_, err = db.Exec(`
-            INSERT INTO query_results 
+		_, err = db.Exec(fmt.Sprintf(`
+            INSERT INTO %s 
             (kpi_id, metric_value, timestamp_value, cluster_id, metric_labels)
             VALUES ($1, $2, $3, $4, $5)
-            ON CONFLICT (kpi_id, cluster_id, timestamp_value, metric_labels) DO NOTHING`,
+            ON CONFLICT (kpi_id, cluster_id, timestamp_value, metric_labels) DO NOTHING`, table),
 			queryID, value, timestamp, clusterID, string(labelsJSON),
 		)
 		if err != nil {
@@ -188,7 +299,7 @@ func (p *PostgresDB) storeVectorResults(db *sql.DB, clusterID int64, queryID str
 	return nil
 }
 
-func (p *PostgresDB) storeMatrixResults(db *sql.DB, clusterID int64, queryID string, matrix model.Matrix) error {
+func (p *PostgresDB) storeMatrixResults(db *sql.DB, clusterID int64, queryID, table string, matrix model.Matrix) error {
 	for _, stream := range matrix {
 		metric := stream.Metric
 		labelsJSON, err := json.Marshal(metric)
@@ -200,11 +311,11 @@ func (p *PostgresDB) storeMatrixResults(db *sql.DB, clusterID int64, queryID str
 			value := float64(samplePair.Value)
 			timestamp := float64(samplePair.Timestamp) / 1000
 
-			_, execErr := db.Exec(`
-                INSERT INTO query_results 
+			_, execErr := db.Exec(fmt.Sprintf(`
+                INSERT INTO %s 
                 (kpi_id, metric_value, timestamp_value, cluster_id, metric_labels)
                 VALUES ($1, $2, $3, $4, $5)
-                ON CONFLICT (kpi_id, cluster_id, timestamp_value, metric_labels) DO NOTHING`,
+                ON CONFLICT (kpi_id, cluster_id, timestamp_value, metric_labels) DO NOTHING`, table),
 				queryID, value, timestamp, clusterID, string(labelsJSON),
 			)
 			if execErr != nil {

--- a/internal/database/postgres_test.go
+++ b/internal/database/postgres_test.go
@@ -3,6 +3,7 @@ package database
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -65,15 +66,15 @@ var _ = Describe("Postgres Implementation", func() {
 		db, err = postgresDB.InitDB()
 		Expect(err).NotTo(HaveOccurred())
 
-		// Clean tables before each test
-		_, err = db.Exec("TRUNCATE TABLE query_results, query_errors, clusters RESTART IDENTITY CASCADE")
+		dropPostgresCategoryTables(db)
+		_, err = db.Exec("TRUNCATE TABLE kpi_registry, query_results, query_errors, clusters RESTART IDENTITY CASCADE")
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	AfterEach(func() {
 		if db != nil {
-			// Clean up after test
-			_, _ = db.Exec("TRUNCATE TABLE query_results, query_errors, clusters RESTART IDENTITY CASCADE")
+			dropPostgresCategoryTables(db)
+			_, _ = db.Exec("TRUNCATE TABLE kpi_registry, query_results, query_errors, clusters RESTART IDENTITY CASCADE")
 			_ = db.Close()
 		}
 	})
@@ -128,6 +129,64 @@ var _ = Describe("Postgres Implementation", func() {
 
 	})
 
+	Describe("Postgres Category Tables", func() {
+		It("should create the kpi_registry table at init", func() {
+			var tableName string
+			err := db.QueryRow(
+				"SELECT table_name FROM information_schema.tables WHERE table_schema='public' AND table_name='kpi_registry'",
+			).Scan(&tableName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(tableName).To(Equal("kpi_registry"))
+		})
+
+		It("should create a category table with JSONB column", func() {
+			_, err := postgresDB.EnsureCategoryTable(db, "cpu", "node-cpu")
+			Expect(err).NotTo(HaveOccurred())
+
+			var dataType string
+			err = db.QueryRow(`
+				SELECT data_type FROM information_schema.columns
+				WHERE table_name = 'kpi_cpu' AND column_name = 'metric_labels'
+			`).Scan(&dataType)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dataType).To(Equal("jsonb"))
+		})
+
+		It("should create a dedup index on the category table", func() {
+			_, err := postgresDB.EnsureCategoryTable(db, "network", "net-kpi")
+			Expect(err).NotTo(HaveOccurred())
+
+			var indexExists bool
+			err = db.QueryRow(`
+				SELECT EXISTS (
+					SELECT 1 FROM pg_indexes WHERE indexname = 'idx_kpi_network_dedup'
+				)
+			`).Scan(&indexExists)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(indexExists).To(BeTrue())
+		})
+	})
+
 	// Run all the shared interface tests
 	RunDatabaseInterfaceTests(func() (Database, *sql.DB) { return postgresDB, db })
 })
+
+func dropPostgresCategoryTables(db *sql.DB) {
+	rows, err := db.Query(`
+		SELECT table_name FROM information_schema.tables
+		WHERE table_schema = 'public'
+		AND table_name LIKE 'kpi_%'
+		AND table_name != 'kpi_registry'`)
+	if err != nil {
+		return
+	}
+	defer func() { _ = rows.Close() }()
+
+	for rows.Next() {
+		var tn string
+		if rows.Scan(&tn) == nil {
+			_, _ = db.Exec(fmt.Sprintf("DROP TABLE IF EXISTS %s CASCADE", tn))
+		}
+	}
+	_ = rows.Err()
+}


### PR DESCRIPTION
Brings the PostgreSQL backend to full category parity with SQLite.

### Changes
- **postgres.go**: Implemented all category methods — `EnsureCategoryTable`, `ValidateCategoryConsistency`,
  `ListCategories`, `LookupCategoryForKPI`, `DeleteByCategory`; `StoreQueryResults` routes writes
  to `kpi_<category>` when a category is set; added `kpi_registry` table to `InitDB` schema
- **postgres-dashboard.json**: Added `category` and hidden `_table` template variables; replaced
  all hardcoded `query_results` references with `${_table}`
- **Tests**: Added shared category tests in `db_interface_test.go` (creation, routing, dedup,
  consistency, listing, lookup, deletion); updated `postgres_test.go` cleanup to handle category tables