### PR TITLE
Add category documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,7 +128,7 @@ Tests use Ginkgo/Gomega BDD framework. Test files follow the pattern `*_test.go`
 Commands are organized using Cobra:
 - `kpi-collector kpis generate --profile <profile>`: Generate a KPI file for a cluster profile (ran, core, hub). Use `--uncategorized` to omit category fields. Use `--uncategorized` to omit category fields
 - `kpi-collector run`: Collect KPI metrics (use `--once` to collect once and exit)
-- `kpi-collector db show clusters|kpis|errors`: Query stored data
+- `kpi-collector db show clusters|kpis|categories|errors`: Query stored data
 - `kpi-collector db remove clusters|kpis|errors`: Delete data
 - `kpi-collector grafana start|stop`: Manage Grafana dashboard
 
@@ -162,6 +162,8 @@ kpis:
     promquery: your_promql_query
     # Optional: override global frequency (duration string or seconds)
     sample-frequency: 2m
+    # Optional: route to a dedicated kpi_<category> table for better query performance
+    category: cpu
     # Optional: collect this query only once
     run-once: true
     # Optional: instant (default) or range

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -156,10 +156,10 @@ kpi-collector db show kpis --name pods-running
 Expected output:
 
 ```
-ID  KPI_NAME      CLUSTER      VALUE   TIMESTAMP    EXECUTION_TIME        LABELS
---  ---           ---          ---     ---          ---                   ---
-1   pods-running  my-cluster   47      1700000000   YYYY-MM-DD HH:MM:SS  {"instance":"node1"}
-2   pods-running  my-cluster   32      1700000000   YYYY-MM-DD HH:MM:SS  {"instance":"node2"}
+ID  KPI_NAME      CATEGORY  CLUSTER      VALUE   TIMESTAMP    EXECUTION_TIME        LABELS
+--  ---           ---       ---          ---     ---          ---                   ---
+1   pods-running  -         my-cluster   47      1700000000   YYYY-MM-DD HH:MM:SS  {"instance":"node1"}
+2   pods-running  -         my-cluster   32      1700000000   YYYY-MM-DD HH:MM:SS  {"instance":"node2"}
 
 Total results: 2
 ```

--- a/docs/kpis-file-configuration.md
+++ b/docs/kpis-file-configuration.md
@@ -41,9 +41,11 @@ kpis:
 kpis:
   - id: node-cpu-usage
     promquery: avg by (instance) (rate(node_cpu_seconds_total{mode!="idle"}[5m]))
+    category: cpu
 
   - id: node-memory-usage
     promquery: node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes
+    category: memory
     sample-frequency: 2m
 
   - id: cluster-uptime
@@ -52,11 +54,45 @@ kpis:
 
   - id: node-cpu-usage-range
     promquery: avg by (instance) (rate(node_cpu_seconds_total{mode!="idle"}[5m]))
+    category: cpu
     query-type: range
     range:
       step: 30s
       since: 1h
 ```
+
+## Categories
+
+The optional `category` field routes a KPI's metrics into a dedicated database table named `kpi_<category>` instead of the shared `query_results` table. This improves query performance at scale — when the database holds hundreds of thousands of rows, filtering by category avoids scanning unrelated data.
+
+```yaml
+kpis:
+  - id: node-cpu-usage
+    promquery: avg by (instance) (rate(node_cpu_seconds_total{mode!="idle"}[5m]))
+    category: cpu
+
+  - id: node-memory-usage
+    promquery: node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes
+    category: memory
+
+  - id: cluster-uptime
+    promquery: max(time() - process_start_time_seconds{job="kubelet"})
+```
+
+In this example, `node-cpu-usage` is stored in a `kpi_cpu` table, `node-memory-usage` in `kpi_memory`, and `cluster-uptime` in the default `query_results` table (no category).
+
+How it works:
+
+- **On write**: When the collector runs, it automatically creates the `kpi_<category>` table if it doesn't exist and registers the KPI in a `kpi_registry` lookup table.
+- **On read**: `db show kpis` queries all tables (default + every category) and merges the results. Use `--category=cpu` to query only one category, or `--name=node-cpu-usage` to auto-discover the right table via the registry.
+- **On delete**: `db remove kpis --category=cpu` removes all data from the category table and its registry entries.
+- **Listing**: `db show categories` displays all registered categories, their backing tables, and KPI counts.
+
+Category names are freeform strings (e.g. `cpu`, `memory`, `network`, `ptp`). The built-in KPI profiles (`kpis generate --profile`) include categories by default. Use `--uncategorized` to generate without them.
+
+> [!NOTE]
+> Once a KPI is stored with a category, you cannot change its category in a later run.
+> The collector validates consistency at startup and will error if a category mismatch is detected.
 
 ## KPI Profiles
 

--- a/kpis.yaml.template
+++ b/kpis.yaml.template
@@ -7,6 +7,8 @@
 #   id:               Unique identifier (used in database and output)
 #   promquery:        PromQL query to execute against Prometheus/Thanos
 #   sample-frequency: (Optional) Override global --frequency for this KPI
+#   category:         (Optional) Storage category — routes metrics to a dedicated kpi_<category>
+#                     table for better query performance at scale
 #   query-type:       (Optional) "instant" (default) or "range"
 #   range:            (Required for range) Nested object with step, since, and optionally until
 #     step:           Resolution between points in query_range (e.g. 30s)
@@ -32,8 +34,10 @@ kpis:
     promquery: avg by (instance) (rate(node_cpu_seconds_total{mode!="idle"}[5m]))
 
   # Memory currently in use per node — sampled less frequently (every 2 min)
+  # The category field routes this KPI to the kpi_memory table
   - id: node-memory-usage
     promquery: node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes
+    category: memory
     sample-frequency: 120
 
   # CPU usage on reserved cores (dynamically fetched from PerformanceProfile)


### PR DESCRIPTION
### Summary

- Add `category` field to kpis.yaml.template with description and example
- Add "Categories" section to docs/kpis-file-configuration.md explaining how categories map to database tables, read/write/delete behavior, and consistency rules
- Update docs/getting-started.md example output to show the CATEGORY column in `db show kpis`