### PR TITLE
Add db show categories subcommand and --category validation

### DIFF
--- a/internal/commands/db_remove.go
+++ b/internal/commands/db_remove.go
@@ -132,6 +132,9 @@ func runRemoveKPIs(cmd *cobra.Command, args []string) error {
 	defer func() { _ = db.Close() }()
 
 	if removeCategory != "" {
+		if err := validateCategory(db, dbImpl, removeCategory); err != nil {
+			return err
+		}
 		deleted, err := dbImpl.DeleteByCategory(db, removeCategory)
 		if err != nil {
 			return fmt.Errorf("failed to delete category '%s': %w", removeCategory, err)

--- a/internal/commands/db_show.go
+++ b/internal/commands/db_show.go
@@ -84,6 +84,16 @@ var showClustersCmd = &cobra.Command{
 	RunE: runShowClusters,
 }
 
+var showCategoriesCmd = &cobra.Command{
+	Use:   "categories",
+	Short: "List all KPI categories",
+	Long: `Display all KPI categories registered in the database.
+Shows the category name, backing table, and number of KPIs per category.`,
+	Example: `  # List all categories
+  kpi-collector db show categories`,
+	RunE: runShowCategories,
+}
+
 var showErrorsCmd = &cobra.Command{
 	Use:   "errors",
 	Short: "Show query error counts",
@@ -99,6 +109,7 @@ func init() {
 	dbCmd.AddCommand(showCmd)
 	showCmd.AddCommand(showKPIsCmd)
 	showCmd.AddCommand(showClustersCmd)
+	showCmd.AddCommand(showCategoriesCmd)
 	showCmd.AddCommand(showErrorsCmd)
 
 	// Flags for 'show kpis'
@@ -146,6 +157,12 @@ func runShowKPIs(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to connect to DB: %w", err)
 	}
 	defer func() { _ = db.Close() }()
+
+	if kpiQueryFlags.category != "" {
+		if err := validateCategory(db, dbImpl, kpiQueryFlags.category); err != nil {
+			return err
+		}
+	}
 
 	// Parse time filters
 	var sinceTime, untilTime *time.Time
@@ -233,6 +250,36 @@ func runShowClusters(cmd *cobra.Command, args []string) error {
 	}
 
 	output.PrintClustersTable(records)
+	return nil
+}
+
+func runShowCategories(cmd *cobra.Command, args []string) error {
+	db, dbImpl, err := connectToDB()
+	if err != nil {
+		return fmt.Errorf("failed to connect to DB: %w", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	categories, err := dbImpl.ListCategories(db)
+	if err != nil {
+		return fmt.Errorf("failed to list categories: %w", err)
+	}
+
+	if len(categories) == 0 {
+		fmt.Println("No categories found.")
+		return nil
+	}
+
+	records := make([]output.CategoryRecord, len(categories))
+	for i, c := range categories {
+		records[i] = output.CategoryRecord{
+			Category:  c.Category,
+			TableName: c.TableName,
+			KPICount:  c.KPICount,
+		}
+	}
+
+	output.PrintCategoriesTable(records)
 	return nil
 }
 
@@ -578,6 +625,31 @@ func convertToKPIRecords(results []KPIResult) []output.KPIRecord {
 		}
 	}
 	return records
+}
+
+// validateCategory checks that the given category exists in kpi_registry.
+// Returns a descriptive error listing available categories when it does not.
+func validateCategory(db *sql.DB, dbImpl database.Database, category string) error {
+	categories, err := dbImpl.ListCategories(db)
+	if err != nil {
+		return fmt.Errorf("failed to list categories: %w", err)
+	}
+
+	for _, c := range categories {
+		if c.Category == category {
+			return nil
+		}
+	}
+
+	if len(categories) == 0 {
+		return fmt.Errorf("category %q not found (no categories exist in the database)", category)
+	}
+
+	names := make([]string, len(categories))
+	for i, c := range categories {
+		names[i] = c.Category
+	}
+	return fmt.Errorf("category %q not found; available categories: %s", category, strings.Join(names, ", "))
 }
 
 func convertPostgresToSQLitePlaceholders(query string) string {

--- a/internal/database/db_interface_test.go
+++ b/internal/database/db_interface_test.go
@@ -470,7 +470,7 @@ func RunDatabaseInterfaceTests(getImpl func() (Database, *sql.DB)) {
 				Expect(categories).To(BeEmpty())
 			})
 
-			It("should return all distinct categories", func() {
+			It("should return all distinct categories with KPI counts", func() {
 				_, err := dbImpl.EnsureCategoryTable(db, "cpu", "node-cpu")
 				Expect(err).NotTo(HaveOccurred())
 				_, err = dbImpl.EnsureCategoryTable(db, "cpu", "container-cpu")
@@ -481,6 +481,13 @@ func RunDatabaseInterfaceTests(getImpl func() (Database, *sql.DB)) {
 				categories, err := dbImpl.ListCategories(db)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(categories).To(HaveLen(2))
+
+				cpuIdx, memIdx := 0, 1
+				if categories[0].Category == "memory" {
+					cpuIdx, memIdx = 1, 0
+				}
+				Expect(categories[cpuIdx].KPICount).To(Equal(2))
+				Expect(categories[memIdx].KPICount).To(Equal(1))
 			})
 		})
 

--- a/internal/database/interface.go
+++ b/internal/database/interface.go
@@ -15,6 +15,7 @@ import (
 type CategoryInfo struct {
 	Category  string
 	TableName string
+	KPICount  int
 }
 
 // Database defines the interface that all database implementations must satisfy

--- a/internal/database/postgres.go
+++ b/internal/database/postgres.go
@@ -197,9 +197,14 @@ func (p *PostgresDB) ValidateCategoryConsistency(db *sql.DB, kpis []config.Query
 	return nil
 }
 
-// ListCategories returns all distinct categories registered in kpi_registry.
+// ListCategories returns all distinct categories registered in kpi_registry,
+// along with the number of KPIs in each category.
 func (p *PostgresDB) ListCategories(db *sql.DB) ([]CategoryInfo, error) {
-	rows, err := db.Query("SELECT DISTINCT category, table_name FROM kpi_registry ORDER BY category")
+	rows, err := db.Query(`
+		SELECT category, table_name, COUNT(*) as kpi_count
+		FROM kpi_registry
+		GROUP BY category, table_name
+		ORDER BY category`)
 	if err != nil {
 		return nil, fmt.Errorf("query kpi_registry: %w", err)
 	}
@@ -208,7 +213,7 @@ func (p *PostgresDB) ListCategories(db *sql.DB) ([]CategoryInfo, error) {
 	var categories []CategoryInfo
 	for rows.Next() {
 		var ci CategoryInfo
-		if err := rows.Scan(&ci.Category, &ci.TableName); err != nil {
+		if err := rows.Scan(&ci.Category, &ci.TableName, &ci.KPICount); err != nil {
 			return nil, fmt.Errorf("scan kpi_registry row: %w", err)
 		}
 		categories = append(categories, ci)

--- a/internal/database/sqlite.go
+++ b/internal/database/sqlite.go
@@ -240,9 +240,14 @@ func (sqlite_db *SQLiteDB) ValidateCategoryConsistency(db *sql.DB, kpis []config
 	return nil
 }
 
-// ListCategories returns all distinct categories registered in kpi_registry.
+// ListCategories returns all distinct categories registered in kpi_registry,
+// along with the number of KPIs in each category.
 func (sqlite_db *SQLiteDB) ListCategories(db *sql.DB) ([]CategoryInfo, error) {
-	rows, err := db.Query("SELECT DISTINCT category, table_name FROM kpi_registry ORDER BY category")
+	rows, err := db.Query(`
+		SELECT category, table_name, COUNT(*) as kpi_count
+		FROM kpi_registry
+		GROUP BY category, table_name
+		ORDER BY category`)
 	if err != nil {
 		return nil, fmt.Errorf("query kpi_registry: %w", err)
 	}
@@ -251,7 +256,7 @@ func (sqlite_db *SQLiteDB) ListCategories(db *sql.DB) ([]CategoryInfo, error) {
 	var categories []CategoryInfo
 	for rows.Next() {
 		var ci CategoryInfo
-		if err := rows.Scan(&ci.Category, &ci.TableName); err != nil {
+		if err := rows.Scan(&ci.Category, &ci.TableName, &ci.KPICount); err != nil {
 			return nil, fmt.Errorf("scan kpi_registry row: %w", err)
 		}
 		categories = append(categories, ci)

--- a/internal/database/sqlite_test.go
+++ b/internal/database/sqlite_test.go
@@ -259,7 +259,7 @@ var _ = Describe("Sqlite", func() {
 			Expect(categories).To(BeEmpty())
 		})
 
-		It("should return all distinct categories", func() {
+		It("should return all distinct categories with KPI counts", func() {
 			_, err := sqliteDB.EnsureCategoryTable(db, "cpu", "node-cpu")
 			Expect(err).NotTo(HaveOccurred())
 			_, err = sqliteDB.EnsureCategoryTable(db, "cpu", "container-cpu")
@@ -272,8 +272,10 @@ var _ = Describe("Sqlite", func() {
 			Expect(categories).To(HaveLen(2))
 			Expect(categories[0].Category).To(Equal("cpu"))
 			Expect(categories[0].TableName).To(Equal("kpi_cpu"))
+			Expect(categories[0].KPICount).To(Equal(2))
 			Expect(categories[1].Category).To(Equal("memory"))
 			Expect(categories[1].TableName).To(Equal("kpi_memory"))
+			Expect(categories[1].KPICount).To(Equal(1))
 		})
 	})
 

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -59,6 +59,13 @@ type ErrorRecord struct {
 	ErrorCount int    `json:"error_count"`
 }
 
+// CategoryRecord represents a category info record for output
+type CategoryRecord struct {
+	Category  string `json:"category"`
+	TableName string `json:"table_name"`
+	KPICount  int    `json:"kpi_count"`
+}
+
 // Printer handles output formatting
 type Printer struct {
 	format     Format

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -86,3 +86,15 @@ func PrintErrorsTable(records []ErrorRecord) {
 	}
 	_ = w.Flush()
 }
+
+// PrintCategoriesTable prints category records as a table to stdout
+func PrintCategoriesTable(records []CategoryRecord) {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(w, "CATEGORY\tTABLE\tKPIS")
+	_, _ = fmt.Fprintln(w, "---\t---\t---")
+
+	for _, c := range records {
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%d\n", c.Category, c.TableName, c.KPICount)
+	}
+	_ = w.Flush()
+}


### PR DESCRIPTION
- Add `db show categories` subcommand that lists all registered KPI categories with their backing table and KPI count
- Validate `--category` flag in `db show kpis` and `db remove kpis` - return a clear error listing available categories when the value doesn't match any existing category
- Extend `CategoryInfo` with `KPICount` field and update `ListCategories` in both SQLite and PostgreSQL
