### PR TITLE
Merge category-tables feature branch into main

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,7 +128,7 @@ Tests use Ginkgo/Gomega BDD framework. Test files follow the pattern `*_test.go`
 Commands are organized using Cobra:
 - `kpi-collector kpis generate --profile <profile>`: Generate a KPI file for a cluster profile (ran, core, hub). Use `--uncategorized` to omit category fields. Use `--uncategorized` to omit category fields
 - `kpi-collector run`: Collect KPI metrics (use `--once` to collect once and exit)
-- `kpi-collector db show clusters|kpis|errors`: Query stored data
+- `kpi-collector db show clusters|kpis|categories|errors`: Query stored data
 - `kpi-collector db remove clusters|kpis|errors`: Delete data
 - `kpi-collector grafana start|stop`: Manage Grafana dashboard
 
@@ -162,6 +162,8 @@ kpis:
     promquery: your_promql_query
     # Optional: override global frequency (duration string or seconds)
     sample-frequency: 2m
+    # Optional: route to a dedicated kpi_<category> table for better query performance
+    category: cpu
     # Optional: collect this query only once
     run-once: true
     # Optional: instant (default) or range

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,7 +126,7 @@ Tests use Ginkgo/Gomega BDD framework. Test files follow the pattern `*_test.go`
 
 ### CLI Structure
 Commands are organized using Cobra:
-- `kpi-collector kpis generate --profile <profile>`: Generate a KPI file for a cluster profile (ran, core, hub)
+- `kpi-collector kpis generate --profile <profile>`: Generate a KPI file for a cluster profile (ran, core, hub). Use `--uncategorized` to omit category fields. Use `--uncategorized` to omit category fields
 - `kpi-collector run`: Collect KPI metrics (use `--once` to collect once and exit)
 - `kpi-collector db show clusters|kpis|errors`: Query stored data
 - `kpi-collector db remove clusters|kpis|errors`: Delete data

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -40,7 +40,7 @@ kpi-collector kpis generate --profile ran --all
 kpi-collector kpis generate --profile ran
 ```
 
-This creates a `ran-kpis.yaml` file in your current directory with battle-tested PromQL queries for that profile. Use `-f <path>` to write to a custom location.
+This creates a `ran-kpis.yaml` file in your current directory with battle-tested PromQL queries for that profile. Use `-f <path>` to write to a custom location. Add `--uncategorized` to omit category fields from the output.
 
 **Alternatively**, you can write a KPI file by hand. Save the following as `my-kpis.yaml` — a minimal example with two basic cluster-health queries:
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -156,10 +156,10 @@ kpi-collector db show kpis --name pods-running
 Expected output:
 
 ```
-ID  KPI_NAME      CLUSTER      VALUE   TIMESTAMP    EXECUTION_TIME        LABELS
---  ---           ---          ---     ---          ---                   ---
-1   pods-running  my-cluster   47      1700000000   YYYY-MM-DD HH:MM:SS  {"instance":"node1"}
-2   pods-running  my-cluster   32      1700000000   YYYY-MM-DD HH:MM:SS  {"instance":"node2"}
+ID  KPI_NAME      CATEGORY  CLUSTER      VALUE   TIMESTAMP    EXECUTION_TIME        LABELS
+--  ---           ---       ---          ---     ---          ---                   ---
+1   pods-running  -         my-cluster   47      1700000000   YYYY-MM-DD HH:MM:SS  {"instance":"node1"}
+2   pods-running  -         my-cluster   32      1700000000   YYYY-MM-DD HH:MM:SS  {"instance":"node2"}
 
 Total results: 2
 ```

--- a/docs/kpis-file-configuration.md
+++ b/docs/kpis-file-configuration.md
@@ -25,6 +25,7 @@ kpis:
 | `id` | Yes | - | Unique identifier used in the database and output |
 | `promquery` | Yes | - | PromQL query to execute |
 | `sample-frequency` | No | global `--frequency` | Per-query override (duration string like `2m` or seconds like `120`) |
+| `category` | No | — | Storage category; routes metrics to a dedicated `kpi_<category>` table for better query performance |
 | `run-once` | No | false | Collect this query only once, skip repeated sampling |
 | `query-type` | No | `instant` | `instant` or `range` |
 | `range` | No* | — | Object with `step`, `since`, and optionally `until` |
@@ -73,7 +74,14 @@ kpi-collector kpis generate --profile hub --all -f /path/to/hub-kpis.yaml
 
 # Overwrite an existing file
 kpi-collector kpis generate --profile ran --all --overwrite
+
+# Generate without category fields (all data stored in a single table)
+kpi-collector kpis generate --profile ran --all --uncategorized
 ```
+
+By default, generated KPIs include a `category` field that routes metrics into
+per-category database tables for better query performance at scale. Use
+`--uncategorized` to omit the `category` field from the output.
 
 Available profiles:
 

--- a/docs/kpis-file-configuration.md
+++ b/docs/kpis-file-configuration.md
@@ -41,9 +41,11 @@ kpis:
 kpis:
   - id: node-cpu-usage
     promquery: avg by (instance) (rate(node_cpu_seconds_total{mode!="idle"}[5m]))
+    category: cpu
 
   - id: node-memory-usage
     promquery: node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes
+    category: memory
     sample-frequency: 2m
 
   - id: cluster-uptime
@@ -52,11 +54,45 @@ kpis:
 
   - id: node-cpu-usage-range
     promquery: avg by (instance) (rate(node_cpu_seconds_total{mode!="idle"}[5m]))
+    category: cpu
     query-type: range
     range:
       step: 30s
       since: 1h
 ```
+
+## Categories
+
+The optional `category` field routes a KPI's metrics into a dedicated database table named `kpi_<category>` instead of the shared `query_results` table. This improves query performance at scale — when the database holds hundreds of thousands of rows, filtering by category avoids scanning unrelated data.
+
+```yaml
+kpis:
+  - id: node-cpu-usage
+    promquery: avg by (instance) (rate(node_cpu_seconds_total{mode!="idle"}[5m]))
+    category: cpu
+
+  - id: node-memory-usage
+    promquery: node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes
+    category: memory
+
+  - id: cluster-uptime
+    promquery: max(time() - process_start_time_seconds{job="kubelet"})
+```
+
+In this example, `node-cpu-usage` is stored in a `kpi_cpu` table, `node-memory-usage` in `kpi_memory`, and `cluster-uptime` in the default `query_results` table (no category).
+
+How it works:
+
+- **On write**: When the collector runs, it automatically creates the `kpi_<category>` table if it doesn't exist and registers the KPI in a `kpi_registry` lookup table.
+- **On read**: `db show kpis` queries all tables (default + every category) and merges the results. Use `--category=cpu` to query only one category, or `--name=node-cpu-usage` to auto-discover the right table via the registry.
+- **On delete**: `db remove kpis --category=cpu` removes all data from the category table and its registry entries.
+- **Listing**: `db show categories` displays all registered categories, their backing tables, and KPI counts.
+
+Category names are freeform strings (e.g. `cpu`, `memory`, `network`, `ptp`). The built-in KPI profiles (`kpis generate --profile`) include categories by default. Use `--uncategorized` to generate without them.
+
+> [!NOTE]
+> Once a KPI is stored with a category, you cannot change its category in a later run.
+> The collector validates consistency at startup and will error if a category mismatch is detected.
 
 ## KPI Profiles
 

--- a/grafana-templates/postgres-dashboard.json
+++ b/grafana-templates/postgres-dashboard.json
@@ -5,7 +5,7 @@
         "builtIn": 1,
         "datasource": {
           "type": "grafana",
-          "uid": "-- Grafana --"
+          "uid": "kpi-datasource"
         },
         "enable": true,
         "hide": true,
@@ -26,7 +26,7 @@
       "keepTime": false,
       "tags": [],
       "targetBlank": false,
-      "title": "Fit to data",
+      "title": "Auto Fit",
       "tooltip": "Adjust time range to fit all available data",
       "type": "link",
       "url": "/d/kpi-collector-dynamic/?from=${data_start}&to=${data_end}"
@@ -35,18 +35,9 @@
   "liveNow": false,
   "panels": [
     {
-      "id": 1,
-      "type": "timeseries",
-      "title": "Metric Values Over Time",
       "datasource": {
         "type": "postgres",
         "uid": "kpi-datasource"
-      },
-      "gridPos": {
-        "h": 10,
-        "w": 24,
-        "x": 0,
-        "y": 0
       },
       "fieldConfig": {
         "defaults": {
@@ -67,13 +58,13 @@
               "viz": false,
               "legend": false
             },
-            "lineInterpolation": "linear",
+            "lineInterpolation": "smooth",
             "lineWidth": 2,
-            "pointSize": 5,
+            "pointSize": 4,
             "scaleDistribution": {
               "type": "linear"
             },
-            "showPoints": "never",
+            "showPoints": "auto",
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -90,57 +81,11 @@
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "blue",
-                "value": null,
-                "label": "Min"
-              },
-              {
-                "color": "orange",
-                "value": null,
-                "label": "Avg"
-              },
-              {
-                "color": "red",
-                "value": null,
-                "label": "Max"
-              }
-            ],
-            "showThresholdLabels": true,
-            "showThresholdMarkers": {
-              "mode": "off"
-            }
-          },
-          "unit": "short"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "metric_value"
-            },
-            "properties": [
-              {
-                "id": "custom.lineWidth",
-                "value": 2
-              },
-              {
-                "id": "custom.lineStyle",
-                "value": {
-                  "fill": "solid"
-                }
-              },
-              {
-                "id": "custom.hideFrom",
-                "value": {
-                  "tooltip": false,
-                  "viz": false,
-                  "legend": false
-                }
               }
             ]
-          },
+          }
+        },
+        "overrides": [
           {
             "matcher": {
               "id": "byName",
@@ -177,7 +122,7 @@
                 "value": {
                   "tooltip": true,
                   "viz": false,
-                  "legend": true
+                  "legend": false
                 }
               }
             ]
@@ -209,7 +154,7 @@
               {
                 "id": "color",
                 "value": {
-                  "fixedColor": "blue",
+                  "fixedColor": "green",
                   "mode": "fixed"
                 }
               },
@@ -218,7 +163,7 @@
                 "value": {
                   "tooltip": true,
                   "viz": false,
-                  "legend": true
+                  "legend": false
                 }
               }
             ]
@@ -259,24 +204,30 @@
                 "value": {
                   "tooltip": true,
                   "viz": false,
-                  "legend": true
+                  "legend": false
                 }
               }
             ]
           }
         ]
       },
+      "gridPos": {
+        "h": 10,
+        "w": 18,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
       "options": {
         "legend": {
+          "showLegend": true,
+          "displayMode": "table",
+          "placement": "bottom",
           "calcs": [
             "last",
             "mean",
-            "min",
             "max"
-          ],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true
+          ]
         },
         "tooltip": {
           "mode": "multi",
@@ -290,11 +241,24 @@
             "uid": "kpi-datasource"
           },
           "format": "table",
-          "rawSql": "SELECT to_timestamp(timestamp_value) AS time, metric_value, metric_labels FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR metric_labels->>'node' = '${node}' OR metric_labels->>'instance' = '${node}') AND ('${job}' = 'All' OR metric_labels->>'job' = '${job}') AND ('${pod}' = 'All' OR metric_labels->>'pod' = '${pod}') AND ('${container}' = 'All' OR metric_labels->>'container' = '${container}') AND timestamp_value >= $__from / 1000 AND timestamp_value < $__to / 1000 ORDER BY time ASC",
+          "rawSql": "SELECT to_timestamp(timestamp_value) AS time, metric_value, metric_labels FROM ${_table} qr JOIN clusters c ON qr.cluster_id = c.id WHERE timestamp_value >= $__from / 1000 AND timestamp_value < $__to / 1000 AND kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) AND COALESCE(metric_labels->>'node', metric_labels->>'instance', 'N/A') LIKE (CASE WHEN '${node}' = 'All' THEN '%%' ELSE '${node}' END) AND COALESCE(metric_labels->>'job', 'N/A') LIKE (CASE WHEN '${job}' = 'All' THEN '%%' ELSE '${job}' END) AND COALESCE(metric_labels->>'container', 'N/A') LIKE (CASE WHEN '${container}' = 'All' THEN '%%' ELSE '${container}' END) AND COALESCE(metric_labels->>'pod', 'N/A') LIKE (CASE WHEN '${pod}' = 'All' THEN '%%' ELSE '${pod}' END) ORDER BY time ASC",
           "refId": "A",
           "timeColumns": [
-            "time",
-            "ts"
+            "time"
+          ],
+          "legendFormat": "Node: {{__field.labels.node}} | Pod: {{__field.labels.pod}} | Job: {{__field.labels.job}}"
+        },
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "kpi-datasource"
+          },
+          "format": "table",
+          "rawSql": "SELECT 'Max Value' AS metric_labels, MAX(metric_value) AS metric_value, $__from/1000 AS time FROM ${_table} qr JOIN clusters c ON qr.cluster_id = c.id WHERE timestamp_value >= $__from / 1000 AND timestamp_value < $__to / 1000 AND kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) AND COALESCE(metric_labels->>'node', metric_labels->>'instance', 'N/A') LIKE (CASE WHEN '${node}' = 'All' THEN '%%' ELSE '${node}' END) AND COALESCE(metric_labels->>'job', 'N/A') LIKE (CASE WHEN '${job}' = 'All' THEN '%%' ELSE '${job}' END) AND COALESCE(metric_labels->>'container', 'N/A') LIKE (CASE WHEN '${container}' = 'All' THEN '%%' ELSE '${container}' END) AND COALESCE(metric_labels->>'pod', 'N/A') LIKE (CASE WHEN '${pod}' = 'All' THEN '%%' ELSE '${pod}' END)",
+          "refId": "B",
+          "legendFormat": "Max Value",
+          "timeColumns": [
+            "time"
           ]
         },
         {
@@ -303,27 +267,12 @@
             "uid": "kpi-datasource"
           },
           "format": "table",
-          "rawSql": "SELECT 'Max Value' AS metric_labels, MAX(metric_value) AS metric_value, to_timestamp($__from/1000) AS time FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR metric_labels->>'node' = '${node}' OR metric_labels->>'instance' = '${node}') AND ('${job}' = 'All' OR metric_labels->>'job' = '${job}') AND ('${pod}' = 'All' OR metric_labels->>'pod' = '${pod}') AND ('${container}' = 'All' OR metric_labels->>'container' = '${container}')",
-          "refId": "B",
-          "legendFormat": "Max Value",
-          "timeColumns": [
-            "time"
-          ],
-          "hide": true
-        },
-        {
-          "datasource": {
-            "type": "postgres",
-            "uid": "kpi-datasource"
-          },
-          "format": "table",
-          "rawSql": "SELECT 'Min Value' AS metric_labels, MIN(metric_value) AS metric_value, to_timestamp($__from/1000) AS time FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR metric_labels->>'node' = '${node}' OR metric_labels->>'instance' = '${node}') AND ('${job}' = 'All' OR metric_labels->>'job' = '${job}') AND ('${pod}' = 'All' OR metric_labels->>'pod' = '${pod}') AND ('${container}' = 'All' OR metric_labels->>'container' = '${container}')",
+          "rawSql": "SELECT 'Min Value' AS metric_labels, MIN(metric_value) AS metric_value, $__from/1000 AS time FROM ${_table} qr JOIN clusters c ON qr.cluster_id = c.id WHERE timestamp_value >= $__from / 1000 AND timestamp_value < $__to / 1000 AND kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) AND COALESCE(metric_labels->>'node', metric_labels->>'instance', 'N/A') LIKE (CASE WHEN '${node}' = 'All' THEN '%%' ELSE '${node}' END) AND COALESCE(metric_labels->>'job', 'N/A') LIKE (CASE WHEN '${job}' = 'All' THEN '%%' ELSE '${job}' END) AND COALESCE(metric_labels->>'container', 'N/A') LIKE (CASE WHEN '${container}' = 'All' THEN '%%' ELSE '${container}' END) AND COALESCE(metric_labels->>'pod', 'N/A') LIKE (CASE WHEN '${pod}' = 'All' THEN '%%' ELSE '${pod}' END)",
           "refId": "C",
           "legendFormat": "Min Value",
           "timeColumns": [
             "time"
-          ],
-          "hide": true
+          ]
         },
         {
           "datasource": {
@@ -331,15 +280,16 @@
             "uid": "kpi-datasource"
           },
           "format": "table",
-          "rawSql": "SELECT 'Average Value' AS metric_labels, AVG(metric_value) AS metric_value, to_timestamp($__from/1000) AS time FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR metric_labels->>'node' = '${node}' OR metric_labels->>'instance' = '${node}') AND ('${job}' = 'All' OR metric_labels->>'job' = '${job}') AND ('${pod}' = 'All' OR metric_labels->>'pod' = '${pod}') AND ('${container}' = 'All' OR metric_labels->>'container' = '${container}')",
+          "rawSql": "SELECT 'Average Value' AS metric_labels, AVG(metric_value) AS metric_value, $__from/1000 AS time FROM ${_table} qr JOIN clusters c ON qr.cluster_id = c.id WHERE timestamp_value >= $__from / 1000 AND timestamp_value < $__to / 1000 AND kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) AND COALESCE(metric_labels->>'node', metric_labels->>'instance', 'N/A') LIKE (CASE WHEN '${node}' = 'All' THEN '%%' ELSE '${node}' END) AND COALESCE(metric_labels->>'job', 'N/A') LIKE (CASE WHEN '${job}' = 'All' THEN '%%' ELSE '${job}' END) AND COALESCE(metric_labels->>'container', 'N/A') LIKE (CASE WHEN '${container}' = 'All' THEN '%%' ELSE '${container}' END) AND COALESCE(metric_labels->>'pod', 'N/A') LIKE (CASE WHEN '${pod}' = 'All' THEN '%%' ELSE '${pod}' END)",
           "refId": "D",
           "legendFormat": "Average Value",
           "timeColumns": [
             "time"
-          ],
-          "hide": true
+          ]
         }
       ],
+      "title": "Metric Values Over Time",
+      "type": "timeseries",
       "transformations": [
         {
           "id": "extractFields",
@@ -351,21 +301,6 @@
           }
         },
         {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "metric_labels": true,
-              "undefined": true,
-              "cpu": true,
-              "device": true,
-              "endpoint": true,
-              "instance": true
-            },
-            "indexByName": {},
-            "renameByName": {}
-          }
-        },
-        {
           "id": "prepareTimeSeries",
           "options": {
             "format": "multi"
@@ -374,34 +309,69 @@
       ]
     },
     {
-      "id": 2,
-      "type": "text",
-      "title": "",
-      "gridPos": {
-        "h": 2,
-        "w": 24,
-        "x": 0,
-        "y": 10
-      },
-      "options": {
-        "mode": "html",
-        "content": "<div style=\"text-align: center; vertical-align: middle\">sample count: ${samples_count}, average value: ${avg_value}, max value: ${max_value}, min value: ${min_value}</div>"
-      },
-      "transparent": true
-    },
-    {
-      "id": 3,
-      "type": "table",
-      "title": "Detailed Metrics with All Labels",
       "datasource": {
         "type": "postgres",
         "uid": "kpi-datasource"
       },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
       "gridPos": {
         "h": 10,
-        "w": 24,
-        "x": 0,
-        "y": 12
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "vertical",
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "textMode": "value_and_name",
+        "showPercentChange": false
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "kpi-datasource"
+          },
+          "format": "table",
+          "rawSql": "SELECT COUNT(*) as \"Samples\", ROUND(CAST(AVG(metric_value) AS numeric), 6) as \"Average\", ROUND(CAST(MIN(metric_value) AS numeric), 6) as \"Minimum\", ROUND(CAST(MAX(metric_value) AS numeric), 6) as \"Maximum\" FROM ${_table} qr JOIN clusters c ON qr.cluster_id = c.id WHERE timestamp_value >= $__from / 1000 AND timestamp_value < $__to / 1000 AND kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) AND COALESCE(metric_labels->>'node', metric_labels->>'instance', 'N/A') LIKE (CASE WHEN '${node}' = 'All' THEN '%%' ELSE '${node}' END) AND COALESCE(metric_labels->>'job', 'N/A') LIKE (CASE WHEN '${job}' = 'All' THEN '%%' ELSE '${job}' END) AND COALESCE(metric_labels->>'container', 'N/A') LIKE (CASE WHEN '${container}' = 'All' THEN '%%' ELSE '${container}' END) AND COALESCE(metric_labels->>'pod', 'N/A') LIKE (CASE WHEN '${pod}' = 'All' THEN '%%' ELSE '${pod}' END)",
+          "refId": "A"
+        }
+      ],
+      "title": "KPI Statistics",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "kpi-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -429,9 +399,24 @@
         },
         "overrides": []
       },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 10
+      },
+      "id": 3,
       "options": {
         "showHeader": true,
         "cellHeight": "sm",
+        "footer": {
+          "show": false,
+          "reducer": [
+            "sum"
+          ],
+          "countRows": false,
+          "fields": ""
+        },
         "sortBy": [
           {
             "displayName": "Avg Value",
@@ -439,6 +424,7 @@
           }
         ]
       },
+      "pluginVersion": "10.0.0",
       "targets": [
         {
           "datasource": {
@@ -446,10 +432,12 @@
             "uid": "kpi-datasource"
           },
           "format": "table",
-          "rawSql": "SELECT metric_labels, ROUND(CAST(AVG(metric_value) AS numeric), 6) AS avg_value, ROUND(CAST(MIN(metric_value) AS numeric), 6) AS min_value, ROUND(CAST(MAX(metric_value) AS numeric), 6) AS max_value, COUNT(*) AS samples FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR metric_labels->>'node' = '${node}' OR metric_labels->>'instance' = '${node}') AND ('${job}' = 'All' OR metric_labels->>'job' = '${job}') AND ('${pod}' = 'All' OR metric_labels->>'pod' = '${pod}') AND ('${container}' = 'All' OR metric_labels->>'container' = '${container}') GROUP BY metric_labels ORDER BY avg_value DESC LIMIT 100",
+          "rawSql": "SELECT metric_labels, ROUND(CAST(AVG(metric_value) AS numeric), 6) AS avg_value, ROUND(CAST(MIN(metric_value) AS numeric), 6) AS min_value, ROUND(CAST(MAX(metric_value) AS numeric), 6) AS max_value, COUNT(*) AS samples FROM ${_table} qr JOIN clusters c ON qr.cluster_id = c.id WHERE timestamp_value >= $__from / 1000 AND timestamp_value < $__to / 1000 AND kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) AND COALESCE(metric_labels->>'node', metric_labels->>'instance', 'N/A') LIKE (CASE WHEN '${node}' = 'All' THEN '%%' ELSE '${node}' END) AND COALESCE(metric_labels->>'job', 'N/A') LIKE (CASE WHEN '${job}' = 'All' THEN '%%' ELSE '${job}' END) AND COALESCE(metric_labels->>'container', 'N/A') LIKE (CASE WHEN '${container}' = 'All' THEN '%%' ELSE '${container}' END) AND COALESCE(metric_labels->>'pod', 'N/A') LIKE (CASE WHEN '${pod}' = 'All' THEN '%%' ELSE '${pod}' END) GROUP BY metric_labels ORDER BY avg_value DESC LIMIT 100",
           "refId": "A"
         }
       ],
+      "title": "Detailed Metrics with All Labels",
+      "type": "table",
       "transformations": [
         {
           "id": "extractFields",
@@ -462,23 +450,31 @@
       ]
     },
     {
-      "id": 5,
-      "type": "barchart",
-      "title": "Query Errors by KPI",
       "datasource": {
         "type": "postgres",
         "uid": "kpi-datasource"
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 24,
-        "x": 0,
-        "y": 22
       },
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineWidth": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            }
           },
           "mappings": [],
           "thresholds": {
@@ -501,13 +497,22 @@
         },
         "overrides": []
       },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 20
+      },
+      "id": 5,
       "options": {
         "barRadius": 0,
         "barWidth": 0.97,
         "fullHighlight": false,
         "groupWidth": 0.7,
         "legend": {
+          "calcs": [],
           "displayMode": "list",
+          "placement": "bottom",
           "showLegend": false
         },
         "orientation": "horizontal",
@@ -516,8 +521,11 @@
         "tooltip": {
           "mode": "single",
           "sort": "none"
-        }
+        },
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 0
       },
+      "pluginVersion": "10.0.0",
       "targets": [
         {
           "datasource": {
@@ -525,24 +533,17 @@
             "uid": "kpi-datasource"
           },
           "format": "table",
-          "rawSql": "SELECT kpi_id AS metric, errors AS value FROM query_errors WHERE errors > 0 ORDER BY errors DESC;",
+          "rawSql": "SELECT kpi_id AS metric, errors AS value FROM query_errors WHERE errors > 0 ORDER BY errors DESC",
           "refId": "A"
         }
-      ]
+      ],
+      "title": "Query Errors by KPI (Static)",
+      "type": "barchart"
     },
     {
-      "id": 6,
-      "type": "table",
-      "title": "All KPIs - Summary Statistics",
       "datasource": {
         "type": "postgres",
         "uid": "kpi-datasource"
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 24,
-        "x": 0,
-        "y": 30
       },
       "fieldConfig": {
         "defaults": {
@@ -554,7 +555,8 @@
             "cellOptions": {
               "type": "auto"
             },
-            "inspect": false
+            "inspect": false,
+            "filterable": true
           },
           "mappings": [],
           "thresholds": {
@@ -569,11 +571,23 @@
         },
         "overrides": []
       },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 28
+      },
+      "id": 6,
       "options": {
         "showHeader": true,
         "cellHeight": "sm",
         "footer": {
-          "show": false
+          "show": false,
+          "reducer": [
+            "sum"
+          ],
+          "countRows": false,
+          "fields": ""
         },
         "sortBy": [
           {
@@ -582,6 +596,7 @@
           }
         ]
       },
+      "pluginVersion": "10.0.0",
       "targets": [
         {
           "datasource": {
@@ -589,24 +604,17 @@
             "uid": "kpi-datasource"
           },
           "format": "table",
-          "rawSql": "SELECT kpi_id, COUNT(*) AS sample_count, ROUND(CAST(AVG(metric_value) AS numeric), 6) AS avg_value, ROUND(CAST(MIN(metric_value) AS numeric), 6) AS min_value, ROUND(CAST(MAX(metric_value) AS numeric), 6) AS max_value, ROUND(CAST(MAX(metric_value) - MIN(metric_value) AS numeric), 6) AS range, COUNT(DISTINCT metric_labels) AS unique_metrics FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR metric_labels->>'node' = '${node}' OR metric_labels->>'instance' = '${node}') AND ('${job}' = 'All' OR metric_labels->>'job' = '${job}') AND ('${pod}' = 'All' OR metric_labels->>'pod' = '${pod}') AND ('${container}' = 'All' OR metric_labels->>'container' = '${container}') GROUP BY kpi_id ORDER BY kpi_id",
+          "rawSql": "SELECT kpi_id, COUNT(*) AS sample_count, ROUND(CAST(AVG(metric_value) AS numeric), 6) AS avg_value, ROUND(CAST(MIN(metric_value) AS numeric), 6) AS min_value, ROUND(CAST(MAX(metric_value) AS numeric), 6) AS max_value, ROUND(CAST(MAX(metric_value) - MIN(metric_value) AS numeric), 6) AS range, COUNT(DISTINCT metric_labels) AS unique_metrics FROM ${_table} qr JOIN clusters c ON qr.cluster_id = c.id WHERE timestamp_value >= $__from / 1000 AND timestamp_value < $__to / 1000 AND kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) AND COALESCE(metric_labels->>'node', metric_labels->>'instance', 'N/A') LIKE (CASE WHEN '${node}' = 'All' THEN '%%' ELSE '${node}' END) AND COALESCE(metric_labels->>'job', 'N/A') LIKE (CASE WHEN '${job}' = 'All' THEN '%%' ELSE '${job}' END) AND COALESCE(metric_labels->>'container', 'N/A') LIKE (CASE WHEN '${container}' = 'All' THEN '%%' ELSE '${container}' END) AND COALESCE(metric_labels->>'pod', 'N/A') LIKE (CASE WHEN '${pod}' = 'All' THEN '%%' ELSE '${pod}' END) GROUP BY kpi_id ORDER BY kpi_id",
           "refId": "A"
         }
-      ]
+      ],
+      "title": "All KPIs - Summary Statistics",
+      "type": "table"
     },
     {
-      "id": 7,
-      "type": "table",
-      "title": "Cluster Monitoring Status",
       "datasource": {
         "type": "postgres",
         "uid": "kpi-datasource"
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 24,
-        "x": 0,
-        "y": 39
       },
       "fieldConfig": {
         "defaults": {
@@ -633,10 +641,27 @@
         },
         "overrides": []
       },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 37
+      },
+      "id": 7,
       "options": {
         "showHeader": true,
-        "cellHeight": "sm"
+        "cellHeight": "sm",
+        "footer": {
+          "show": false,
+          "reducer": [
+            "sum"
+          ],
+          "countRows": false,
+          "fields": ""
+        },
+        "sortBy": []
       },
+      "pluginVersion": "10.0.0",
       "targets": [
         {
           "datasource": {
@@ -644,10 +669,12 @@
             "uid": "kpi-datasource"
           },
           "format": "table",
-          "rawSql": "SELECT c.cluster_name, c.cluster_type, COUNT(DISTINCT qr.kpi_id) AS kpi_count, COUNT(*) AS total_samples, MAX(qr.created_at) AS last_collection FROM clusters c LEFT JOIN query_results qr ON c.id = qr.cluster_id WHERE ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${node}' = 'All' OR qr.metric_labels->>'node' = '${node}' OR qr.metric_labels->>'instance' = '${node}') AND ('${job}' = 'All' OR qr.metric_labels->>'job' = '${job}') AND ('${pod}' = 'All' OR qr.metric_labels->>'pod' = '${pod}') AND ('${container}' = 'All' OR qr.metric_labels->>'container' = '${container}') GROUP BY c.cluster_name, c.cluster_type ORDER BY c.cluster_name",
+          "rawSql": "SELECT c.cluster_name, COALESCE(c.cluster_type, 'N/A') AS cluster_type, COUNT(DISTINCT qr.kpi_id) AS kpi_count, COUNT(qr.metric_value) AS total_samples, MAX(qr.created_at) AS last_collection FROM clusters c LEFT JOIN ${_table} qr ON c.id = qr.cluster_id AND qr.timestamp_value >= $__from / 1000 AND qr.timestamp_value < $__to / 1000 WHERE COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) GROUP BY c.cluster_name, COALESCE(c.cluster_type, 'N/A') ORDER BY c.cluster_name",
           "refId": "A"
         }
-      ]
+      ],
+      "title": "Cluster Monitoring Status (Time-Aware Counts)",
+      "type": "table"
     }
   ],
   "refresh": "",
@@ -661,191 +688,184 @@
   "templating": {
     "list": [
       {
-        "name": "cluster_type",
-        "type": "query",
+        "current": {
+          "text": "All",
+          "value": "All"
+        },
+        "datasource": {
+          "type": "postgres",
+          "uid": "kpi-datasource"
+        },
+        "definition": "SELECT cluster_type FROM (SELECT 'All' AS cluster_type, 1 AS order_col UNION ALL SELECT DISTINCT COALESCE(cluster_type, 'N/A'), 2 AS order_col FROM clusters) AS temp_data ORDER BY order_col, cluster_type;",
+        "hide": 0,
+        "includeAll": false,
         "label": "Cluster Type",
+        "multi": false,
+        "name": "cluster_type",
+        "options": [],
+        "query": "SELECT cluster_type FROM (SELECT 'All' AS cluster_type, 1 AS order_col UNION ALL SELECT DISTINCT COALESCE(cluster_type, 'N/A'), 2 AS order_col FROM clusters) AS temp_data ORDER BY order_col, cluster_type;",
+        "refresh": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "text": "",
+          "value": ""
+        },
         "datasource": {
           "type": "postgres",
           "uid": "kpi-datasource"
         },
-        "query": "SELECT cluster_type FROM (SELECT 'All' AS cluster_type, 1 AS sort_order UNION ALL SELECT DISTINCT cluster_type, 2 AS sort_order FROM clusters WHERE cluster_type IS NOT NULL AND cluster_type <> '') AS t ORDER BY sort_order, cluster_type;",
+        "definition": "SELECT cluster_name FROM (SELECT c.cluster_name, CASE WHEN c.id = (SELECT cluster_id FROM ${_table} ORDER BY created_at DESC LIMIT 1) THEN 1 ELSE 3 END AS sort_order FROM clusters c WHERE COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) UNION ALL SELECT 'All', 2) AS t ORDER BY sort_order, cluster_name;",
+        "hide": 0,
         "includeAll": false,
-        "multi": false,
-        "current": {
-          "text": "All",
-          "value": "All"
-        },
-        "refresh": 1
-      },
-      {
-        "name": "cluster",
-        "type": "query",
         "label": "Cluster",
+        "multi": false,
+        "name": "cluster",
+        "options": [],
+        "query": "SELECT cluster_name FROM (SELECT c.cluster_name, CASE WHEN c.id = (SELECT cluster_id FROM ${_table} ORDER BY created_at DESC LIMIT 1) THEN 1 ELSE 3 END AS sort_order FROM clusters c WHERE COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END) UNION ALL SELECT 'All', 2) AS t ORDER BY sort_order, cluster_name;",
+        "refresh": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "text": "",
+          "value": ""
+        },
         "datasource": {
           "type": "postgres",
           "uid": "kpi-datasource"
         },
-        "query": "SELECT cluster_name FROM (SELECT DISTINCT c.cluster_name, CASE WHEN c.id = (SELECT cluster_id FROM query_results ORDER BY created_at DESC LIMIT 1) THEN 1 ELSE 3 END AS sort_order FROM clusters c WHERE c.cluster_name IS NOT NULL AND c.cluster_name <> '' AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') UNION ALL SELECT 'All', 2) AS t ORDER BY sort_order, cluster_name;",
+        "definition": "SELECT category FROM (SELECT DISTINCT category, 1 AS sort_order FROM kpi_registry WHERE category IS NOT NULL AND category <> '' UNION ALL SELECT 'default', 2) AS t ORDER BY sort_order, category;",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Category",
+        "multi": false,
+        "name": "category",
+        "options": [],
+        "query": "SELECT category FROM (SELECT DISTINCT category, 1 AS sort_order FROM kpi_registry WHERE category IS NOT NULL AND category <> '' UNION ALL SELECT 'default', 2) AS t ORDER BY sort_order, category;",
+        "refresh": 1,
+        "type": "query"
+      },
+      {
+        "name": "_table",
+        "type": "query",
+        "label": "",
+        "datasource": {
+          "type": "postgres",
+          "uid": "kpi-datasource"
+        },
+        "query": "SELECT CASE WHEN '${category}' = 'default' THEN 'query_results' ELSE 'kpi_' || '${category}' END;",
+        "definition": "SELECT CASE WHEN '${category}' = 'default' THEN 'query_results' ELSE 'kpi_' || '${category}' END;",
         "includeAll": false,
         "multi": false,
         "current": {
           "text": "",
           "value": ""
         },
-        "refresh": 1
+        "options": [],
+        "refresh": 1,
+        "hide": 2
       },
       {
-        "name": "kpi",
-        "type": "query",
+        "current": {
+          "text": "",
+          "value": ""
+        },
+        "datasource": {
+          "type": "postgres",
+          "uid": "kpi-datasource"
+        },
+        "definition": "SELECT kpi_id FROM (SELECT DISTINCT kpi_id, 1 AS sort_order FROM ${_table} WHERE kpi_id IS NOT NULL AND kpi_id != '' UNION ALL SELECT 'All', 2) AS t ORDER BY sort_order, kpi_id;",
+        "hide": 0,
+        "includeAll": false,
         "label": "KPI",
+        "multi": false,
+        "name": "kpi",
+        "options": [],
+        "query": "SELECT kpi_id FROM (SELECT DISTINCT kpi_id, 1 AS sort_order FROM ${_table} WHERE kpi_id IS NOT NULL AND kpi_id != '' UNION ALL SELECT 'All', 2) AS t ORDER BY sort_order, kpi_id;",
+        "refresh": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "text": "All",
+          "value": "All"
+        },
         "datasource": {
           "type": "postgres",
           "uid": "kpi-datasource"
         },
-        "query": "SELECT kpi_id FROM (SELECT DISTINCT kpi_id, 1 AS sort_order FROM query_results WHERE kpi_id IS NOT NULL AND kpi_id <> '' UNION ALL SELECT 'All', 2) AS t ORDER BY sort_order, kpi_id;",
+        "definition": "SELECT node FROM (SELECT 'All' AS node, 1 AS order_col UNION ALL SELECT DISTINCT COALESCE(metric_labels->>'node', metric_labels->>'instance', 'N/A'), 2 AS order_col FROM ${_table} WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND COALESCE(metric_labels->>'node', metric_labels->>'instance') IS NOT NULL) AS temp_data ORDER BY order_col, node;",
+        "hide": 0,
         "includeAll": false,
-        "multi": false,
-        "current": {
-          "text": "",
-          "value": ""
-        },
-        "refresh": 1
-      },
-      {
-        "name": "node",
-        "type": "query",
         "label": "Node",
-        "datasource": {
-          "type": "postgres",
-          "uid": "kpi-datasource"
-        },
-        "query": "SELECT node FROM (SELECT 'All' AS node, 1 AS sort_order UNION ALL SELECT DISTINCT COALESCE(metric_labels->>'node', metric_labels->>'instance'), 2 FROM query_results WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND metric_labels IS NOT NULL AND COALESCE(metric_labels->>'node', metric_labels->>'instance') IS NOT NULL AND COALESCE(metric_labels->>'node', metric_labels->>'instance') <> '') AS t ORDER BY sort_order, node;",
-        "includeAll": false,
         "multi": false,
+        "name": "node",
+        "options": [],
+        "query": "SELECT node FROM (SELECT 'All' AS node, 1 AS order_col UNION ALL SELECT DISTINCT COALESCE(metric_labels->>'node', metric_labels->>'instance', 'N/A'), 2 AS order_col FROM ${_table} WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND COALESCE(metric_labels->>'node', metric_labels->>'instance') IS NOT NULL) AS temp_data ORDER BY order_col, node;",
+        "refresh": 1,
+        "type": "query"
+      },
+      {
         "current": {
           "text": "All",
           "value": "All"
         },
-        "refresh": 1
-      },
-      {
-        "name": "job",
-        "type": "query",
+        "datasource": {
+          "type": "postgres",
+          "uid": "kpi-datasource"
+        },
+        "definition": "SELECT job FROM (SELECT 'All' AS job, 1 AS order_col UNION ALL SELECT DISTINCT COALESCE(metric_labels->>'job', 'N/A'), 2 AS order_col FROM ${_table} WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND metric_labels->>'job' IS NOT NULL) AS temp_data ORDER BY order_col, job;",
+        "hide": 0,
+        "includeAll": false,
         "label": "Job",
-        "datasource": {
-          "type": "postgres",
-          "uid": "kpi-datasource"
-        },
-        "query": "SELECT job FROM (SELECT 'All' AS job, 1 AS sort_order UNION ALL SELECT DISTINCT metric_labels->>'job', 2 FROM query_results WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND metric_labels IS NOT NULL AND metric_labels->>'job' IS NOT NULL AND metric_labels->>'job' <> '') AS t ORDER BY sort_order, job;",
-        "includeAll": false,
         "multi": false,
+        "name": "job",
+        "options": [],
+        "query": "SELECT job FROM (SELECT 'All' AS job, 1 AS order_col UNION ALL SELECT DISTINCT COALESCE(metric_labels->>'job', 'N/A'), 2 AS order_col FROM ${_table} WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND metric_labels->>'job' IS NOT NULL) AS temp_data ORDER BY order_col, job;",
+        "refresh": 1,
+        "type": "query"
+      },
+      {
         "current": {
           "text": "All",
           "value": "All"
         },
-        "refresh": 1
-      },
-      {
-        "name": "pod",
-        "type": "query",
-        "label": "Pod",
         "datasource": {
           "type": "postgres",
           "uid": "kpi-datasource"
         },
-        "query": "SELECT pod FROM (SELECT 'All' AS pod, 1 AS sort_order UNION ALL SELECT DISTINCT metric_labels->>'pod', 2 FROM query_results WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND metric_labels IS NOT NULL AND metric_labels->>'pod' IS NOT NULL AND metric_labels->>'pod' <> '') AS t ORDER BY sort_order, pod;",
+        "definition": "SELECT container FROM (SELECT 'All' AS container, 1 AS order_col UNION ALL SELECT DISTINCT COALESCE(metric_labels->>'container', 'N/A'), 2 AS order_col FROM ${_table} WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND metric_labels->>'container' IS NOT NULL) AS temp_data ORDER BY order_col, container;",
+        "hide": 0,
         "includeAll": false,
-        "multi": false,
-        "current": {
-          "text": "All",
-          "value": "All"
-        },
-        "refresh": 1
-      },
-      {
-        "name": "container",
-        "type": "query",
         "label": "Container",
-        "datasource": {
-          "type": "postgres",
-          "uid": "kpi-datasource"
-        },
-        "query": "SELECT container FROM (SELECT 'All' AS container, 1 AS sort_order UNION ALL SELECT DISTINCT metric_labels->>'container', 2 FROM query_results WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND metric_labels IS NOT NULL AND metric_labels->>'container' IS NOT NULL AND metric_labels->>'container' <> '') AS t ORDER BY sort_order, container;",
-        "includeAll": false,
         "multi": false,
+        "name": "container",
+        "options": [],
+        "query": "SELECT container FROM (SELECT 'All' AS container, 1 AS order_col UNION ALL SELECT DISTINCT COALESCE(metric_labels->>'container', 'N/A'), 2 AS order_col FROM ${_table} WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND metric_labels->>'container' IS NOT NULL) AS temp_data ORDER BY order_col, container;",
+        "refresh": 1,
+        "type": "query"
+      },
+      {
         "current": {
           "text": "All",
           "value": "All"
         },
-        "refresh": 1
-      },
-      {
-        "name": "samples_count",
-        "type": "query",
         "datasource": {
           "type": "postgres",
           "uid": "kpi-datasource"
         },
-        "query": "SELECT COALESCE(COUNT(*), 0) FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR metric_labels->>'node' = '${node}' OR metric_labels->>'instance' = '${node}') AND ('${job}' = 'All' OR metric_labels->>'job' = '${job}') AND ('${pod}' = 'All' OR metric_labels->>'pod' = '${pod}') AND ('${container}' = 'All' OR metric_labels->>'container' = '${container}')",
+        "definition": "SELECT pod FROM (SELECT 'All' AS pod, 1 AS order_col UNION ALL SELECT DISTINCT COALESCE(metric_labels->>'pod', 'N/A'), 2 AS order_col FROM ${_table} WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND metric_labels->>'pod' IS NOT NULL) AS temp_data ORDER BY order_col, pod;",
+        "hide": 0,
         "includeAll": false,
+        "label": "Pod",
         "multi": false,
-        "current": {
-          "text": "",
-          "value": ""
-        },
+        "name": "pod",
+        "options": [],
+        "query": "SELECT pod FROM (SELECT 'All' AS pod, 1 AS order_col UNION ALL SELECT DISTINCT COALESCE(metric_labels->>'pod', 'N/A'), 2 AS order_col FROM ${_table} WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND metric_labels->>'pod' IS NOT NULL) AS temp_data ORDER BY order_col, pod;",
         "refresh": 1,
-        "hide": 2
-      },
-      {
-        "name": "avg_value",
-        "type": "query",
-        "datasource": {
-          "type": "postgres",
-          "uid": "kpi-datasource"
-        },
-        "query": "SELECT COALESCE(ROUND(CAST(AVG(metric_value) AS numeric), 6)::text, 'N/A') FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR metric_labels->>'node' = '${node}' OR metric_labels->>'instance' = '${node}') AND ('${job}' = 'All' OR metric_labels->>'job' = '${job}') AND ('${pod}' = 'All' OR metric_labels->>'pod' = '${pod}') AND ('${container}' = 'All' OR metric_labels->>'container' = '${container}')",
-        "includeAll": false,
-        "multi": false,
-        "current": {
-          "text": "",
-          "value": ""
-        },
-        "refresh": 1,
-        "hide": 2
-      },
-      {
-        "name": "min_value",
-        "type": "query",
-        "datasource": {
-          "type": "postgres",
-          "uid": "kpi-datasource"
-        },
-        "query": "SELECT COALESCE(ROUND(CAST(MIN(metric_value) AS numeric), 6)::text, 'N/A') FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR metric_labels->>'node' = '${node}' OR metric_labels->>'instance' = '${node}') AND ('${job}' = 'All' OR metric_labels->>'job' = '${job}') AND ('${pod}' = 'All' OR metric_labels->>'pod' = '${pod}') AND ('${container}' = 'All' OR metric_labels->>'container' = '${container}')",
-        "includeAll": false,
-        "multi": false,
-        "current": {
-          "text": "",
-          "value": ""
-        },
-        "refresh": 1,
-        "hide": 2
-      },
-      {
-        "name": "max_value",
-        "type": "query",
-        "datasource": {
-          "type": "postgres",
-          "uid": "kpi-datasource"
-        },
-        "query": "SELECT COALESCE(ROUND(CAST(MAX(metric_value) AS numeric), 6)::text, 'N/A') FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR metric_labels->>'node' = '${node}' OR metric_labels->>'instance' = '${node}') AND ('${job}' = 'All' OR metric_labels->>'job' = '${job}') AND ('${pod}' = 'All' OR metric_labels->>'pod' = '${pod}') AND ('${container}' = 'All' OR metric_labels->>'container' = '${container}')",
-        "includeAll": false,
-        "multi": false,
-        "current": {
-          "text": "",
-          "value": ""
-        },
-        "refresh": 1,
-        "hide": 2
+        "type": "query"
       },
       {
         "name": "data_start",
@@ -854,13 +874,15 @@
           "type": "postgres",
           "uid": "kpi-datasource"
         },
-        "query": "SELECT COALESCE(CAST(MIN(timestamp_value) * 1000 AS BIGINT), 0) FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}')",
+        "query": "SELECT COALESCE(CAST(MIN(timestamp_value) * 1000 AS BIGINT), 0) FROM ${_table} qr JOIN clusters c ON qr.cluster_id = c.id WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END)",
+        "definition": "SELECT COALESCE(CAST(MIN(timestamp_value) * 1000 AS BIGINT), 0) FROM ${_table} qr JOIN clusters c ON qr.cluster_id = c.id WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END)",
         "includeAll": false,
         "multi": false,
         "current": {
           "text": "",
           "value": ""
         },
+        "options": [],
         "refresh": 1,
         "hide": 2
       },
@@ -871,13 +893,15 @@
           "type": "postgres",
           "uid": "kpi-datasource"
         },
-        "query": "SELECT COALESCE(CAST(MAX(timestamp_value) * 1000 AS BIGINT), 0) FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}')",
+        "query": "SELECT COALESCE(CAST(MAX(timestamp_value) * 1000 AS BIGINT), 0) FROM ${_table} qr JOIN clusters c ON qr.cluster_id = c.id WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END)",
+        "definition": "SELECT COALESCE(CAST(MAX(timestamp_value) * 1000 AS BIGINT), 0) FROM ${_table} qr JOIN clusters c ON qr.cluster_id = c.id WHERE kpi_id LIKE (CASE WHEN '${kpi}' = 'All' THEN '%%' ELSE '${kpi}' END) AND c.cluster_name LIKE (CASE WHEN '${cluster}' = 'All' THEN '%%' ELSE '${cluster}' END) AND COALESCE(c.cluster_type, 'N/A') LIKE (CASE WHEN '${cluster_type}' = 'All' THEN '%%' ELSE '${cluster_type}' END)",
         "includeAll": false,
         "multi": false,
         "current": {
           "text": "",
           "value": ""
         },
+        "options": [],
         "refresh": 1,
         "hide": 2
       }

--- a/grafana-templates/sqlite-dashboard.json
+++ b/grafana-templates/sqlite-dashboard.json
@@ -286,7 +286,7 @@
       "targets": [
         {
           "queryType": "table",
-          "rawQueryText": "SELECT timestamp_value AS time, metric_value, metric_labels FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR json_extract(metric_labels, '$.node') = '${node}' OR json_extract(metric_labels, '$.instance') = '${node}') AND ('${job}' = 'All' OR json_extract(metric_labels, '$.job') = '${job}') AND ('${pod}' = 'All' OR json_extract(metric_labels, '$.pod') = '${pod}') AND ('${container}' = 'All' OR json_extract(metric_labels, '$.container') = '${container}') AND timestamp_value >= $__from / 1000 AND timestamp_value < $__to / 1000 ORDER BY time ASC",
+          "rawQueryText": "SELECT timestamp_value AS time, metric_value, metric_labels FROM ${_table} qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR json_extract(metric_labels, '$.node') = '${node}' OR json_extract(metric_labels, '$.instance') = '${node}') AND ('${job}' = 'All' OR json_extract(metric_labels, '$.job') = '${job}') AND ('${pod}' = 'All' OR json_extract(metric_labels, '$.pod') = '${pod}') AND ('${container}' = 'All' OR json_extract(metric_labels, '$.container') = '${container}') AND timestamp_value >= $__from / 1000 AND timestamp_value < $__to / 1000 ORDER BY time ASC",
           "refId": "A",
           "timeColumns": [
             "time",
@@ -296,21 +296,21 @@
         },
         {
           "queryType": "table",
-          "rawQueryText": "SELECT 'Max Value' AS metric_labels, MAX(metric_value) AS metric_value, $__from/1000 AS time FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR json_extract(metric_labels, '$.node') = '${node}' OR json_extract(metric_labels, '$.instance') = '${node}') AND ('${job}' = 'All' OR json_extract(metric_labels, '$.job') = '${job}') AND ('${pod}' = 'All' OR json_extract(metric_labels, '$.pod') = '${pod}') AND ('${container}' = 'All' OR json_extract(metric_labels, '$.container') = '${container}')",
+          "rawQueryText": "SELECT 'Max Value' AS metric_labels, MAX(metric_value) AS metric_value, $__from/1000 AS time FROM ${_table} qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR json_extract(metric_labels, '$.node') = '${node}' OR json_extract(metric_labels, '$.instance') = '${node}') AND ('${job}' = 'All' OR json_extract(metric_labels, '$.job') = '${job}') AND ('${pod}' = 'All' OR json_extract(metric_labels, '$.pod') = '${pod}') AND ('${container}' = 'All' OR json_extract(metric_labels, '$.container') = '${container}')",
           "refId": "B",
           "legendFormat": "Max Value",
           "hide": true
         },
         {
           "queryType": "table",
-          "rawQueryText": "SELECT 'Min Value' AS metric_labels, MIN(metric_value) AS metric_value, $__from/1000 AS time FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR json_extract(metric_labels, '$.node') = '${node}' OR json_extract(metric_labels, '$.instance') = '${node}') AND ('${job}' = 'All' OR json_extract(metric_labels, '$.job') = '${job}') AND ('${pod}' = 'All' OR json_extract(metric_labels, '$.pod') = '${pod}') AND ('${container}' = 'All' OR json_extract(metric_labels, '$.container') = '${container}')",
+          "rawQueryText": "SELECT 'Min Value' AS metric_labels, MIN(metric_value) AS metric_value, $__from/1000 AS time FROM ${_table} qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR json_extract(metric_labels, '$.node') = '${node}' OR json_extract(metric_labels, '$.instance') = '${node}') AND ('${job}' = 'All' OR json_extract(metric_labels, '$.job') = '${job}') AND ('${pod}' = 'All' OR json_extract(metric_labels, '$.pod') = '${pod}') AND ('${container}' = 'All' OR json_extract(metric_labels, '$.container') = '${container}')",
           "refId": "C",
           "legendFormat": "Min Value",
           "hide": true
         },
         {
           "queryType": "table",
-          "rawQueryText": "SELECT 'Average Value' AS metric_labels, AVG(metric_value) AS metric_value, $__from/1000 AS time FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR json_extract(metric_labels, '$.node') = '${node}' OR json_extract(metric_labels, '$.instance') = '${node}') AND ('${job}' = 'All' OR json_extract(metric_labels, '$.job') = '${job}') AND ('${pod}' = 'All' OR json_extract(metric_labels, '$.pod') = '${pod}') AND ('${container}' = 'All' OR json_extract(metric_labels, '$.container') = '${container}')",
+          "rawQueryText": "SELECT 'Average Value' AS metric_labels, AVG(metric_value) AS metric_value, $__from/1000 AS time FROM ${_table} qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR json_extract(metric_labels, '$.node') = '${node}' OR json_extract(metric_labels, '$.instance') = '${node}') AND ('${job}' = 'All' OR json_extract(metric_labels, '$.job') = '${job}') AND ('${pod}' = 'All' OR json_extract(metric_labels, '$.pod') = '${pod}') AND ('${container}' = 'All' OR json_extract(metric_labels, '$.container') = '${container}')",
           "refId": "D",
           "legendFormat": "Average Value",
           "hide": true
@@ -418,7 +418,7 @@
       "targets": [
         {
           "queryType": "table",
-          "rawQueryText": "SELECT metric_labels, ROUND(AVG(metric_value), 6) AS avg_value, ROUND(MIN(metric_value), 6) AS min_value, ROUND(MAX(metric_value), 6) AS max_value, COUNT(*) AS samples FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR json_extract(metric_labels, '$.node') = '${node}' OR json_extract(metric_labels, '$.instance') = '${node}') AND ('${job}' = 'All' OR json_extract(metric_labels, '$.job') = '${job}') AND ('${pod}' = 'All' OR json_extract(metric_labels, '$.pod') = '${pod}') AND ('${container}' = 'All' OR json_extract(metric_labels, '$.container') = '${container}') GROUP BY metric_labels ORDER BY avg_value DESC LIMIT 100",
+          "rawQueryText": "SELECT metric_labels, ROUND(AVG(metric_value), 6) AS avg_value, ROUND(MIN(metric_value), 6) AS min_value, ROUND(MAX(metric_value), 6) AS max_value, COUNT(*) AS samples FROM ${_table} qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR json_extract(metric_labels, '$.node') = '${node}' OR json_extract(metric_labels, '$.instance') = '${node}') AND ('${job}' = 'All' OR json_extract(metric_labels, '$.job') = '${job}') AND ('${pod}' = 'All' OR json_extract(metric_labels, '$.pod') = '${pod}') AND ('${container}' = 'All' OR json_extract(metric_labels, '$.container') = '${container}') GROUP BY metric_labels ORDER BY avg_value DESC LIMIT 100",
           "refId": "A"
         }
       ],
@@ -553,7 +553,7 @@
       "targets": [
         {
           "queryType": "table",
-          "rawQueryText": "SELECT kpi_id, COUNT(*) AS sample_count, ROUND(AVG(metric_value), 6) AS avg_value, ROUND(MIN(metric_value), 6) AS min_value, ROUND(MAX(metric_value), 6) AS max_value, ROUND(MAX(metric_value) - MIN(metric_value), 6) AS range, COUNT(DISTINCT metric_labels) AS unique_metrics FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR json_extract(metric_labels, '$.node') = '${node}' OR json_extract(metric_labels, '$.instance') = '${node}') AND ('${job}' = 'All' OR json_extract(metric_labels, '$.job') = '${job}') AND ('${pod}' = 'All' OR json_extract(metric_labels, '$.pod') = '${pod}') AND ('${container}' = 'All' OR json_extract(metric_labels, '$.container') = '${container}') GROUP BY kpi_id ORDER BY kpi_id",
+          "rawQueryText": "SELECT kpi_id, COUNT(*) AS sample_count, ROUND(AVG(metric_value), 6) AS avg_value, ROUND(MIN(metric_value), 6) AS min_value, ROUND(MAX(metric_value), 6) AS max_value, ROUND(MAX(metric_value) - MIN(metric_value), 6) AS range, COUNT(DISTINCT metric_labels) AS unique_metrics FROM ${_table} qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR json_extract(metric_labels, '$.node') = '${node}' OR json_extract(metric_labels, '$.instance') = '${node}') AND ('${job}' = 'All' OR json_extract(metric_labels, '$.job') = '${job}') AND ('${pod}' = 'All' OR json_extract(metric_labels, '$.pod') = '${pod}') AND ('${container}' = 'All' OR json_extract(metric_labels, '$.container') = '${container}') GROUP BY kpi_id ORDER BY kpi_id",
           "refId": "A"
         }
       ]
@@ -604,7 +604,7 @@
       "targets": [
         {
           "queryType": "table",
-          "rawQueryText": "SELECT c.cluster_name, c.cluster_type, COUNT(DISTINCT qr.kpi_id) AS kpi_count, COUNT(*) AS total_samples, MAX(qr.created_at) AS last_collection FROM clusters c LEFT JOIN query_results qr ON c.id = qr.cluster_id WHERE ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${node}' = 'All' OR json_extract(qr.metric_labels, '$.node') = '${node}' OR json_extract(qr.metric_labels, '$.instance') = '${node}') AND ('${job}' = 'All' OR json_extract(qr.metric_labels, '$.job') = '${job}') AND ('${pod}' = 'All' OR json_extract(qr.metric_labels, '$.pod') = '${pod}') AND ('${container}' = 'All' OR json_extract(qr.metric_labels, '$.container') = '${container}') GROUP BY c.cluster_name, c.cluster_type ORDER BY c.cluster_name",
+          "rawQueryText": "SELECT c.cluster_name, c.cluster_type, COUNT(DISTINCT qr.kpi_id) AS kpi_count, COUNT(*) AS total_samples, MAX(qr.created_at) AS last_collection FROM clusters c LEFT JOIN ${_table} qr ON c.id = qr.cluster_id WHERE ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${node}' = 'All' OR json_extract(qr.metric_labels, '$.node') = '${node}' OR json_extract(qr.metric_labels, '$.instance') = '${node}') AND ('${job}' = 'All' OR json_extract(qr.metric_labels, '$.job') = '${job}') AND ('${pod}' = 'All' OR json_extract(qr.metric_labels, '$.pod') = '${pod}') AND ('${container}' = 'All' OR json_extract(qr.metric_labels, '$.container') = '${container}') GROUP BY c.cluster_name, c.cluster_type ORDER BY c.cluster_name",
           "refId": "A"
         }
       ]
@@ -645,7 +645,7 @@
           "type": "frser-sqlite-datasource",
           "uid": "kpi-datasource"
         },
-        "query": "SELECT cluster_name FROM (SELECT DISTINCT c.cluster_name, CASE WHEN c.id = (SELECT cluster_id FROM query_results ORDER BY created_at DESC LIMIT 1) THEN 1 ELSE 3 END AS sort_order FROM clusters c WHERE c.cluster_name IS NOT NULL AND c.cluster_name <> '' AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') UNION ALL SELECT 'All', 2) ORDER BY sort_order, cluster_name;",
+        "query": "SELECT cluster_name FROM (SELECT DISTINCT c.cluster_name, CASE WHEN c.id = (SELECT cluster_id FROM ${_table} ORDER BY created_at DESC LIMIT 1) THEN 1 ELSE 3 END AS sort_order FROM clusters c WHERE c.cluster_name IS NOT NULL AND c.cluster_name <> '' AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') UNION ALL SELECT 'All', 2) ORDER BY sort_order, cluster_name;",
         "includeAll": false,
         "multi": false,
         "current": {
@@ -655,6 +655,41 @@
         "refresh": 1
       },
       {
+        "name": "category",
+        "type": "query",
+        "label": "Category",
+        "datasource": {
+          "type": "frser-sqlite-datasource",
+          "uid": "kpi-datasource"
+        },
+        "query": "SELECT category FROM (SELECT DISTINCT category, 1 AS sort_order FROM kpi_registry WHERE category IS NOT NULL AND category <> '' UNION ALL SELECT 'default', 2) ORDER BY sort_order, category;",
+        "includeAll": false,
+        "multi": false,
+        "current": {
+          "text": "",
+          "value": ""
+        },
+        "refresh": 1
+      },
+      {
+        "name": "_table",
+        "type": "query",
+        "label": "",
+        "datasource": {
+          "type": "frser-sqlite-datasource",
+          "uid": "kpi-datasource"
+        },
+        "query": "SELECT CASE WHEN '${category}' = 'default' THEN 'query_results' ELSE 'kpi_' || '${category}' END;",
+        "includeAll": false,
+        "multi": false,
+        "current": {
+          "text": "",
+          "value": ""
+        },
+        "refresh": 1,
+        "hide": 2
+      },
+      {
         "name": "kpi",
         "type": "query",
         "label": "KPI",
@@ -662,7 +697,7 @@
           "type": "frser-sqlite-datasource",
           "uid": "kpi-datasource"
         },
-        "query": "SELECT kpi_id FROM (SELECT DISTINCT kpi_id, 1 AS sort_order FROM query_results WHERE kpi_id IS NOT NULL AND kpi_id <> '' UNION ALL SELECT 'All', 2) ORDER BY sort_order, kpi_id;",
+        "query": "SELECT kpi_id FROM (SELECT DISTINCT kpi_id, 1 AS sort_order FROM ${_table} WHERE kpi_id IS NOT NULL AND kpi_id <> '' UNION ALL SELECT 'All', 2) ORDER BY sort_order, kpi_id;",
         "includeAll": false,
         "multi": false,
         "current": {
@@ -679,7 +714,7 @@
           "type": "frser-sqlite-datasource",
           "uid": "kpi-datasource"
         },
-        "query": "SELECT node FROM (SELECT 'All' AS node, 1 AS sort_order UNION ALL SELECT DISTINCT COALESCE(json_extract(metric_labels, '$.node'), json_extract(metric_labels, '$.instance')), 2 FROM query_results WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND metric_labels IS NOT NULL AND COALESCE(json_extract(metric_labels, '$.node'), json_extract(metric_labels, '$.instance')) IS NOT NULL AND COALESCE(json_extract(metric_labels, '$.node'), json_extract(metric_labels, '$.instance')) <> '') ORDER BY sort_order, node;",
+        "query": "SELECT node FROM (SELECT 'All' AS node, 1 AS sort_order UNION ALL SELECT DISTINCT COALESCE(json_extract(metric_labels, '$.node'), json_extract(metric_labels, '$.instance')), 2 FROM ${_table} WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND metric_labels IS NOT NULL AND COALESCE(json_extract(metric_labels, '$.node'), json_extract(metric_labels, '$.instance')) IS NOT NULL AND COALESCE(json_extract(metric_labels, '$.node'), json_extract(metric_labels, '$.instance')) <> '') ORDER BY sort_order, node;",
         "includeAll": false,
         "multi": false,
         "current": {
@@ -696,7 +731,7 @@
           "type": "frser-sqlite-datasource",
           "uid": "kpi-datasource"
         },
-        "query": "SELECT job FROM (SELECT 'All' AS job, 1 AS sort_order UNION ALL SELECT DISTINCT json_extract(metric_labels, '$.job'), 2 FROM query_results WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND metric_labels IS NOT NULL AND json_extract(metric_labels, '$.job') IS NOT NULL AND json_extract(metric_labels, '$.job') <> '') ORDER BY sort_order, job;",
+        "query": "SELECT job FROM (SELECT 'All' AS job, 1 AS sort_order UNION ALL SELECT DISTINCT json_extract(metric_labels, '$.job'), 2 FROM ${_table} WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND metric_labels IS NOT NULL AND json_extract(metric_labels, '$.job') IS NOT NULL AND json_extract(metric_labels, '$.job') <> '') ORDER BY sort_order, job;",
         "includeAll": false,
         "multi": false,
         "current": {
@@ -713,7 +748,7 @@
           "type": "frser-sqlite-datasource",
           "uid": "kpi-datasource"
         },
-        "query": "SELECT pod FROM (SELECT 'All' AS pod, 1 AS sort_order UNION ALL SELECT DISTINCT json_extract(metric_labels, '$.pod'), 2 FROM query_results WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND metric_labels IS NOT NULL AND json_extract(metric_labels, '$.pod') IS NOT NULL AND json_extract(metric_labels, '$.pod') <> '') ORDER BY sort_order, pod;",
+        "query": "SELECT pod FROM (SELECT 'All' AS pod, 1 AS sort_order UNION ALL SELECT DISTINCT json_extract(metric_labels, '$.pod'), 2 FROM ${_table} WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND metric_labels IS NOT NULL AND json_extract(metric_labels, '$.pod') IS NOT NULL AND json_extract(metric_labels, '$.pod') <> '') ORDER BY sort_order, pod;",
         "includeAll": false,
         "multi": false,
         "current": {
@@ -730,7 +765,7 @@
           "type": "frser-sqlite-datasource",
           "uid": "kpi-datasource"
         },
-        "query": "SELECT container FROM (SELECT 'All' AS container, 1 AS sort_order UNION ALL SELECT DISTINCT json_extract(metric_labels, '$.container'), 2 FROM query_results WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND metric_labels IS NOT NULL AND json_extract(metric_labels, '$.container') IS NOT NULL AND json_extract(metric_labels, '$.container') <> '') ORDER BY sort_order, container;",
+        "query": "SELECT container FROM (SELECT 'All' AS container, 1 AS sort_order UNION ALL SELECT DISTINCT json_extract(metric_labels, '$.container'), 2 FROM ${_table} WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND metric_labels IS NOT NULL AND json_extract(metric_labels, '$.container') IS NOT NULL AND json_extract(metric_labels, '$.container') <> '') ORDER BY sort_order, container;",
         "includeAll": false,
         "multi": false,
         "current": {
@@ -746,7 +781,7 @@
           "type": "frser-sqlite-datasource",
           "uid": "kpi-datasource"
         },
-        "query": "SELECT COALESCE(COUNT(*), 0) FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR json_extract(metric_labels, '$.node') = '${node}' OR json_extract(metric_labels, '$.instance') = '${node}') AND ('${job}' = 'All' OR json_extract(metric_labels, '$.job') = '${job}') AND ('${pod}' = 'All' OR json_extract(metric_labels, '$.pod') = '${pod}') AND ('${container}' = 'All' OR json_extract(metric_labels, '$.container') = '${container}')",
+        "query": "SELECT COALESCE(COUNT(*), 0) FROM ${_table} qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR json_extract(metric_labels, '$.node') = '${node}' OR json_extract(metric_labels, '$.instance') = '${node}') AND ('${job}' = 'All' OR json_extract(metric_labels, '$.job') = '${job}') AND ('${pod}' = 'All' OR json_extract(metric_labels, '$.pod') = '${pod}') AND ('${container}' = 'All' OR json_extract(metric_labels, '$.container') = '${container}')",
         "includeAll": false,
         "multi": false,
         "current": {
@@ -763,7 +798,7 @@
           "type": "frser-sqlite-datasource",
           "uid": "kpi-datasource"
         },
-        "query": "SELECT COALESCE(ROUND(AVG(metric_value), 6), 'N/A') FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR json_extract(metric_labels, '$.node') = '${node}' OR json_extract(metric_labels, '$.instance') = '${node}') AND ('${job}' = 'All' OR json_extract(metric_labels, '$.job') = '${job}') AND ('${pod}' = 'All' OR json_extract(metric_labels, '$.pod') = '${pod}') AND ('${container}' = 'All' OR json_extract(metric_labels, '$.container') = '${container}')",
+        "query": "SELECT COALESCE(ROUND(AVG(metric_value), 6), 'N/A') FROM ${_table} qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR json_extract(metric_labels, '$.node') = '${node}' OR json_extract(metric_labels, '$.instance') = '${node}') AND ('${job}' = 'All' OR json_extract(metric_labels, '$.job') = '${job}') AND ('${pod}' = 'All' OR json_extract(metric_labels, '$.pod') = '${pod}') AND ('${container}' = 'All' OR json_extract(metric_labels, '$.container') = '${container}')",
         "includeAll": false,
         "multi": false,
         "current": {
@@ -780,7 +815,7 @@
           "type": "frser-sqlite-datasource",
           "uid": "kpi-datasource"
         },
-        "query": "SELECT COALESCE(ROUND(MIN(metric_value), 6), 'N/A') FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR json_extract(metric_labels, '$.node') = '${node}' OR json_extract(metric_labels, '$.instance') = '${node}') AND ('${job}' = 'All' OR json_extract(metric_labels, '$.job') = '${job}') AND ('${pod}' = 'All' OR json_extract(metric_labels, '$.pod') = '${pod}') AND ('${container}' = 'All' OR json_extract(metric_labels, '$.container') = '${container}')",
+        "query": "SELECT COALESCE(ROUND(MIN(metric_value), 6), 'N/A') FROM ${_table} qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR json_extract(metric_labels, '$.node') = '${node}' OR json_extract(metric_labels, '$.instance') = '${node}') AND ('${job}' = 'All' OR json_extract(metric_labels, '$.job') = '${job}') AND ('${pod}' = 'All' OR json_extract(metric_labels, '$.pod') = '${pod}') AND ('${container}' = 'All' OR json_extract(metric_labels, '$.container') = '${container}')",
         "includeAll": false,
         "multi": false,
         "current": {
@@ -797,7 +832,7 @@
           "type": "frser-sqlite-datasource",
           "uid": "kpi-datasource"
         },
-        "query": "SELECT COALESCE(ROUND(MAX(metric_value), 6), 'N/A') FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR json_extract(metric_labels, '$.node') = '${node}' OR json_extract(metric_labels, '$.instance') = '${node}') AND ('${job}' = 'All' OR json_extract(metric_labels, '$.job') = '${job}') AND ('${pod}' = 'All' OR json_extract(metric_labels, '$.pod') = '${pod}') AND ('${container}' = 'All' OR json_extract(metric_labels, '$.container') = '${container}')",
+        "query": "SELECT COALESCE(ROUND(MAX(metric_value), 6), 'N/A') FROM ${_table} qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR json_extract(metric_labels, '$.node') = '${node}' OR json_extract(metric_labels, '$.instance') = '${node}') AND ('${job}' = 'All' OR json_extract(metric_labels, '$.job') = '${job}') AND ('${pod}' = 'All' OR json_extract(metric_labels, '$.pod') = '${pod}') AND ('${container}' = 'All' OR json_extract(metric_labels, '$.container') = '${container}')",
         "includeAll": false,
         "multi": false,
         "current": {
@@ -814,7 +849,7 @@
           "type": "frser-sqlite-datasource",
           "uid": "kpi-datasource"
         },
-        "query": "SELECT COALESCE(CAST(MIN(timestamp_value) * 1000 AS INTEGER), 0) FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}')",
+        "query": "SELECT COALESCE(CAST(MIN(timestamp_value) * 1000 AS INTEGER), 0) FROM ${_table} qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}')",
         "includeAll": false,
         "multi": false,
         "current": {
@@ -831,7 +866,7 @@
           "type": "frser-sqlite-datasource",
           "uid": "kpi-datasource"
         },
-        "query": "SELECT COALESCE(CAST(MAX(timestamp_value) * 1000 AS INTEGER), 0) FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}')",
+        "query": "SELECT COALESCE(CAST(MAX(timestamp_value) * 1000 AS INTEGER), 0) FROM ${_table} qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}')",
         "includeAll": false,
         "multi": false,
         "current": {
@@ -849,7 +884,7 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "KPI Collection Tool - Dynamic Dashboard",
+  "title": "KPI Collection Tool Dashboard",
   "uid": "kpi-collector-dynamic",
   "version": 3,
   "weekStart": ""

--- a/internal/commands/db_remove.go
+++ b/internal/commands/db_remove.go
@@ -13,6 +13,7 @@ import (
 var (
 	removeClusterName string
 	removeKPIName     string
+	removeCategory    string
 	removeAll         bool
 )
 
@@ -38,12 +39,18 @@ WARNING: This operation cannot be undone. All metric samples for the cluster wil
 var removeKPIsCmd = &cobra.Command{
 	Use:   "kpis",
 	Short: "Remove KPI metrics",
-	Long:  `Delete KPI metrics from the database, optionally filtered by cluster and KPI name.`,
+	Long: `Delete KPI metrics from the database, filtered by cluster, KPI name, or category.
+
+When --category is used, all data in that category table is removed along with
+the registry entries. This is independent of the --cluster-name flag.`,
 	Example: `  # Remove all KPIs from a cluster
   kpi-collector db remove kpis --cluster-name="mycluster1"
   
   # Remove specific KPI from a cluster
-  kpi-collector db remove kpis --cluster-name="mycluster1" --name="cpu-system"`,
+  kpi-collector db remove kpis --cluster-name="mycluster1" --name="cpu-system"
+
+  # Remove all data for a category
+  kpi-collector db remove kpis --category=cpu`,
 	RunE: runRemoveKPIs,
 }
 
@@ -72,10 +79,11 @@ func init() {
 
 	// Flags for 'remove kpis'
 	removeKPIsCmd.Flags().StringVar(&removeClusterName, "cluster-name", "",
-		"cluster name (required)")
+		"cluster name (required unless --category is used)")
 	removeKPIsCmd.Flags().StringVar(&removeKPIName, "name", "",
 		"KPI name to remove (optional)")
-	_ = removeKPIsCmd.MarkFlagRequired("cluster-name")
+	removeKPIsCmd.Flags().StringVar(&removeCategory, "category", "",
+		"remove all data for a category (e.g. cpu, memory)")
 
 	// Flags for 'remove errors'
 	removeErrorsCmd.Flags().StringVar(&removeKPIName, "name", "",
@@ -112,11 +120,29 @@ func runRemoveClusters(cmd *cobra.Command, args []string) error {
 }
 
 func runRemoveKPIs(cmd *cobra.Command, args []string) error {
+	// user must provide the cluster namr OR a category to remove KPIs
+	if removeCategory == "" && removeClusterName == "" {
+		return fmt.Errorf("must specify either --cluster-name or --category")
+	}
+
 	db, dbImpl, err := connectToDB()
 	if err != nil {
 		return fmt.Errorf("failed to connect to DB: %w", err)
 	}
 	defer func() { _ = db.Close() }()
+
+	if removeCategory != "" {
+		deleted, err := dbImpl.DeleteByCategory(db, removeCategory)
+		if err != nil {
+			return fmt.Errorf("failed to delete category '%s': %w", removeCategory, err)
+		}
+		if deleted == 0 {
+			fmt.Printf("No metrics found for category '%s'.\n", removeCategory)
+			return nil
+		}
+		fmt.Printf("✓ Deleted %s metric samples from category '%s'.\n", humanize.Comma(deleted), removeCategory)
+		return nil
+	}
 
 	_, deleted, err := deleteClusterMetrics(db, dbImpl, removeClusterName, removeKPIName)
 	if err != nil {
@@ -180,23 +206,33 @@ func deleteClusterMetrics(db *sql.DB, dbImpl database.Database, clusterName, kpi
 	}
 	cluster := clusters[0]
 
-	query := "DELETE FROM query_results WHERE cluster_id = $1"
-	queryArgs := []interface{}{cluster.ID}
-
-	if kpiName != "" {
-		query += " AND kpi_id = $2"
-		queryArgs = append(queryArgs, kpiName)
-	}
-
-	if _, ok := dbImpl.(*database.SQLiteDB); ok {
-		query = convertPostgresToSQLitePlaceholders(query)
-	}
-
-	result, err := db.Exec(query, queryArgs...)
+	tables, err := allCategoryTables(db, dbImpl)
 	if err != nil {
-		return nil, 0, fmt.Errorf("failed to delete metrics: %w", err)
+		return nil, 0, fmt.Errorf("list tables: %w", err)
 	}
 
-	deleted, _ := result.RowsAffected()
-	return &cluster, deleted, nil
+	var totalDeleted int64
+	for _, t := range tables {
+		query := fmt.Sprintf("DELETE FROM %s WHERE cluster_id = $1", t.TableName)
+		queryArgs := []interface{}{cluster.ID}
+
+		if kpiName != "" {
+			query += " AND kpi_id = $2"
+			queryArgs = append(queryArgs, kpiName)
+		}
+
+		if _, ok := dbImpl.(*database.SQLiteDB); ok {
+			query = convertPostgresToSQLitePlaceholders(query)
+		}
+
+		result, err := db.Exec(query, queryArgs...)
+		if err != nil {
+			return nil, totalDeleted, fmt.Errorf("failed to delete from %s: %w", t.TableName, err)
+		}
+
+		deleted, _ := result.RowsAffected()
+		totalDeleted += deleted
+	}
+
+	return &cluster, totalDeleted, nil
 }

--- a/internal/commands/db_remove.go
+++ b/internal/commands/db_remove.go
@@ -132,6 +132,9 @@ func runRemoveKPIs(cmd *cobra.Command, args []string) error {
 	defer func() { _ = db.Close() }()
 
 	if removeCategory != "" {
+		if err := validateCategory(db, dbImpl, removeCategory); err != nil {
+			return err
+		}
 		deleted, err := dbImpl.DeleteByCategory(db, removeCategory)
 		if err != nil {
 			return fmt.Errorf("failed to delete category '%s': %w", removeCategory, err)

--- a/internal/commands/db_show.go
+++ b/internal/commands/db_show.go
@@ -87,6 +87,16 @@ var showClustersCmd = &cobra.Command{
 	RunE: runShowClusters,
 }
 
+var showCategoriesCmd = &cobra.Command{
+	Use:   "categories",
+	Short: "List all KPI categories",
+	Long: `Display all KPI categories registered in the database.
+Shows the category name, backing table, and number of KPIs per category.`,
+	Example: `  # List all categories
+  kpi-collector db show categories`,
+	RunE: runShowCategories,
+}
+
 var showErrorsCmd = &cobra.Command{
 	Use:   "errors",
 	Short: "Show query error counts",
@@ -102,6 +112,7 @@ func init() {
 	dbCmd.AddCommand(showCmd)
 	showCmd.AddCommand(showKPIsCmd)
 	showCmd.AddCommand(showClustersCmd)
+	showCmd.AddCommand(showCategoriesCmd)
 	showCmd.AddCommand(showErrorsCmd)
 
 	// Flags for 'show kpis'
@@ -149,6 +160,12 @@ func runShowKPIs(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to connect to DB: %w", err)
 	}
 	defer func() { _ = db.Close() }()
+
+	if kpiQueryFlags.category != "" {
+		if err := validateCategory(db, dbImpl, kpiQueryFlags.category); err != nil {
+			return err
+		}
+	}
 
 	// Parse time filters using a single reference time to avoid drift.
 	sinceTime, untilTime, err := parseKPIQueryTimeWindow(kpiQueryFlags.since, kpiQueryFlags.until, time.Now())
@@ -225,6 +242,36 @@ func runShowClusters(cmd *cobra.Command, args []string) error {
 	}
 
 	output.PrintClustersTable(records)
+	return nil
+}
+
+func runShowCategories(cmd *cobra.Command, args []string) error {
+	db, dbImpl, err := connectToDB()
+	if err != nil {
+		return fmt.Errorf("failed to connect to DB: %w", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	categories, err := dbImpl.ListCategories(db)
+	if err != nil {
+		return fmt.Errorf("failed to list categories: %w", err)
+	}
+
+	if len(categories) == 0 {
+		fmt.Println("No categories found.")
+		return nil
+	}
+
+	records := make([]output.CategoryRecord, len(categories))
+	for i, c := range categories {
+		records[i] = output.CategoryRecord{
+			Category:  c.Category,
+			TableName: c.TableName,
+			KPICount:  c.KPICount,
+		}
+	}
+
+	output.PrintCategoriesTable(records)
 	return nil
 }
 
@@ -608,6 +655,31 @@ func convertToKPIRecords(results []KPIResult) []output.KPIRecord {
 		}
 	}
 	return records
+}
+
+// validateCategory checks that the given category exists in kpi_registry.
+// Returns a descriptive error listing available categories when it does not.
+func validateCategory(db *sql.DB, dbImpl database.Database, category string) error {
+	categories, err := dbImpl.ListCategories(db)
+	if err != nil {
+		return fmt.Errorf("failed to list categories: %w", err)
+	}
+
+	for _, c := range categories {
+		if c.Category == category {
+			return nil
+		}
+	}
+
+	if len(categories) == 0 {
+		return fmt.Errorf("category %q not found (no categories exist in the database)", category)
+	}
+
+	names := make([]string, len(categories))
+	for i, c := range categories {
+		names[i] = c.Category
+	}
+	return fmt.Errorf("category %q not found; available categories: %s", category, strings.Join(names, ", "))
 }
 
 func convertPostgresToSQLitePlaceholders(query string) string {

--- a/internal/commands/db_show.go
+++ b/internal/commands/db_show.go
@@ -487,7 +487,6 @@ func queryFromTable(db *sql.DB, dbImpl database.Database, tableName, category st
 	if params.Until != nil {
 		query += fmt.Sprintf(" AND qr.timestamp_value <= $%d", argIndex)
 		args = append(args, float64(params.Until.Truncate(time.Second).Unix()))
-		argIndex++
 	}
 
 	if _, ok := dbImpl.(*database.SQLiteDB); ok {

--- a/internal/commands/db_show.go
+++ b/internal/commands/db_show.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -16,6 +17,7 @@ import (
 // kpiQueryFlags holds the flags for the 'show kpis' command
 var kpiQueryFlags struct {
 	kpiName      string
+	category     string
 	clusterName  string
 	labelsFilter string
 	since        string
@@ -40,11 +42,14 @@ var showCmd = &cobra.Command{
 var showKPIsCmd = &cobra.Command{
 	Use:   "kpis",
 	Short: "Show KPI metrics",
-	Long: `Query and display KPI metrics with optional filtering by name, cluster, labels, and time range.
+	Long: `Query and display KPI metrics with optional filtering by name, category, cluster, labels, and time range.
 
 The results can be displayed in table, JSON, or CSV format.`,
 	Example: `  # Show all metrics for a KPI
   kpi-collector db show kpis --name="cpu-system"
+  
+  # Show all metrics in a category
+  kpi-collector db show kpis --category=cpu
   
   # Filter by cluster
   kpi-collector db show kpis --name="cpu-system" --cluster-name="mycluster1"
@@ -102,6 +107,8 @@ func init() {
 	// Flags for 'show kpis'
 	showKPIsCmd.Flags().StringVar(&kpiQueryFlags.kpiName, "name", "",
 		"KPI name to filter by")
+	showKPIsCmd.Flags().StringVar(&kpiQueryFlags.category, "category", "",
+		"category to filter by (e.g. cpu, memory, network)")
 	showKPIsCmd.Flags().StringVar(&kpiQueryFlags.clusterName, "cluster-name", "",
 		"cluster name to filter by")
 	showKPIsCmd.Flags().StringVar(&kpiQueryFlags.labelsFilter, "labels-filter", "",
@@ -125,6 +132,12 @@ func init() {
 }
 
 func runShowKPIs(cmd *cobra.Command, args []string) error {
+	if kpiQueryFlags.kpiName != "" && kpiQueryFlags.category != "" {
+		return fmt.Errorf("--name and --category cannot be used together: " +
+			"--name looks up a specific KPI (auto-discovers its table), " +
+			"--category queries all KPIs in a category")
+	}
+
 	// Parse output format first (fail fast if invalid)
 	format, err := output.ParseFormat(kpiQueryFlags.outputFormat)
 	if err != nil {
@@ -155,6 +168,7 @@ func runShowKPIs(cmd *cobra.Command, args []string) error {
 	// Build query parameters
 	params := KPIQueryParams{
 		KPIName:      kpiQueryFlags.kpiName,
+		Category:     kpiQueryFlags.category,
 		ClusterName:  kpiQueryFlags.clusterName,
 		LabelFilters: labelFilters,
 		Since:        sinceTime,
@@ -304,6 +318,7 @@ func parseLabelFilters(filterStr string) (map[string]string, error) {
 type KPIResult struct {
 	ID             int64
 	KPIName        string
+	Category       string
 	ClusterName    string
 	MetricValue    float64
 	TimestampValue float64
@@ -313,6 +328,7 @@ type KPIResult struct {
 
 type KPIQueryParams struct {
 	KPIName      string
+	Category     string
 	ClusterName  string
 	LabelFilters map[string]string
 	Since        *time.Time
@@ -322,13 +338,80 @@ type KPIQueryParams struct {
 }
 
 func queryKPIs(db *sql.DB, dbImpl database.Database, params KPIQueryParams) ([]KPIResult, error) {
-	query := `
-		SELECT qr.id, qr.kpi_id, c.cluster_name, qr.metric_value, 
+	if params.KPIName != "" {
+		return queryByName(db, dbImpl, params)
+	}
+	if params.Category != "" {
+		return queryByCategory(db, dbImpl, params)
+	}
+	return queryAll(db, dbImpl, params)
+}
+
+// queryByName resolves which table holds the KPI via the registry and queries it.
+func queryByName(db *sql.DB, dbImpl database.Database, params KPIQueryParams) ([]KPIResult, error) {
+	category, tableName, err := dbImpl.LookupCategoryForKPI(db, params.KPIName)
+	if err != nil {
+		return nil, fmt.Errorf("lookup KPI %q: %w", params.KPIName, err)
+	}
+	if tableName == "" {
+		tableName = database.DefaultTableName
+	}
+	return queryFromTable(db, dbImpl, tableName, category, params)
+}
+
+// queryByCategory queries the single category-specific table.
+func queryByCategory(db *sql.DB, dbImpl database.Database, params KPIQueryParams) ([]KPIResult, error) {
+	tableName := database.CategoryTableName(params.Category)
+	return queryFromTable(db, dbImpl, tableName, params.Category, params)
+}
+
+// allCategoryTables returns the default table plus every registered category table.
+func allCategoryTables(db *sql.DB, dbImpl database.Database) ([]database.CategoryInfo, error) {
+	categories, err := dbImpl.ListCategories(db)
+	if err != nil {
+		return nil, err
+	}
+	all := make([]database.CategoryInfo, 0, 1+len(categories))
+	all = append(all, database.CategoryInfo{TableName: database.DefaultTableName})
+	all = append(all, categories...)
+	return all, nil
+}
+
+// queryAll scans every known table (default + all categories), merges, sorts, and limits.
+// Sort and limit must happen here (not in SQL) because rows come from separate tables —
+// we can't know the global ordering or which rows survive the limit until all tables are merged.
+func queryAll(db *sql.DB, dbImpl database.Database, params KPIQueryParams) ([]KPIResult, error) {
+	tables, err := allCategoryTables(db, dbImpl)
+	if err != nil {
+		return nil, fmt.Errorf("list tables: %w", err)
+	}
+
+	var results []KPIResult
+	for _, t := range tables {
+		rows, err := queryFromTable(db, dbImpl, t.TableName, t.Category, params)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, rows...)
+	}
+
+	sortResults(results, params.Sort)
+
+	if params.Limit > 0 && len(results) > params.Limit {
+		results = results[:params.Limit]
+	}
+
+	return results, nil
+}
+
+func queryFromTable(db *sql.DB, dbImpl database.Database, tableName, category string, params KPIQueryParams) ([]KPIResult, error) {
+	query := fmt.Sprintf(`
+		SELECT qr.id, qr.kpi_id, c.cluster_name, qr.metric_value,
 		       qr.timestamp_value, qr.execution_time, qr.metric_labels
-		FROM query_results qr
+		FROM %s qr
 		JOIN clusters c ON qr.cluster_id = c.id
 		WHERE 1=1
-	`
+	`, tableName)
 
 	args := []interface{}{}
 	argIndex := 1
@@ -360,18 +443,6 @@ func queryKPIs(db *sql.DB, dbImpl database.Database, params KPIQueryParams) ([]K
 		argIndex++
 	}
 
-	if params.Sort == "desc" {
-		query += " ORDER BY qr.timestamp_value DESC"
-	} else {
-		query += " ORDER BY qr.timestamp_value ASC"
-	}
-
-	if params.Limit > 0 {
-		query += fmt.Sprintf(" LIMIT $%d", argIndex)
-		args = append(args, params.Limit)
-	}
-
-	// Convert placeholders for SQLite
 	if _, ok := dbImpl.(*database.SQLiteDB); ok {
 		query = convertPostgresToSQLitePlaceholders(query)
 	}
@@ -390,18 +461,25 @@ func queryKPIs(db *sql.DB, dbImpl database.Database, params KPIQueryParams) ([]K
 		if err != nil {
 			return nil, err
 		}
+		r.Category = category
 
-		// Apply label filters
-		if len(params.LabelFilters) > 0 {
-			if !matchesLabelFilters(r.MetricLabels, params.LabelFilters) {
-				continue
-			}
+		if len(params.LabelFilters) > 0 && !matchesLabelFilters(r.MetricLabels, params.LabelFilters) {
+			continue
 		}
 
 		results = append(results, r)
 	}
 
 	return results, rows.Err()
+}
+
+func sortResults(results []KPIResult, order string) {
+	sort.Slice(results, func(i, j int) bool {
+		if order == "desc" {
+			return results[i].ExecutionTime.After(results[j].ExecutionTime)
+		}
+		return results[i].ExecutionTime.Before(results[j].ExecutionTime)
+	})
 }
 
 func matchesLabelFilters(labelsJSON string, filters map[string]string) bool {
@@ -427,41 +505,61 @@ type ClusterInfo struct {
 }
 
 func listClusters(db *sql.DB, dbImpl database.Database, clusterName string) ([]ClusterInfo, error) {
-	query := `
-		SELECT c.id, c.cluster_name, c.created_at, COUNT(qr.id) as total_metrics
-		FROM clusters c
-		LEFT JOIN query_results qr ON c.id = qr.cluster_id
-	`
-	args := []interface{}{}
-
-	if clusterName != "" {
-		query += " WHERE c.cluster_name = $1"
-		args = append(args, clusterName)
-	}
-
-	query += " GROUP BY c.id, c.cluster_name, c.created_at ORDER BY c.created_at DESC"
-
-	if _, ok := dbImpl.(*database.SQLiteDB); ok {
-		query = convertPostgresToSQLitePlaceholders(query)
-	}
-
-	rows, err := db.Query(query, args...)
+	tables, err := allCategoryTables(db, dbImpl)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("list tables: %w", err)
 	}
-	defer func() { _ = rows.Close() }()
 
-	var clusters []ClusterInfo
-	for rows.Next() {
-		var c ClusterInfo
-		err := rows.Scan(&c.ID, &c.Name, &c.CreatedAt, &c.TotalMetrics)
+	clusterMap := make(map[int64]*ClusterInfo)
+	var clusterOrder []int64
+
+	for _, t := range tables {
+		query := fmt.Sprintf(`
+			SELECT c.id, c.cluster_name, c.created_at, COUNT(qr.id) as total_metrics
+			FROM clusters c
+			LEFT JOIN %s qr ON c.id = qr.cluster_id
+		`, t.TableName)
+		args := []interface{}{}
+
+		if clusterName != "" {
+			query += " WHERE c.cluster_name = $1"
+			args = append(args, clusterName)
+		}
+		query += " GROUP BY c.id, c.cluster_name, c.created_at"
+
+		if _, ok := dbImpl.(*database.SQLiteDB); ok {
+			query = convertPostgresToSQLitePlaceholders(query)
+		}
+
+		rows, err := db.Query(query, args...)
 		if err != nil {
 			return nil, err
 		}
-		clusters = append(clusters, c)
+
+		for rows.Next() {
+			var c ClusterInfo
+			if err := rows.Scan(&c.ID, &c.Name, &c.CreatedAt, &c.TotalMetrics); err != nil {
+				_ = rows.Close()
+				return nil, err
+			}
+			if existing, ok := clusterMap[c.ID]; ok {
+				existing.TotalMetrics += c.TotalMetrics
+			} else {
+				clusterMap[c.ID] = &c
+				clusterOrder = append(clusterOrder, c.ID)
+			}
+		}
+		_ = rows.Close()
+		if err := rows.Err(); err != nil {
+			return nil, err
+		}
 	}
 
-	return clusters, rows.Err()
+	clusters := make([]ClusterInfo, 0, len(clusterOrder))
+	for _, id := range clusterOrder {
+		clusters = append(clusters, *clusterMap[id])
+	}
+	return clusters, nil
 }
 
 type ErrorInfo struct {
@@ -491,17 +589,16 @@ func listErrors(db *sql.DB) ([]ErrorInfo, error) {
 	return errors, rows.Err()
 }
 
-// convertToKPIRecords converts internal KPIResult to output.KPIRecord
 func convertToKPIRecords(results []KPIResult) []output.KPIRecord {
 	records := make([]output.KPIRecord, len(results))
 	for i, r := range results {
-		// Parse labels JSON into map
 		var labels map[string]string
 		_ = json.Unmarshal([]byte(r.MetricLabels), &labels)
 
 		records[i] = output.KPIRecord{
 			ID:            r.ID,
 			KPIName:       r.KPIName,
+			Category:      r.Category,
 			Cluster:       r.ClusterName,
 			Value:         r.MetricValue,
 			Timestamp:     r.TimestampValue,

--- a/internal/commands/kpis_generate.go
+++ b/internal/commands/kpis_generate.go
@@ -34,10 +34,11 @@ var profiles = map[string]profile{
 }
 
 var kpisGenerateFlags struct {
-	profile   string
-	file      string
-	all       bool
-	overwrite bool
+	profile       string
+	file          string
+	all           bool
+	overwrite     bool
+	uncategorized bool
 }
 
 var kpisGenerateCmd = &cobra.Command{
@@ -48,7 +49,11 @@ var kpisGenerateCmd = &cobra.Command{
 Supported profiles: ran, core, hub
 
 In interactive mode (default), you will be prompted to select which KPI
-categories to include. Use --all to include all categories without prompts.`,
+categories to include. Use --all to include all categories without prompts.
+
+By default, each KPI includes a category field that routes metrics into
+per-category database tables for better query performance. Use --uncategorized
+to omit category fields and store all metrics in a single table.`,
 	Example: `  # Generate all RAN KPIs
   kpi-collector kpis generate --profile ran --all
 
@@ -56,7 +61,10 @@ categories to include. Use --all to include all categories without prompts.`,
   kpi-collector kpis generate --profile core -f core-kpis.yaml
 
   # Generate Hub KPIs to a custom path
-  kpi-collector kpis generate --profile hub --all -f /path/to/hub-kpis.yaml`,
+  kpi-collector kpis generate --profile hub --all -f /path/to/hub-kpis.yaml
+
+  # Generate without category fields (single-table storage)
+  kpi-collector kpis generate --profile ran --all --uncategorized`,
 	Args: cobra.NoArgs,
 	RunE: runKpisGenerate,
 }
@@ -72,6 +80,8 @@ func init() {
 		"include all KPI categories without prompts")
 	kpisGenerateCmd.Flags().BoolVar(&kpisGenerateFlags.overwrite, "overwrite", false,
 		"overwrite the output file if it already exists")
+	kpisGenerateCmd.Flags().BoolVar(&kpisGenerateFlags.uncategorized, "uncategorized", false,
+		"generate KPIs without category fields (all data stored in a single table)")
 
 	_ = kpisGenerateCmd.MarkFlagRequired("profile")
 }
@@ -104,6 +114,10 @@ func runKpisGenerate(_ *cobra.Command, _ []string) error {
 	if len(queries) == 0 {
 		fmt.Println("No KPI categories selected. No file generated.")
 		return nil
+	}
+
+	if kpisGenerateFlags.uncategorized {
+		queries = stripCategories(queries)
 	}
 
 	return writeKPIsFile(filePath, queries)
@@ -174,6 +188,15 @@ func writeKPIsFile(filePath string, queries []config.Query) error {
 	fmt.Println("  query-type        instant (default) or range for time-window queries")
 	fmt.Println("  range             Required when query-type is range (nested: step, since, until)")
 	return nil
+}
+
+func stripCategories(queries []config.Query) []config.Query {
+	stripped := make([]config.Query, len(queries))
+	copy(stripped, queries)
+	for i := range stripped {
+		stripped[i].Category = ""
+	}
+	return stripped
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/commands/run.go
+++ b/internal/commands/run.go
@@ -1,10 +1,12 @@
 package commands
 
 import (
+	"bufio"
 	"fmt"
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/redhat-best-practices-for-k8s/kpi-collection-tool/internal/collector"
@@ -95,6 +97,10 @@ func init() {
 	runCmd.Flags().BoolVar(&flags.SingleRun, "once", false,
 		"collect all KPI metrics once and exit (ignores --frequency and --duration)")
 
+	// Skip interactive prompts
+	runCmd.Flags().BoolVarP(&flags.SkipPrompts, "yes", "y", false,
+		"skip interactive prompts (e.g. category advisory)")
+
 	// Mark required flags
 	if err := runCmd.MarkFlagRequired("cluster-name"); err != nil {
 		panic(fmt.Sprintf("failed to mark cluster-name as required: %v", err))
@@ -156,6 +162,12 @@ func runCollect(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("found %d KPI validation error(s)", len(validationErrors))
 	}
 	fmt.Printf("✓ Validated %d KPI(s)\n", len(kpis.Queries))
+
+	if !flags.SkipPrompts {
+		if abort := promptIfManyUncategorized(kpis); abort {
+			return fmt.Errorf("aborted by user")
+		}
+	}
 
 	kpis, err = substituteCPUsIfNeeded(kpis, flags)
 	if err != nil {
@@ -288,6 +300,36 @@ func validateRangeFrequency(kpis config.KPIs, flags config.InputFlags) error {
 	}
 
 	return nil
+}
+
+const uncategorizedThreshold = 15
+
+// promptIfManyUncategorized asks the user for confirmation when 15+ KPIs
+// have no category set. Returns true if the user chose to abort.
+func promptIfManyUncategorized(kpis config.KPIs) bool {
+	uncategorized := 0
+	for _, q := range kpis.Queries {
+		if q.Category == "" {
+			uncategorized++
+		}
+	}
+
+	if uncategorized < uncategorizedThreshold {
+		return false
+	}
+
+	fmt.Fprintf(os.Stderr,
+		"\n⚠  %d KPIs detected without categories.\n"+
+			"   Without categories, all data is stored in a single table which\n"+
+			"   degrades query performance at scale.\n\n"+
+			"   Proceed anyway? [y/N] ",
+		uncategorized)
+
+	reader := bufio.NewReader(os.Stdin)
+	answer, _ := reader.ReadString('\n')
+	answer = strings.TrimSpace(strings.ToLower(answer))
+
+	return answer != "y" && answer != "yes"
 }
 
 // warnFrequencyExceedsDuration prints a warning if any KPI's sampling frequency

--- a/internal/config/kpis_loader.go
+++ b/internal/config/kpis_loader.go
@@ -3,12 +3,17 @@ package config
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 
 	"github.com/prometheus/prometheus/promql/parser"
 	"gopkg.in/yaml.v3"
 )
+
+const maxCategoryLength = 32
+
+var categoryCleanRE = regexp.MustCompile(`[^a-z0-9_]`)
 
 // LoadKPIs loads Prometheus queries from a YAML kpis file
 func LoadKPIs(filepath string) (KPIs, error) {
@@ -55,6 +60,7 @@ func ValidateKPIs(kpis KPIs) []error {
 			errors = append(errors, fmt.Errorf("KPI '%s': invalid PromQL syntax - %w", kpi.ID, err))
 		}
 
+		errors = append(errors, validateCategory(kpi)...)
 		errors = append(errors, validateQueryType(kpi)...)
 	}
 
@@ -141,6 +147,41 @@ func validateRangeWindow(kpi Query) []error {
 func validateTimeRefPositive(kpiID, field string, timeRef *TimeRef) error {
 	if timeRef.IsDuration() && timeRef.DurationValue() <= 0 {
 		return fmt.Errorf("KPI '%s': range.%s must be > 0 when specified as a duration", kpiID, field)
+	}
+
+	return nil
+}
+
+// SanitizeCategory normalises a user-supplied category string into a safe,
+// lowercase, underscore-separated identifier suitable for use as a SQL table
+// name suffix. Returns an error if the sanitised result exceeds 32 characters
+// or is empty.
+func SanitizeCategory(raw string) (string, error) {
+	s := strings.ToLower(strings.TrimSpace(raw))
+	s = strings.ReplaceAll(s, " ", "_")
+	s = strings.ReplaceAll(s, "-", "_")
+	s = categoryCleanRE.ReplaceAllString(s, "")
+	s = strings.Trim(s, "_")
+
+	if s == "" {
+		return "", fmt.Errorf("category %q is empty after sanitisation", raw)
+	}
+
+	if len(s) > maxCategoryLength {
+		return "", fmt.Errorf("category %q exceeds %d characters after sanitisation (%d chars: %q)",
+			raw, maxCategoryLength, len(s), s)
+	}
+
+	return s, nil
+}
+
+func validateCategory(kpi Query) []error {
+	if kpi.Category == "" {
+		return nil
+	}
+
+	if _, err := SanitizeCategory(kpi.Category); err != nil {
+		return []error{fmt.Errorf("KPI '%s': %w", kpi.ID, err)}
 	}
 
 	return nil

--- a/internal/config/kpis_loader.go
+++ b/internal/config/kpis_loader.go
@@ -36,7 +36,9 @@ func ValidateKPIs(kpis KPIs) []error {
 	var errors []error
 	seenIDs := make(map[string]bool)
 
-	for _, kpi := range kpis.Queries {
+	for i := range kpis.Queries {
+		kpi := &kpis.Queries[i]
+
 		// Check for empty KPI ID
 		if strings.TrimSpace(kpi.ID) == "" {
 			errors = append(errors, fmt.Errorf("KPI has empty ID"))
@@ -61,7 +63,7 @@ func ValidateKPIs(kpis KPIs) []error {
 		}
 
 		errors = append(errors, validateCategory(kpi)...)
-		errors = append(errors, validateQueryType(kpi)...)
+		errors = append(errors, validateQueryType(*kpi)...)
 	}
 
 	return errors
@@ -175,12 +177,13 @@ func SanitizeCategory(raw string) (string, error) {
 	return s, nil
 }
 
-func validateCategory(kpi Query) []error {
+func validateCategory(kpi *Query) []error {
 	if kpi.Category == "" {
 		return nil
 	}
 
-	if _, err := SanitizeCategory(kpi.Category); err != nil {
+	var err error
+	if kpi.Category, err = SanitizeCategory(kpi.Category); err != nil {
 		return []error{fmt.Errorf("KPI '%s': %w", kpi.ID, err)}
 	}
 

--- a/internal/config/kpis_loader_test.go
+++ b/internal/config/kpis_loader_test.go
@@ -1036,6 +1036,17 @@ var _ = Describe("KPIs Loader", func() {
 			Expect(errors[0].Error()).To(ContainSubstring("bad-cat"))
 			Expect(errors[0].Error()).To(ContainSubstring("empty after sanitisation"))
 		})
+
+		It("should sanitize category with hyphens", func() {
+			kpis := KPIs{
+				Queries: []Query{
+					{ID: "test", PromQuery: "up", Category: "node-cpu"},
+				},
+			}
+			errors := ValidateKPIs(kpis)
+			Expect(errors).To(BeEmpty())
+			Expect(kpis.Queries[0].Category).To(Equal("node_cpu"))
+		})
 	})
 
 	Describe("validateTimestampPositive", func() {

--- a/internal/config/kpis_loader_test.go
+++ b/internal/config/kpis_loader_test.go
@@ -119,6 +119,26 @@ var _ = Describe("KPIs Loader", func() {
 				Expect(kpis.Queries).To(BeEmpty())
 			})
 
+			It("should load KPIs with category field", func() {
+				kpisYAML := `kpis:
+  - id: node-cpu
+    promquery: avg(rate(node_cpu_seconds_total[5m]))
+    category: cpu
+  - id: cluster-up
+    promquery: up
+`
+				kpisPath := filepath.Join(tmpDir, "kpis-cat.yaml")
+				err := os.WriteFile(kpisPath, []byte(kpisYAML), 0644)
+				Expect(err).NotTo(HaveOccurred())
+
+				kpis, err := LoadKPIs(kpisPath)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(kpis.Queries).To(HaveLen(2))
+				Expect(kpis.Queries[0].Category).To(Equal("cpu"))
+				Expect(kpis.Queries[1].Category).To(BeEmpty())
+			})
+
 			It("should load PromQL queries with double quotes without escaping", func() {
 				kpisYAML := `kpis:
   - id: cpu-system-slice
@@ -940,6 +960,81 @@ var _ = Describe("KPIs Loader", func() {
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("failed to decode kpis file"))
 			})
+		})
+	})
+
+	Describe("SanitizeCategory", func() {
+		It("should lowercase and replace spaces/hyphens with underscores", func() {
+			result, err := SanitizeCategory("CPU Usage")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal("cpu_usage"))
+		})
+
+		It("should strip special characters", func() {
+			result, err := SanitizeCategory("mem@ory!!")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal("memory"))
+		})
+
+		It("should trim leading/trailing underscores", func() {
+			result, err := SanitizeCategory("_network_")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal("network"))
+		})
+
+		It("should return error for empty result after sanitisation", func() {
+			_, err := SanitizeCategory("@!#$")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("empty after sanitisation"))
+		})
+
+		It("should return error when exceeding 32 characters", func() {
+			long := "this_is_a_very_long_category_name_that_exceeds_limit"
+			_, err := SanitizeCategory(long)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("exceeds 32 characters"))
+		})
+
+		It("should accept exactly 32 characters", func() {
+			exact := "abcdefghijklmnopqrstuvwxyz012345"
+			Expect(len(exact)).To(Equal(32))
+			result, err := SanitizeCategory(exact)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(exact))
+		})
+	})
+
+	Describe("Category validation in ValidateKPIs", func() {
+		It("should accept KPIs with valid category", func() {
+			kpis := KPIs{
+				Queries: []Query{
+					{ID: "cpu-usage", PromQuery: "up", Category: "cpu"},
+				},
+			}
+			errors := ValidateKPIs(kpis)
+			Expect(errors).To(BeEmpty())
+		})
+
+		It("should accept KPIs without category", func() {
+			kpis := KPIs{
+				Queries: []Query{
+					{ID: "up-check", PromQuery: "up"},
+				},
+			}
+			errors := ValidateKPIs(kpis)
+			Expect(errors).To(BeEmpty())
+		})
+
+		It("should reject KPIs with invalid category", func() {
+			kpis := KPIs{
+				Queries: []Query{
+					{ID: "bad-cat", PromQuery: "up", Category: "@#$"},
+				},
+			}
+			errors := ValidateKPIs(kpis)
+			Expect(errors).To(HaveLen(1))
+			Expect(errors[0].Error()).To(ContainSubstring("bad-cat"))
+			Expect(errors[0].Error()).To(ContainSubstring("empty after sanitisation"))
 		})
 	})
 

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -139,6 +139,7 @@ type InputFlags struct {
 type Query struct {
 	ID              string       `yaml:"id"`
 	PromQuery       string       `yaml:"promquery"`
+	Category        string       `yaml:"category,omitempty"`
 	SampleFrequency *Duration    `yaml:"sample-frequency,omitempty"`
 	QueryType       string       `yaml:"query-type,omitempty"`
 	Range           *RangeWindow `yaml:"range,omitempty"`

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -133,6 +133,7 @@ type InputFlags struct {
 	PostgresURL  string // PostgreSQL connection string
 	KPIsFile     string
 	SingleRun    bool // collect metrics once and exit
+	SkipPrompts  bool // skip interactive prompts (--yes/-y)
 }
 
 // Query represents a single KPI query configuration

--- a/internal/database/db_interface_test.go
+++ b/internal/database/db_interface_test.go
@@ -186,7 +186,7 @@ func RunDatabaseInterfaceTests(getImpl func() (Database, *sql.DB)) {
 					},
 				}
 
-				err := dbImpl.StoreQueryResults(db, clusterID, "test-query-1", vector)
+				err := dbImpl.StoreQueryResults(db, clusterID, "test-query-1", "", vector)
 				Expect(err).NotTo(HaveOccurred())
 
 				var count int
@@ -223,7 +223,7 @@ func RunDatabaseInterfaceTests(getImpl func() (Database, *sql.DB)) {
 						Timestamp: model.Time(time.Now().Unix() * 1000),
 					},
 				}
-				err := dbImpl.StoreQueryResults(db, clusterID, "test-query-3", vector)
+				err := dbImpl.StoreQueryResults(db, clusterID, "test-query-3", "", vector)
 				Expect(err).NotTo(HaveOccurred())
 
 				var metricLabels string
@@ -244,7 +244,7 @@ func RunDatabaseInterfaceTests(getImpl func() (Database, *sql.DB)) {
 						Timestamp: model.Time(time.Now().Unix() * 1000),
 					},
 				}
-				err := dbImpl.StoreQueryResults(db, clusterID, "test-query-4", vector)
+				err := dbImpl.StoreQueryResults(db, clusterID, "test-query-4", "", vector)
 				Expect(err).NotTo(HaveOccurred())
 
 				var executionTime, createdAt string
@@ -279,7 +279,7 @@ func RunDatabaseInterfaceTests(getImpl func() (Database, *sql.DB)) {
 					},
 				}
 
-				err := dbImpl.StoreQueryResults(db, clusterID, "test-query-2", vector)
+				err := dbImpl.StoreQueryResults(db, clusterID, "test-query-2", "", vector)
 				Expect(err).NotTo(HaveOccurred())
 
 				var count int
@@ -315,10 +315,10 @@ func RunDatabaseInterfaceTests(getImpl func() (Database, *sql.DB)) {
 					},
 				}
 
-				err := dbImpl.StoreQueryResults(db, clusterID, "query-cluster-1", vector1)
+				err := dbImpl.StoreQueryResults(db, clusterID, "query-cluster-1", "", vector1)
 				Expect(err).NotTo(HaveOccurred())
 
-				err = dbImpl.StoreQueryResults(db, clusterID2, "query-cluster-2", vector2)
+				err = dbImpl.StoreQueryResults(db, clusterID2, "query-cluster-2", "", vector2)
 				Expect(err).NotTo(HaveOccurred())
 
 				var storedClusterID int64

--- a/internal/database/db_interface_test.go
+++ b/internal/database/db_interface_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/prometheus/common/model"
+	"github.com/redhat-best-practices-for-k8s/kpi-collection-tool/internal/config"
 )
 
 // RunDatabaseInterfaceTests runs the complete test suite for any Database implementation.
@@ -329,6 +330,203 @@ func RunDatabaseInterfaceTests(getImpl func() (Database, *sql.DB)) {
 				err = db.QueryRow("SELECT cluster_id FROM query_results WHERE kpi_id = $1", "query-cluster-2").Scan(&storedClusterID)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(storedClusterID).To(Equal(clusterID2))
+			})
+		})
+	})
+
+	Describe("Category Tables", func() {
+		var clusterID int64
+
+		BeforeEach(func() {
+			var err error
+			clusterID, err = dbImpl.GetOrCreateCluster(db, "cat-cluster", "ran")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		Describe("EnsureCategoryTable", func() {
+			It("should create a table and register the KPI", func() {
+				tableName, err := dbImpl.EnsureCategoryTable(db, "cpu", "node-cpu-usage")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(tableName).To(Equal("kpi_cpu"))
+
+				cat, tn, err := dbImpl.LookupCategoryForKPI(db, "node-cpu-usage")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cat).To(Equal("cpu"))
+				Expect(tn).To(Equal("kpi_cpu"))
+			})
+
+			It("should be idempotent for the same category", func() {
+				_, err := dbImpl.EnsureCategoryTable(db, "memory", "mem-usage-1")
+				Expect(err).NotTo(HaveOccurred())
+				_, err = dbImpl.EnsureCategoryTable(db, "memory", "mem-usage-2")
+				Expect(err).NotTo(HaveOccurred())
+
+				categories, err := dbImpl.ListCategories(db)
+				Expect(err).NotTo(HaveOccurred())
+				memCount := 0
+				for _, c := range categories {
+					if c.Category == "memory" {
+						memCount++
+						Expect(c.TableName).To(Equal("kpi_memory"))
+					}
+				}
+				Expect(memCount).To(Equal(1))
+			})
+		})
+
+		Describe("StoreQueryResults with category", func() {
+			It("should route categorised writes to the category table", func() {
+				vector := model.Vector{
+					&model.Sample{
+						Metric:    model.Metric{"__name__": "cpu_seconds"},
+						Value:     model.SampleValue(0.75),
+						Timestamp: model.Time(time.Now().Unix() * 1000),
+					},
+				}
+
+				err := dbImpl.StoreQueryResults(db, clusterID, "node-cpu", "cpu", vector)
+				Expect(err).NotTo(HaveOccurred())
+
+				var count int
+				err = db.QueryRow("SELECT COUNT(*) FROM kpi_cpu WHERE kpi_id = $1", "node-cpu").Scan(&count)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(count).To(Equal(1))
+
+				err = db.QueryRow("SELECT COUNT(*) FROM query_results WHERE kpi_id = $1", "node-cpu").Scan(&count)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(count).To(Equal(0))
+			})
+
+			It("should enforce dedup on category tables", func() {
+				ts := model.Time(time.Now().Unix() * 1000)
+				vector := model.Vector{
+					&model.Sample{
+						Metric:    model.Metric{"__name__": "mem_bytes"},
+						Value:     model.SampleValue(1024),
+						Timestamp: ts,
+					},
+				}
+
+				err := dbImpl.StoreQueryResults(db, clusterID, "mem-kpi", "memory", vector)
+				Expect(err).NotTo(HaveOccurred())
+				err = dbImpl.StoreQueryResults(db, clusterID, "mem-kpi", "memory", vector)
+				Expect(err).NotTo(HaveOccurred())
+
+				var count int
+				err = db.QueryRow("SELECT COUNT(*) FROM kpi_memory WHERE kpi_id = $1", "mem-kpi").Scan(&count)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(count).To(Equal(1))
+			})
+		})
+
+		Describe("ValidateCategoryConsistency", func() {
+			BeforeEach(func() {
+				_, err := dbImpl.EnsureCategoryTable(db, "cpu", "node-cpu")
+				Expect(err).NotTo(HaveOccurred())
+				_, err = dbImpl.EnsureCategoryTable(db, "memory", "mem-usage")
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should pass when categories match", func() {
+				kpis := []config.Query{
+					{ID: "node-cpu", Category: "cpu"},
+					{ID: "mem-usage", Category: "memory"},
+				}
+				err := dbImpl.ValidateCategoryConsistency(db, kpis)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should pass for new KPIs not yet in registry", func() {
+				kpis := []config.Query{
+					{ID: "node-cpu", Category: "cpu"},
+					{ID: "brand-new-kpi", Category: "network"},
+				}
+				err := dbImpl.ValidateCategoryConsistency(db, kpis)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should error when a KPI changes category", func() {
+				kpis := []config.Query{
+					{ID: "node-cpu", Category: "networking"},
+				}
+				err := dbImpl.ValidateCategoryConsistency(db, kpis)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("node-cpu"))
+			})
+
+			It("should error when a categorised KPI becomes uncategorised", func() {
+				kpis := []config.Query{
+					{ID: "node-cpu", Category: ""},
+				}
+				err := dbImpl.ValidateCategoryConsistency(db, kpis)
+				Expect(err).To(HaveOccurred())
+			})
+		})
+
+		Describe("ListCategories", func() {
+			It("should return empty list when no categories exist", func() {
+				categories, err := dbImpl.ListCategories(db)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(categories).To(BeEmpty())
+			})
+
+			It("should return all distinct categories", func() {
+				_, err := dbImpl.EnsureCategoryTable(db, "cpu", "node-cpu")
+				Expect(err).NotTo(HaveOccurred())
+				_, err = dbImpl.EnsureCategoryTable(db, "cpu", "container-cpu")
+				Expect(err).NotTo(HaveOccurred())
+				_, err = dbImpl.EnsureCategoryTable(db, "memory", "mem-usage")
+				Expect(err).NotTo(HaveOccurred())
+
+				categories, err := dbImpl.ListCategories(db)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(categories).To(HaveLen(2))
+			})
+		})
+
+		Describe("LookupCategoryForKPI", func() {
+			It("should return empty strings for an unregistered KPI", func() {
+				cat, table, err := dbImpl.LookupCategoryForKPI(db, "unknown-kpi")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cat).To(BeEmpty())
+				Expect(table).To(BeEmpty())
+			})
+
+			It("should return category and table for a registered KPI", func() {
+				_, err := dbImpl.EnsureCategoryTable(db, "cpu", "node-cpu")
+				Expect(err).NotTo(HaveOccurred())
+
+				cat, table, err := dbImpl.LookupCategoryForKPI(db, "node-cpu")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cat).To(Equal("cpu"))
+				Expect(table).To(Equal("kpi_cpu"))
+			})
+		})
+
+		Describe("DeleteByCategory", func() {
+			It("should delete all rows from the category table and clean registry", func() {
+				vector := model.Vector{
+					&model.Sample{
+						Metric:    model.Metric{"__name__": "cpu_usage"},
+						Value:     model.SampleValue(0.5),
+						Timestamp: model.Time(time.Now().Unix() * 1000),
+					},
+				}
+				err := dbImpl.StoreQueryResults(db, clusterID, "cpu-kpi", "cpu", vector)
+				Expect(err).NotTo(HaveOccurred())
+
+				deleted, err := dbImpl.DeleteByCategory(db, "cpu")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(deleted).To(Equal(int64(1)))
+
+				var count int
+				err = db.QueryRow("SELECT COUNT(*) FROM kpi_cpu").Scan(&count)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(count).To(Equal(0))
+
+				err = db.QueryRow("SELECT COUNT(*) FROM kpi_registry WHERE category = $1", "cpu").Scan(&count)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(count).To(Equal(0))
 			})
 		})
 	})

--- a/internal/database/db_interface_test.go
+++ b/internal/database/db_interface_test.go
@@ -470,7 +470,7 @@ func RunDatabaseInterfaceTests(getImpl func() (Database, *sql.DB)) {
 				Expect(categories).To(BeEmpty())
 			})
 
-			It("should return all distinct categories", func() {
+			It("should return all distinct categories with KPI counts", func() {
 				_, err := dbImpl.EnsureCategoryTable(db, "cpu", "node-cpu")
 				Expect(err).NotTo(HaveOccurred())
 				_, err = dbImpl.EnsureCategoryTable(db, "cpu", "container-cpu")
@@ -481,6 +481,13 @@ func RunDatabaseInterfaceTests(getImpl func() (Database, *sql.DB)) {
 				categories, err := dbImpl.ListCategories(db)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(categories).To(HaveLen(2))
+
+				cpuIdx, memIdx := 0, 1
+				if categories[0].Category == "memory" {
+					cpuIdx, memIdx = 1, 0
+				}
+				Expect(categories[cpuIdx].KPICount).To(Equal(2))
+				Expect(categories[memIdx].KPICount).To(Equal(1))
 			})
 		})
 

--- a/internal/database/interface.go
+++ b/internal/database/interface.go
@@ -11,6 +11,12 @@ import (
 	"github.com/redhat-best-practices-for-k8s/kpi-collection-tool/internal/config"
 )
 
+// CategoryInfo holds metadata about a registered category.
+type CategoryInfo struct {
+	Category  string
+	TableName string
+}
+
 // Database defines the interface that all database implementations must satisfy
 type Database interface {
 	// InitDB initializes the database and creates required tables
@@ -39,4 +45,15 @@ type Database interface {
 	// changed its category compared to what is already stored in kpi_registry.
 	// Must be called after InitDB and before any collection begins.
 	ValidateCategoryConsistency(db *sql.DB, kpis []config.Query) error
+
+	// ListCategories returns all distinct categories from kpi_registry.
+	ListCategories(db *sql.DB) ([]CategoryInfo, error)
+
+	// LookupCategoryForKPI returns the category and table name for a given KPI ID.
+	// Returns empty strings if the KPI is not in the registry (uncategorized).
+	LookupCategoryForKPI(db *sql.DB, kpiID string) (category string, tableName string, err error)
+
+	// DeleteByCategory removes all metric rows from the given category table.
+	// Also removes the corresponding kpi_registry entries.
+	DeleteByCategory(db *sql.DB, category string) (int64, error)
 }

--- a/internal/database/interface.go
+++ b/internal/database/interface.go
@@ -25,6 +25,12 @@ type Database interface {
 	GetQueryErrorCount(db *sql.DB, kpiID string) (int, error)
 
 	// StoreQueryResults stores the results of a Prometheus query in the database.
+	// When category is non-empty, data is written to a category-specific table
+	// (e.g. kpi_cpu); otherwise it goes to the default query_results table.
 	// Supports model.Vector (from instant queries) and model.Matrix (from range queries).
-	StoreQueryResults(db *sql.DB, clusterID int64, queryID string, result model.Value) error
+	StoreQueryResults(db *sql.DB, clusterID int64, queryID string, category string, result model.Value) error
+
+	// EnsureCategoryTable creates the per-category table and dedup index if they
+	// don't already exist, and registers the KPI→category mapping in kpi_registry.
+	EnsureCategoryTable(db *sql.DB, category string, kpiID string) (string, error)
 }

--- a/internal/database/interface.go
+++ b/internal/database/interface.go
@@ -8,6 +8,7 @@ import (
 	"database/sql"
 
 	"github.com/prometheus/common/model"
+	"github.com/redhat-best-practices-for-k8s/kpi-collection-tool/internal/config"
 )
 
 // Database defines the interface that all database implementations must satisfy
@@ -33,4 +34,9 @@ type Database interface {
 	// EnsureCategoryTable creates the per-category table and dedup index if they
 	// don't already exist, and registers the KPI→category mapping in kpi_registry.
 	EnsureCategoryTable(db *sql.DB, category string, kpiID string) (string, error)
+
+	// ValidateCategoryConsistency checks that no KPI in the incoming config has
+	// changed its category compared to what is already stored in kpi_registry.
+	// Must be called after InitDB and before any collection begins.
+	ValidateCategoryConsistency(db *sql.DB, kpis []config.Query) error
 }

--- a/internal/database/interface.go
+++ b/internal/database/interface.go
@@ -15,6 +15,7 @@ import (
 type CategoryInfo struct {
 	Category  string
 	TableName string
+	KPICount  int
 }
 
 // Database defines the interface that all database implementations must satisfy

--- a/internal/database/postgres.go
+++ b/internal/database/postgres.go
@@ -40,17 +40,6 @@ func (p *PostgresDB) InitDB() (*sql.DB, error) {
 		return nil, fmt.Errorf("creating PostgreSQL schema: %w", err)
 	}
 
-	if _, err = db.Exec(`
-		CREATE TABLE IF NOT EXISTS kpi_registry (
-			kpi_id TEXT PRIMARY KEY,
-			category TEXT NOT NULL,
-			table_name TEXT NOT NULL,
-			created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-		)`); err != nil {
-		_ = db.Close()
-		return nil, fmt.Errorf("creating kpi_registry table: %w", err)
-	}
-
 	return db, nil
 }
 
@@ -96,20 +85,7 @@ func (p *PostgresDB) EnsureCategoryTable(db *sql.DB, category, kpiID string) (st
 	tableName := CategoryTableName(category)
 
 	if _, ok := p.knownTables.Load(tableName); !ok {
-		ddl := fmt.Sprintf(`
-			CREATE TABLE IF NOT EXISTS %s (
-				id SERIAL PRIMARY KEY,
-				kpi_id TEXT NOT NULL,
-				metric_value DOUBLE PRECISION,
-				timestamp_value DOUBLE PRECISION,
-				cluster_id INTEGER NOT NULL REFERENCES clusters(id),
-				execution_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-				created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-				metric_labels JSONB
-			);
-			CREATE UNIQUE INDEX IF NOT EXISTS idx_%s_dedup
-			ON %s(kpi_id, cluster_id, timestamp_value, metric_labels)`,
-			tableName, tableName, tableName)
+		ddl := fmt.Sprintf(schema.PostgresCategoryTableFmt, tableName, tableName, tableName)
 
 		if _, err := db.Exec(ddl); err != nil {
 			return "", fmt.Errorf("create table %s: %w", tableName, err)
@@ -118,10 +94,7 @@ func (p *PostgresDB) EnsureCategoryTable(db *sql.DB, category, kpiID string) (st
 		p.knownTables.Store(tableName, true)
 	}
 
-	_, err := db.Exec(`
-		INSERT INTO kpi_registry (kpi_id, category, table_name) VALUES ($1, $2, $3)
-		ON CONFLICT(kpi_id) DO NOTHING`,
-		kpiID, category, tableName)
+	_, err := db.Exec(schema.PostgresUpsertRegistry, kpiID, category, tableName)
 	if err != nil {
 		return "", fmt.Errorf("register kpi '%s' in kpi_registry: %w", kpiID, err)
 	}
@@ -132,7 +105,7 @@ func (p *PostgresDB) EnsureCategoryTable(db *sql.DB, category, kpiID string) (st
 // ValidateCategoryConsistency checks that no KPI in the incoming config has
 // changed its category compared to what is already stored in kpi_registry.
 func (p *PostgresDB) ValidateCategoryConsistency(db *sql.DB, kpis []config.Query) error {
-	rows, err := db.Query("SELECT kpi_id, category FROM kpi_registry")
+	rows, err := db.Query(schema.PostgresSelectRegistryAll)
 	if err != nil {
 		return fmt.Errorf("query kpi_registry: %w", err)
 	}
@@ -169,11 +142,7 @@ func (p *PostgresDB) ValidateCategoryConsistency(db *sql.DB, kpis []config.Query
 // ListCategories returns all distinct categories registered in kpi_registry,
 // along with the number of KPIs in each category.
 func (p *PostgresDB) ListCategories(db *sql.DB) ([]CategoryInfo, error) {
-	rows, err := db.Query(`
-		SELECT category, table_name, COUNT(*) as kpi_count
-		FROM kpi_registry
-		GROUP BY category, table_name
-		ORDER BY category`)
+	rows, err := db.Query(schema.PostgresSelectRegistryCategories)
 	if err != nil {
 		return nil, fmt.Errorf("query kpi_registry: %w", err)
 	}
@@ -194,8 +163,7 @@ func (p *PostgresDB) ListCategories(db *sql.DB) ([]CategoryInfo, error) {
 // LookupCategoryForKPI returns the category and table name for a KPI ID.
 // Returns empty strings when the KPI has no registry entry (uncategorized).
 func (p *PostgresDB) LookupCategoryForKPI(db *sql.DB, kpiID string) (category, tableName string, err error) {
-	err = db.QueryRow("SELECT category, table_name FROM kpi_registry WHERE kpi_id = $1", kpiID).
-		Scan(&category, &tableName)
+	err = db.QueryRow(schema.PostgresSelectRegistryByKPI, kpiID).Scan(&category, &tableName)
 
 	if err == sql.ErrNoRows {
 		return "", "", nil
@@ -218,7 +186,7 @@ func (p *PostgresDB) DeleteByCategory(db *sql.DB, category string) (int64, error
 	}
 	deleted, _ := result.RowsAffected()
 
-	_, err = db.Exec("DELETE FROM kpi_registry WHERE category = $1", category)
+	_, err = db.Exec(schema.PostgresDeleteRegistryByCategory, category)
 	if err != nil {
 		return deleted, fmt.Errorf("clean kpi_registry for category '%s': %w", category, err)
 	}
@@ -249,10 +217,7 @@ func (p *PostgresDB) StoreQueryResults(db *sql.DB, clusterID int64, queryID, cat
 }
 
 func (p *PostgresDB) storeVectorResults(db *sql.DB, clusterID int64, queryID, table string, vector model.Vector) error {
-	insertSQL := fmt.Sprintf(`INSERT INTO %s
-		(kpi_id, metric_value, timestamp_value, cluster_id, metric_labels)
-		VALUES ($1, $2, $3, $4, $5)
-		ON CONFLICT (kpi_id, cluster_id, timestamp_value, metric_labels) DO NOTHING`, table)
+	insertSQL := fmt.Sprintf(schema.PostgresInsertResultFmt, table)
 
 	for _, sample := range vector {
 		labelsJSON, err := json.Marshal(sample.Metric)
@@ -271,10 +236,7 @@ func (p *PostgresDB) storeVectorResults(db *sql.DB, clusterID int64, queryID, ta
 }
 
 func (p *PostgresDB) storeMatrixResults(db *sql.DB, clusterID int64, queryID, table string, matrix model.Matrix) error {
-	insertSQL := fmt.Sprintf(`INSERT INTO %s
-		(kpi_id, metric_value, timestamp_value, cluster_id, metric_labels)
-		VALUES ($1, $2, $3, $4, $5)
-		ON CONFLICT (kpi_id, cluster_id, timestamp_value, metric_labels) DO NOTHING`, table)
+	insertSQL := fmt.Sprintf(schema.PostgresInsertResultFmt, table)
 
 	for _, stream := range matrix {
 		labelsJSON, err := json.Marshal(stream.Metric)

--- a/internal/database/postgres.go
+++ b/internal/database/postgres.go
@@ -8,6 +8,7 @@ import (
 	_ "github.com/lib/pq"
 	"github.com/prometheus/common/model"
 
+	"github.com/redhat-best-practices-for-k8s/kpi-collection-tool/internal/config"
 	"github.com/redhat-best-practices-for-k8s/kpi-collection-tool/internal/database/schema"
 )
 
@@ -80,6 +81,13 @@ func (p *PostgresDB) GetQueryErrorCount(db *sql.DB, kpiID string) (int, error) {
 // --- TODO ---
 func (p *PostgresDB) EnsureCategoryTable(_ *sql.DB, _ string, _ string) (string, error) {
 	return "query_results", nil
+}
+
+// ValidateCategoryConsistency is a no-op stub for PostgreSQL until category
+// table support is implemented.
+// --- TODO ---
+func (p *PostgresDB) ValidateCategoryConsistency(_ *sql.DB, _ []config.Query) error {
+	return nil
 }
 
 // StoreQueryResults stores the results of a Prometheus query in the database.

--- a/internal/database/postgres.go
+++ b/internal/database/postgres.go
@@ -80,7 +80,7 @@ func (p *PostgresDB) GetQueryErrorCount(db *sql.DB, kpiID string) (int, error) {
 // will be implemented in a future PR; all writes go to query_results for now.
 // --- TODO ---
 func (p *PostgresDB) EnsureCategoryTable(_ *sql.DB, _ string, _ string) (string, error) {
-	return "query_results", nil
+	return DefaultTableName, nil
 }
 
 // ValidateCategoryConsistency is a no-op stub for PostgreSQL until category
@@ -88,6 +88,24 @@ func (p *PostgresDB) EnsureCategoryTable(_ *sql.DB, _ string, _ string) (string,
 // --- TODO ---
 func (p *PostgresDB) ValidateCategoryConsistency(_ *sql.DB, _ []config.Query) error {
 	return nil
+}
+
+// ListCategories is a no-op stub for PostgreSQL until category support is implemented.
+// --- TODO ---
+func (p *PostgresDB) ListCategories(_ *sql.DB) ([]CategoryInfo, error) {
+	return nil, nil
+}
+
+// LookupCategoryForKPI is a no-op stub for PostgreSQL until category support is implemented.
+// --- TODO ---
+func (p *PostgresDB) LookupCategoryForKPI(_ *sql.DB, _ string) (string, string, error) {
+	return "", "", nil
+}
+
+// DeleteByCategory is a no-op stub for PostgreSQL until category support is implemented.
+// --- TODO ---
+func (p *PostgresDB) DeleteByCategory(_ *sql.DB, _ string) (int64, error) {
+	return 0, nil
 }
 
 // StoreQueryResults stores the results of a Prometheus query in the database.

--- a/internal/database/postgres.go
+++ b/internal/database/postgres.go
@@ -75,8 +75,18 @@ func (p *PostgresDB) GetQueryErrorCount(db *sql.DB, kpiID string) (int, error) {
 	return count, err
 }
 
-// StoreQueryResults stores the results of a Prometheus query in the database
-func (p *PostgresDB) StoreQueryResults(db *sql.DB, clusterID int64, queryID string, result model.Value) error {
+// EnsureCategoryTable is a no-op stub for PostgreSQL. Category table support
+// will be implemented in a future PR; all writes go to query_results for now.
+// --- TODO ---
+func (p *PostgresDB) EnsureCategoryTable(_ *sql.DB, _ string, _ string) (string, error) {
+	return "query_results", nil
+}
+
+// StoreQueryResults stores the results of a Prometheus query in the database.
+// The category parameter is accepted for interface compatibility but ignored —
+// all data is written to the default query_results table until PostgreSQL
+// category support is implemented.
+func (p *PostgresDB) StoreQueryResults(db *sql.DB, clusterID int64, queryID string, _ string, result model.Value) error {
 	switch values := result.(type) {
 	case model.Vector:
 		return p.storeVectorResults(db, clusterID, queryID, values)

--- a/internal/database/postgres.go
+++ b/internal/database/postgres.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"sync"
 
 	_ "github.com/lib/pq"
 	"github.com/prometheus/common/model"
@@ -15,6 +16,7 @@ import (
 // PostgresDB implements the Database interface for PostgreSQL
 type PostgresDB struct {
 	ConnectionURL string
+	knownTables   sync.Map
 }
 
 // NewPostgresDB creates a new PostgreSQL database instance
@@ -36,6 +38,17 @@ func (p *PostgresDB) InitDB() (*sql.DB, error) {
 	if _, err = db.Exec(schema.PostgresSchema); err != nil {
 		_ = db.Close()
 		return nil, fmt.Errorf("creating PostgreSQL schema: %w", err)
+	}
+
+	if _, err = db.Exec(`
+		CREATE TABLE IF NOT EXISTS kpi_registry (
+			kpi_id TEXT PRIMARY KEY,
+			category TEXT NOT NULL,
+			table_name TEXT NOT NULL,
+			created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+		)`); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("creating kpi_registry table: %w", err)
 	}
 
 	return db, nil
@@ -76,61 +89,173 @@ func (p *PostgresDB) GetQueryErrorCount(db *sql.DB, kpiID string) (int, error) {
 	return count, err
 }
 
-// EnsureCategoryTable is a no-op stub for PostgreSQL. Category table support
-// will be implemented in a future PR; all writes go to query_results for now.
-// --- TODO ---
-func (p *PostgresDB) EnsureCategoryTable(_ *sql.DB, _ string, _ string) (string, error) {
-	return DefaultTableName, nil
+// EnsureCategoryTable lazily creates the per-category table and registers the
+// KPI->category mapping. The DDL is idempotent and only executed once per
+// process lifetime thanks to the in-memory knownTables cache.
+func (p *PostgresDB) EnsureCategoryTable(db *sql.DB, category, kpiID string) (string, error) {
+	tableName := CategoryTableName(category)
+
+	if _, ok := p.knownTables.Load(tableName); !ok {
+		ddl := fmt.Sprintf(`
+			CREATE TABLE IF NOT EXISTS %s (
+				id SERIAL PRIMARY KEY,
+				kpi_id TEXT NOT NULL,
+				metric_value DOUBLE PRECISION,
+				timestamp_value DOUBLE PRECISION,
+				cluster_id INTEGER NOT NULL REFERENCES clusters(id),
+				execution_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+				created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+				metric_labels JSONB
+			);
+			CREATE UNIQUE INDEX IF NOT EXISTS idx_%s_dedup
+			ON %s(kpi_id, cluster_id, timestamp_value, metric_labels)`,
+			tableName, tableName, tableName)
+
+		if _, err := db.Exec(ddl); err != nil {
+			return "", fmt.Errorf("create table %s: %w", tableName, err)
+		}
+
+		p.knownTables.Store(tableName, true)
+	}
+
+	_, err := db.Exec(`
+		INSERT INTO kpi_registry (kpi_id, category, table_name) VALUES ($1, $2, $3)
+		ON CONFLICT(kpi_id) DO NOTHING`,
+		kpiID, category, tableName)
+	if err != nil {
+		return "", fmt.Errorf("register kpi '%s' in kpi_registry: %w", kpiID, err)
+	}
+
+	return tableName, nil
 }
 
-// ValidateCategoryConsistency is a no-op stub for PostgreSQL until category
-// table support is implemented.
-// --- TODO ---
-func (p *PostgresDB) ValidateCategoryConsistency(_ *sql.DB, _ []config.Query) error {
+// ValidateCategoryConsistency checks that no KPI in the incoming config has
+// changed its category compared to what is already stored in kpi_registry.
+func (p *PostgresDB) ValidateCategoryConsistency(db *sql.DB, kpis []config.Query) error {
+	rows, err := db.Query("SELECT kpi_id, category FROM kpi_registry")
+	if err != nil {
+		return fmt.Errorf("query kpi_registry: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	registered := make(map[string]string)
+	for rows.Next() {
+		var kpiID, category string
+		if err := rows.Scan(&kpiID, &category); err != nil {
+			return fmt.Errorf("scan kpi_registry row: %w", err)
+		}
+		registered[kpiID] = category
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate kpi_registry: %w", err)
+	}
+
+	for i := range kpis {
+		prev, exists := registered[kpis[i].ID]
+		if !exists {
+			continue
+		}
+		if prev != kpis[i].Category {
+			return fmt.Errorf(
+				"KPI '%s' category changed from %q to %q — "+
+					"use a different database or delete the existing one",
+				kpis[i].ID, prev, kpis[i].Category)
+		}
+	}
+
 	return nil
 }
 
-// ListCategories is a no-op stub for PostgreSQL until category support is implemented.
-// --- TODO ---
-func (p *PostgresDB) ListCategories(_ *sql.DB) ([]CategoryInfo, error) {
-	return nil, nil
+// ListCategories returns all distinct categories registered in kpi_registry.
+func (p *PostgresDB) ListCategories(db *sql.DB) ([]CategoryInfo, error) {
+	rows, err := db.Query("SELECT DISTINCT category, table_name FROM kpi_registry ORDER BY category")
+	if err != nil {
+		return nil, fmt.Errorf("query kpi_registry: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var categories []CategoryInfo
+	for rows.Next() {
+		var ci CategoryInfo
+		if err := rows.Scan(&ci.Category, &ci.TableName); err != nil {
+			return nil, fmt.Errorf("scan kpi_registry row: %w", err)
+		}
+		categories = append(categories, ci)
+	}
+
+	return categories, rows.Err()
 }
 
-// LookupCategoryForKPI is a no-op stub for PostgreSQL until category support is implemented.
-// --- TODO ---
-func (p *PostgresDB) LookupCategoryForKPI(_ *sql.DB, _ string) (string, string, error) {
-	return "", "", nil
+// LookupCategoryForKPI returns the category and table name for a KPI ID.
+// Returns empty strings when the KPI has no registry entry (uncategorized).
+func (p *PostgresDB) LookupCategoryForKPI(db *sql.DB, kpiID string) (category, tableName string, err error) {
+	err = db.QueryRow("SELECT category, table_name FROM kpi_registry WHERE kpi_id = $1", kpiID).
+		Scan(&category, &tableName)
+
+	if err == sql.ErrNoRows {
+		return "", "", nil
+	}
+	if err != nil {
+		return "", "", fmt.Errorf("lookup kpi_registry for '%s': %w", kpiID, err)
+	}
+
+	return category, tableName, nil
 }
 
-// DeleteByCategory is a no-op stub for PostgreSQL until category support is implemented.
-// --- TODO ---
-func (p *PostgresDB) DeleteByCategory(_ *sql.DB, _ string) (int64, error) {
-	return 0, nil
+// DeleteByCategory removes all rows from the given category table and cleans
+// up the corresponding kpi_registry entries. Returns the number of metric rows deleted.
+func (p *PostgresDB) DeleteByCategory(db *sql.DB, category string) (int64, error) {
+	tableName := CategoryTableName(category)
+
+	result, err := db.Exec(fmt.Sprintf("DELETE FROM %s", tableName))
+	if err != nil {
+		return 0, fmt.Errorf("delete from %s: %w", tableName, err)
+	}
+	deleted, _ := result.RowsAffected()
+
+	_, err = db.Exec("DELETE FROM kpi_registry WHERE category = $1", category)
+	if err != nil {
+		return deleted, fmt.Errorf("clean kpi_registry for category '%s': %w", category, err)
+	}
+
+	return deleted, nil
 }
 
 // StoreQueryResults stores the results of a Prometheus query in the database.
-// The category parameter is accepted for interface compatibility but ignored —
-// all data is written to the default query_results table until PostgreSQL
-// category support is implemented.
-func (p *PostgresDB) StoreQueryResults(db *sql.DB, clusterID int64, queryID string, _ string, result model.Value) error {
+// When category is non-empty, writes go to the per-category table (kpi_<category>).
+func (p *PostgresDB) StoreQueryResults(db *sql.DB, clusterID int64, queryID, category string, result model.Value) error {
+	tableName := DefaultTableName
+	if category != "" {
+		name, err := p.EnsureCategoryTable(db, category, queryID)
+		if err != nil {
+			return fmt.Errorf("ensure category table for '%s': %w", category, err)
+		}
+		tableName = name
+	}
+
 	switch values := result.(type) {
 	case model.Vector:
-		return p.storeVectorResults(db, clusterID, queryID, values)
+		return p.storeVectorResults(db, clusterID, queryID, tableName, values)
 	case model.Matrix:
-		return p.storeMatrixResults(db, clusterID, queryID, values)
+		return p.storeMatrixResults(db, clusterID, queryID, tableName, values)
 	default:
 		return fmt.Errorf("unsupported Prometheus result type for KPI '%s': %T", queryID, result)
 	}
 }
 
-func (p *PostgresDB) storeVectorResults(db *sql.DB, clusterID int64, queryID string, vector model.Vector) error {
+func (p *PostgresDB) storeVectorResults(db *sql.DB, clusterID int64, queryID, table string, vector model.Vector) error {
+	insertSQL := fmt.Sprintf(`INSERT INTO %s
+		(kpi_id, metric_value, timestamp_value, cluster_id, metric_labels)
+		VALUES ($1, $2, $3, $4, $5)
+		ON CONFLICT (kpi_id, cluster_id, timestamp_value, metric_labels) DO NOTHING`, table)
+
 	for _, sample := range vector {
 		labelsJSON, err := json.Marshal(sample.Metric)
 		if err != nil {
 			return err
 		}
 
-		_, err = db.Exec(schema.PostgresInsertResult,
+		_, err = db.Exec(insertSQL,
 			queryID, float64(sample.Value), float64(sample.Timestamp)/1000, clusterID, string(labelsJSON),
 		)
 		if err != nil {
@@ -140,7 +265,12 @@ func (p *PostgresDB) storeVectorResults(db *sql.DB, clusterID int64, queryID str
 	return nil
 }
 
-func (p *PostgresDB) storeMatrixResults(db *sql.DB, clusterID int64, queryID string, matrix model.Matrix) error {
+func (p *PostgresDB) storeMatrixResults(db *sql.DB, clusterID int64, queryID, table string, matrix model.Matrix) error {
+	insertSQL := fmt.Sprintf(`INSERT INTO %s
+		(kpi_id, metric_value, timestamp_value, cluster_id, metric_labels)
+		VALUES ($1, $2, $3, $4, $5)
+		ON CONFLICT (kpi_id, cluster_id, timestamp_value, metric_labels) DO NOTHING`, table)
+
 	for _, stream := range matrix {
 		labelsJSON, err := json.Marshal(stream.Metric)
 		if err != nil {
@@ -148,7 +278,7 @@ func (p *PostgresDB) storeMatrixResults(db *sql.DB, clusterID int64, queryID str
 		}
 
 		for _, samplePair := range stream.Values {
-			_, execErr := db.Exec(schema.PostgresInsertResult,
+			_, execErr := db.Exec(insertSQL,
 				queryID, float64(samplePair.Value), float64(samplePair.Timestamp)/1000, clusterID, string(labelsJSON),
 			)
 			if execErr != nil {

--- a/internal/database/postgres.go
+++ b/internal/database/postgres.go
@@ -166,9 +166,14 @@ func (p *PostgresDB) ValidateCategoryConsistency(db *sql.DB, kpis []config.Query
 	return nil
 }
 
-// ListCategories returns all distinct categories registered in kpi_registry.
+// ListCategories returns all distinct categories registered in kpi_registry,
+// along with the number of KPIs in each category.
 func (p *PostgresDB) ListCategories(db *sql.DB) ([]CategoryInfo, error) {
-	rows, err := db.Query("SELECT DISTINCT category, table_name FROM kpi_registry ORDER BY category")
+	rows, err := db.Query(`
+		SELECT category, table_name, COUNT(*) as kpi_count
+		FROM kpi_registry
+		GROUP BY category, table_name
+		ORDER BY category`)
 	if err != nil {
 		return nil, fmt.Errorf("query kpi_registry: %w", err)
 	}
@@ -177,7 +182,7 @@ func (p *PostgresDB) ListCategories(db *sql.DB) ([]CategoryInfo, error) {
 	var categories []CategoryInfo
 	for rows.Next() {
 		var ci CategoryInfo
-		if err := rows.Scan(&ci.Category, &ci.TableName); err != nil {
+		if err := rows.Scan(&ci.Category, &ci.TableName, &ci.KPICount); err != nil {
 			return nil, fmt.Errorf("scan kpi_registry row: %w", err)
 		}
 		categories = append(categories, ci)

--- a/internal/database/postgres_test.go
+++ b/internal/database/postgres_test.go
@@ -3,6 +3,7 @@ package database
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -65,15 +66,15 @@ var _ = Describe("Postgres Implementation", func() {
 		db, err = postgresDB.InitDB()
 		Expect(err).NotTo(HaveOccurred())
 
-		// Clean tables before each test
-		_, err = db.Exec("TRUNCATE TABLE query_results, query_errors, clusters RESTART IDENTITY CASCADE")
+		dropPostgresCategoryTables(db)
+		_, err = db.Exec("TRUNCATE TABLE kpi_registry, query_results, query_errors, clusters RESTART IDENTITY CASCADE")
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	AfterEach(func() {
 		if db != nil {
-			// Clean up after test
-			_, _ = db.Exec("TRUNCATE TABLE query_results, query_errors, clusters RESTART IDENTITY CASCADE")
+			dropPostgresCategoryTables(db)
+			_, _ = db.Exec("TRUNCATE TABLE kpi_registry, query_results, query_errors, clusters RESTART IDENTITY CASCADE")
 			_ = db.Close()
 		}
 	})
@@ -128,6 +129,64 @@ var _ = Describe("Postgres Implementation", func() {
 
 	})
 
+	Describe("Postgres Category Tables", func() {
+		It("should create the kpi_registry table at init", func() {
+			var tableName string
+			err := db.QueryRow(
+				"SELECT table_name FROM information_schema.tables WHERE table_schema='public' AND table_name='kpi_registry'",
+			).Scan(&tableName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(tableName).To(Equal("kpi_registry"))
+		})
+
+		It("should create a category table with JSONB column", func() {
+			_, err := postgresDB.EnsureCategoryTable(db, "cpu", "node-cpu")
+			Expect(err).NotTo(HaveOccurred())
+
+			var dataType string
+			err = db.QueryRow(`
+				SELECT data_type FROM information_schema.columns
+				WHERE table_name = 'kpi_cpu' AND column_name = 'metric_labels'
+			`).Scan(&dataType)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dataType).To(Equal("jsonb"))
+		})
+
+		It("should create a dedup index on the category table", func() {
+			_, err := postgresDB.EnsureCategoryTable(db, "network", "net-kpi")
+			Expect(err).NotTo(HaveOccurred())
+
+			var indexExists bool
+			err = db.QueryRow(`
+				SELECT EXISTS (
+					SELECT 1 FROM pg_indexes WHERE indexname = 'idx_kpi_network_dedup'
+				)
+			`).Scan(&indexExists)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(indexExists).To(BeTrue())
+		})
+	})
+
 	// Run all the shared interface tests
 	RunDatabaseInterfaceTests(func() (Database, *sql.DB) { return postgresDB, db })
 })
+
+func dropPostgresCategoryTables(db *sql.DB) {
+	rows, err := db.Query(`
+		SELECT table_name FROM information_schema.tables
+		WHERE table_schema = 'public'
+		AND table_name LIKE 'kpi_%'
+		AND table_name != 'kpi_registry'`)
+	if err != nil {
+		return
+	}
+	defer func() { _ = rows.Close() }()
+
+	for rows.Next() {
+		var tn string
+		if rows.Scan(&tn) == nil {
+			_, _ = db.Exec(fmt.Sprintf("DROP TABLE IF EXISTS %s CASCADE", tn))
+		}
+	}
+	_ = rows.Err()
+}

--- a/internal/database/schema/postgres.go
+++ b/internal/database/schema/postgres.go
@@ -50,5 +50,23 @@ ON query_results(timestamp_value, kpi_id, cluster_id);
 `
 
 // PostgresSchema is the full DDL for initializing a PostgreSQL database
-// (tables + indexes combined).
-const PostgresSchema = PostgresTables + PostgresIndexes
+// (tables + indexes + registry combined).
+const PostgresSchema = PostgresTables + PostgresIndexes + KPIRegistryTable
+
+// PostgresCategoryTableFmt creates a per-category table with the same column
+// layout as query_results (using PostgreSQL types) plus a dedup index.
+// Requires three identical %s arguments: the table name.
+const PostgresCategoryTableFmt = `
+CREATE TABLE IF NOT EXISTS %s (
+    id SERIAL PRIMARY KEY,
+    kpi_id TEXT NOT NULL,
+    metric_value DOUBLE PRECISION,
+    timestamp_value DOUBLE PRECISION,
+    cluster_id INTEGER NOT NULL REFERENCES clusters(id),
+    execution_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    metric_labels JSONB
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_%s_dedup
+ON %s(kpi_id, cluster_id, timestamp_value, metric_labels);
+`

--- a/internal/database/schema/queries_postgres.go
+++ b/internal/database/schema/queries_postgres.go
@@ -2,9 +2,10 @@ package schema
 
 // PostgreSQL DML queries use $N placeholders.
 
-const PostgresInsertResult = `
-INSERT INTO query_results
-(kpi_id, metric_value, timestamp_value, cluster_id, metric_labels)
+// PostgresInsertResultFmt inserts a metric row into any table (query_results or
+// a per-category table). Requires one %s argument: the target table name.
+const PostgresInsertResultFmt = `
+INSERT INTO %s (kpi_id, metric_value, timestamp_value, cluster_id, metric_labels)
 VALUES ($1, $2, $3, $4, $5)
 ON CONFLICT (kpi_id, cluster_id, timestamp_value, metric_labels) DO NOTHING`
 
@@ -22,3 +23,21 @@ const PostgresUpsertCluster = `
 INSERT INTO clusters (cluster_name, cluster_type) VALUES ($1, $2)
 ON CONFLICT (cluster_name) DO UPDATE SET cluster_type = EXCLUDED.cluster_type
 RETURNING id`
+
+// --- kpi_registry queries ---
+
+const PostgresUpsertRegistry = `
+INSERT INTO kpi_registry (kpi_id, category, table_name) VALUES ($1, $2, $3)
+ON CONFLICT(kpi_id) DO NOTHING`
+
+const PostgresSelectRegistryAll = `SELECT kpi_id, category FROM kpi_registry`
+
+const PostgresSelectRegistryCategories = `
+SELECT category, table_name, COUNT(*) as kpi_count
+FROM kpi_registry
+GROUP BY category, table_name
+ORDER BY category`
+
+const PostgresSelectRegistryByKPI = `SELECT category, table_name FROM kpi_registry WHERE kpi_id = $1`
+
+const PostgresDeleteRegistryByCategory = `DELETE FROM kpi_registry WHERE category = $1`

--- a/internal/database/schema/queries_sqlite.go
+++ b/internal/database/schema/queries_sqlite.go
@@ -2,9 +2,10 @@ package schema
 
 // SQLite DML queries use ? placeholders.
 
-const SQLiteInsertResult = `
-INSERT INTO query_results
-(kpi_id, metric_value, timestamp_value, cluster_id, metric_labels)
+// SQLiteInsertResultFmt inserts a metric row into any table (query_results or
+// a per-category table). Requires one %s argument: the target table name.
+const SQLiteInsertResultFmt = `
+INSERT INTO %s (kpi_id, metric_value, timestamp_value, cluster_id, metric_labels)
 VALUES (?, ?, ?, ?, ?)
 ON CONFLICT(kpi_id, cluster_id, timestamp_value, metric_labels) DO NOTHING`
 
@@ -19,3 +20,21 @@ const SQLiteSelectClusterByName = `SELECT id FROM clusters WHERE cluster_name = 
 const SQLiteUpdateClusterType = `UPDATE clusters SET cluster_type = ? WHERE id = ?`
 
 const SQLiteInsertCluster = `INSERT INTO clusters (cluster_name, cluster_type) VALUES (?, ?)`
+
+// --- kpi_registry queries ---
+
+const SQLiteUpsertRegistry = `
+INSERT INTO kpi_registry (kpi_id, category, table_name) VALUES (?, ?, ?)
+ON CONFLICT(kpi_id) DO NOTHING`
+
+const SQLiteSelectRegistryAll = `SELECT kpi_id, category FROM kpi_registry`
+
+const SQLiteSelectRegistryCategories = `
+SELECT category, table_name, COUNT(*) as kpi_count
+FROM kpi_registry
+GROUP BY category, table_name
+ORDER BY category`
+
+const SQLiteSelectRegistryByKPI = `SELECT category, table_name FROM kpi_registry WHERE kpi_id = ?`
+
+const SQLiteDeleteRegistryByCategory = `DELETE FROM kpi_registry WHERE category = ?`

--- a/internal/database/schema/schema.go
+++ b/internal/database/schema/schema.go
@@ -7,4 +7,16 @@ const (
 	TableClusters     = "clusters"
 	TableQueryResults = "query_results"
 	TableQueryErrors  = "query_errors"
+	TableKPIRegistry  = "kpi_registry"
 )
+
+// KPIRegistryTable maps each KPI to its storage category and backing table.
+// The schema is backend-agnostic (TEXT + TIMESTAMP work on both SQLite and PostgreSQL).
+const KPIRegistryTable = `
+CREATE TABLE IF NOT EXISTS kpi_registry (
+    kpi_id TEXT PRIMARY KEY,
+    category TEXT NOT NULL,
+    table_name TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+`

--- a/internal/database/schema/sqlite.go
+++ b/internal/database/schema/sqlite.go
@@ -52,5 +52,23 @@ ON query_results(timestamp_value, kpi_id, cluster_id);
 `
 
 // SQLiteSchema is the full DDL for initializing an SQLite database
-// (tables + indexes combined).
-const SQLiteSchema = SQLiteTables + SQLiteIndexes
+// (tables + indexes + registry combined).
+const SQLiteSchema = SQLiteTables + SQLiteIndexes + KPIRegistryTable
+
+// SQLiteCategoryTableFmt creates a per-category table with the same column
+// layout as query_results plus a dedup index. Requires three identical %s
+// arguments: the table name (for CREATE TABLE, index name, and ON clause).
+const SQLiteCategoryTableFmt = `
+CREATE TABLE IF NOT EXISTS %s (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    kpi_id TEXT NOT NULL,
+    metric_value REAL,
+    timestamp_value REAL,
+    cluster_id INTEGER NOT NULL REFERENCES clusters(id),
+    execution_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    metric_labels TEXT
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_%s_dedup
+ON %s(kpi_id, cluster_id, timestamp_value, metric_labels);
+`

--- a/internal/database/sqlite.go
+++ b/internal/database/sqlite.go
@@ -20,6 +20,8 @@ const (
 	DefaultOutputDir = "kpi-collector-artifacts"
 	// DefaultDBFileName is the SQLite database file name
 	DefaultDBFileName = "kpi_metrics.db"
+	// DefaultTableName is the legacy table used for uncategorized KPIs
+	DefaultTableName = "query_results"
 )
 
 // OutputDir is the resolved artifacts directory. It defaults to DefaultOutputDir
@@ -117,7 +119,7 @@ func (sqlite_db *SQLiteDB) GetQueryErrorCount(db *sql.DB, kpiID string) (int, er
 // StoreQueryResults stores the results of a Prometheus query in the database.
 // When category is non-empty, writes go to the per-category table (kpi_<category>).
 func (sqlite_db *SQLiteDB) StoreQueryResults(db *sql.DB, clusterID int64, queryID string, category string, result model.Value) error {
-	tableName := "query_results"
+	tableName := DefaultTableName
 	if category != "" {
 		name, err := sqlite_db.EnsureCategoryTable(db, category, queryID)
 		if err != nil {
@@ -218,6 +220,62 @@ func (sqlite_db *SQLiteDB) ValidateCategoryConsistency(db *sql.DB, kpis []config
 	}
 
 	return nil
+}
+
+// ListCategories returns all distinct categories registered in kpi_registry.
+func (sqlite_db *SQLiteDB) ListCategories(db *sql.DB) ([]CategoryInfo, error) {
+	rows, err := db.Query("SELECT DISTINCT category, table_name FROM kpi_registry ORDER BY category")
+	if err != nil {
+		return nil, fmt.Errorf("query kpi_registry: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var categories []CategoryInfo
+	for rows.Next() {
+		var ci CategoryInfo
+		if err := rows.Scan(&ci.Category, &ci.TableName); err != nil {
+			return nil, fmt.Errorf("scan kpi_registry row: %w", err)
+		}
+		categories = append(categories, ci)
+	}
+
+	return categories, rows.Err()
+}
+
+// LookupCategoryForKPI returns the category and table name for a KPI ID.
+// Returns empty strings when the KPI has no registry entry (uncategorized).
+func (sqlite_db *SQLiteDB) LookupCategoryForKPI(db *sql.DB, kpiID string) (string, string, error) {
+	var category, tableName string
+	err := db.QueryRow("SELECT category, table_name FROM kpi_registry WHERE kpi_id = ?", kpiID).
+		Scan(&category, &tableName)
+
+	if err == sql.ErrNoRows {
+		return "", "", nil
+	}
+	if err != nil {
+		return "", "", fmt.Errorf("lookup kpi_registry for '%s': %w", kpiID, err)
+	}
+
+	return category, tableName, nil
+}
+
+// DeleteByCategory removes all rows from the given category table and cleans
+// up the corresponding kpi_registry entries. Returns the number of metric rows deleted.
+func (sqlite_db *SQLiteDB) DeleteByCategory(db *sql.DB, category string) (int64, error) {
+	tableName := CategoryTableName(category)
+
+	result, err := db.Exec(fmt.Sprintf("DELETE FROM %s", tableName))
+	if err != nil {
+		return 0, fmt.Errorf("delete from %s: %w", tableName, err)
+	}
+	deleted, _ := result.RowsAffected()
+
+	_, err = db.Exec("DELETE FROM kpi_registry WHERE category = ?", category)
+	if err != nil {
+		return deleted, fmt.Errorf("clean kpi_registry for category '%s': %w", category, err)
+	}
+
+	return deleted, nil
 }
 
 func (sqlite_db *SQLiteDB) storeVectorResults(db *sql.DB, clusterID int64, queryID string, table string, vector model.Vector) error {

--- a/internal/database/sqlite.go
+++ b/internal/database/sqlite.go
@@ -222,9 +222,14 @@ func (sqlite_db *SQLiteDB) ValidateCategoryConsistency(db *sql.DB, kpis []config
 	return nil
 }
 
-// ListCategories returns all distinct categories registered in kpi_registry.
+// ListCategories returns all distinct categories registered in kpi_registry,
+// along with the number of KPIs in each category.
 func (sqlite_db *SQLiteDB) ListCategories(db *sql.DB) ([]CategoryInfo, error) {
-	rows, err := db.Query("SELECT DISTINCT category, table_name FROM kpi_registry ORDER BY category")
+	rows, err := db.Query(`
+		SELECT category, table_name, COUNT(*) as kpi_count
+		FROM kpi_registry
+		GROUP BY category, table_name
+		ORDER BY category`)
 	if err != nil {
 		return nil, fmt.Errorf("query kpi_registry: %w", err)
 	}
@@ -233,7 +238,7 @@ func (sqlite_db *SQLiteDB) ListCategories(db *sql.DB) ([]CategoryInfo, error) {
 	var categories []CategoryInfo
 	for rows.Next() {
 		var ci CategoryInfo
-		if err := rows.Scan(&ci.Category, &ci.TableName); err != nil {
+		if err := rows.Scan(&ci.Category, &ci.TableName, &ci.KPICount); err != nil {
 			return nil, fmt.Errorf("scan kpi_registry row: %w", err)
 		}
 		categories = append(categories, ci)

--- a/internal/database/sqlite.go
+++ b/internal/database/sqlite.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 
 	"github.com/prometheus/common/model"
 	_ "modernc.org/sqlite"
@@ -24,7 +25,13 @@ const (
 // and can be overridden via the --artifacts-dir flag.
 var OutputDir = DefaultOutputDir
 
-type SQLiteDB struct{}
+type SQLiteDB struct {
+	// knownTables caches which category tables have been created during this
+	// process lifetime. It resets on every invocation (including --once), which
+	// is fine because EnsureCategoryTable uses CREATE TABLE IF NOT EXISTS as the
+	// fallback — the cache only avoids redundant DDL within a long-running run.
+	knownTables sync.Map
+}
 
 // NewSQLiteDB creates a new SQLite database instance
 func NewSQLiteDB() *SQLiteDB {
@@ -53,6 +60,17 @@ func (sqlite_db *SQLiteDB) InitDB() (*sql.DB, error) {
 	if _, err = db.Exec(schema.SQLiteSchema); err != nil {
 		_ = db.Close()
 		return nil, fmt.Errorf("creating SQLite schema: %w", err)
+	}
+
+	if _, err = db.Exec(`
+		CREATE TABLE IF NOT EXISTS kpi_registry (
+			kpi_id TEXT PRIMARY KEY,
+			category TEXT NOT NULL,
+			table_name TEXT NOT NULL,
+			created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+		)`); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("creating kpi_registry table: %w", err)
 	}
 
 	return db, nil
@@ -95,26 +113,86 @@ func (sqlite_db *SQLiteDB) GetQueryErrorCount(db *sql.DB, kpiID string) (int, er
 	return count, err
 }
 
-// StoreQueryResults stores the results of a Prometheus query in the database
-func (sqlite_db *SQLiteDB) StoreQueryResults(db *sql.DB, clusterID int64, queryID string, result model.Value) error {
+// StoreQueryResults stores the results of a Prometheus query in the database.
+// When category is non-empty, writes go to the per-category table (kpi_<category>).
+func (sqlite_db *SQLiteDB) StoreQueryResults(db *sql.DB, clusterID int64, queryID string, category string, result model.Value) error {
+	tableName := "query_results"
+	if category != "" {
+		name, err := sqlite_db.EnsureCategoryTable(db, category, queryID)
+		if err != nil {
+			return fmt.Errorf("ensure category table for '%s': %w", category, err)
+		}
+		tableName = name
+	}
+
 	switch values := result.(type) {
 	case model.Vector:
-		return sqlite_db.storeVectorResults(db, clusterID, queryID, values)
+		return sqlite_db.storeVectorResults(db, clusterID, queryID, tableName, values)
 	case model.Matrix:
-		return sqlite_db.storeMatrixResults(db, clusterID, queryID, values)
+		return sqlite_db.storeMatrixResults(db, clusterID, queryID, tableName, values)
 	default:
 		return fmt.Errorf("unsupported Prometheus result type for KPI '%s': %T", queryID, result)
 	}
 }
 
-func (sqlite_db *SQLiteDB) storeVectorResults(db *sql.DB, clusterID int64, queryID string, vector model.Vector) error {
+// CategoryTableName returns the physical table name for a given sanitised category.
+func CategoryTableName(category string) string {
+	return "kpi_" + category
+}
+
+// EnsureCategoryTable lazily creates the per-category table and registers the
+// KPI→category mapping. The DDL is idempotent and only executed once per
+// process lifetime thanks to the in-memory knownTables cache.
+func (sqlite_db *SQLiteDB) EnsureCategoryTable(db *sql.DB, category string, kpiID string) (string, error) {
+	tableName := CategoryTableName(category)
+
+	if _, ok := sqlite_db.knownTables.Load(tableName); !ok {
+		ddl := fmt.Sprintf(`
+			CREATE TABLE IF NOT EXISTS %s (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				kpi_id TEXT NOT NULL,
+				metric_value REAL,
+				timestamp_value REAL,
+				cluster_id INTEGER NOT NULL REFERENCES clusters(id),
+				execution_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+				created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+				metric_labels TEXT
+			);
+			CREATE UNIQUE INDEX IF NOT EXISTS idx_%s_dedup
+			ON %s(kpi_id, cluster_id, timestamp_value, metric_labels)`,
+			tableName, tableName, tableName)
+
+		if _, err := db.Exec(ddl); err != nil {
+			return "", fmt.Errorf("create table %s: %w", tableName, err)
+		}
+
+		sqlite_db.knownTables.Store(tableName, true)
+	}
+
+	_, err := db.Exec(`
+		INSERT INTO kpi_registry (kpi_id, category, table_name) VALUES (?, ?, ?)
+		ON CONFLICT(kpi_id) DO UPDATE SET category = excluded.category, table_name = excluded.table_name`,
+		kpiID, category, tableName)
+	if err != nil {
+		return "", fmt.Errorf("update kpi_registry for '%s': %w", kpiID, err)
+	}
+
+	return tableName, nil
+}
+
+func (sqlite_db *SQLiteDB) storeVectorResults(db *sql.DB, clusterID int64, queryID string, table string, vector model.Vector) error {
 	transaction, err := db.Begin()
 	if err != nil {
 		return fmt.Errorf("begin transaction: %w", err)
 	}
 	defer func() { _ = transaction.Rollback() }()
 
-	preparedStatement, err := transaction.Prepare(schema.SQLiteInsertResult)
+	insertSQL := fmt.Sprintf(`INSERT INTO %s
+		(kpi_id, metric_value, timestamp_value, cluster_id, metric_labels)
+		VALUES (?, ?, ?, ?, ?)
+		ON CONFLICT(kpi_id, cluster_id, timestamp_value, metric_labels) DO NOTHING`, table)
+
+	preparedStatement, err := transaction.Prepare(insertSQL)
 	if err != nil {
 		return fmt.Errorf("prepare statement: %w", err)
 	}
@@ -139,14 +217,19 @@ func (sqlite_db *SQLiteDB) storeVectorResults(db *sql.DB, clusterID int64, query
 	return transaction.Commit()
 }
 
-func (sqlite_db *SQLiteDB) storeMatrixResults(db *sql.DB, clusterID int64, queryID string, matrix model.Matrix) error {
+func (sqlite_db *SQLiteDB) storeMatrixResults(db *sql.DB, clusterID int64, queryID string, table string, matrix model.Matrix) error {
 	transaction, err := db.Begin()
 	if err != nil {
 		return fmt.Errorf("begin transaction: %w", err)
 	}
 	defer func() { _ = transaction.Rollback() }()
 
-	preparedStatement, err := transaction.Prepare(schema.SQLiteInsertResult)
+	insertSQL := fmt.Sprintf(`INSERT INTO %s
+		(kpi_id, metric_value, timestamp_value, cluster_id, metric_labels)
+		VALUES (?, ?, ?, ?, ?)
+		ON CONFLICT(kpi_id, cluster_id, timestamp_value, metric_labels) DO NOTHING`, table)
+
+	preparedStatement, err := transaction.Prepare(insertSQL)
 	if err != nil {
 		return fmt.Errorf("prepare statement: %w", err)
 	}

--- a/internal/database/sqlite.go
+++ b/internal/database/sqlite.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"github.com/prometheus/common/model"
+	"github.com/redhat-best-practices-for-k8s/kpi-collection-tool/internal/config"
 	_ "modernc.org/sqlite"
 
 	"github.com/redhat-best-practices-for-k8s/kpi-collection-tool/internal/database/schema"
@@ -171,13 +172,52 @@ func (sqlite_db *SQLiteDB) EnsureCategoryTable(db *sql.DB, category string, kpiI
 
 	_, err := db.Exec(`
 		INSERT INTO kpi_registry (kpi_id, category, table_name) VALUES (?, ?, ?)
-		ON CONFLICT(kpi_id) DO UPDATE SET category = excluded.category, table_name = excluded.table_name`,
+		ON CONFLICT(kpi_id) DO NOTHING`,
 		kpiID, category, tableName)
 	if err != nil {
-		return "", fmt.Errorf("update kpi_registry for '%s': %w", kpiID, err)
+		return "", fmt.Errorf("register kpi '%s' in kpi_registry: %w", kpiID, err)
 	}
 
 	return tableName, nil
+}
+
+// ValidateCategoryConsistency loads the existing kpi_registry and returns an
+// error if any incoming KPI has a different category than what was previously
+// recorded. This prevents silent data orphaning when a user changes categories
+// between runs.
+func (sqlite_db *SQLiteDB) ValidateCategoryConsistency(db *sql.DB, kpis []config.Query) error {
+	rows, err := db.Query("SELECT kpi_id, category FROM kpi_registry")
+	if err != nil {
+		return fmt.Errorf("query kpi_registry: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	registered := make(map[string]string)
+	for rows.Next() {
+		var kpiID, category string
+		if err := rows.Scan(&kpiID, &category); err != nil {
+			return fmt.Errorf("scan kpi_registry row: %w", err)
+		}
+		registered[kpiID] = category
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate kpi_registry: %w", err)
+	}
+
+	for i := range kpis {
+		prev, exists := registered[kpis[i].ID]
+		if !exists {
+			continue
+		}
+		if prev != kpis[i].Category {
+			return fmt.Errorf(
+				"KPI '%s' category changed from %q to %q — "+
+					"use a different --artifacts-dir or delete the existing database",
+				kpis[i].ID, prev, kpis[i].Category)
+		}
+	}
+
+	return nil
 }
 
 func (sqlite_db *SQLiteDB) storeVectorResults(db *sql.DB, clusterID int64, queryID string, table string, vector model.Vector) error {

--- a/internal/database/sqlite.go
+++ b/internal/database/sqlite.go
@@ -65,17 +65,6 @@ func (sqlite_db *SQLiteDB) InitDB() (*sql.DB, error) {
 		return nil, fmt.Errorf("creating SQLite schema: %w", err)
 	}
 
-	if _, err = db.Exec(`
-		CREATE TABLE IF NOT EXISTS kpi_registry (
-			kpi_id TEXT PRIMARY KEY,
-			category TEXT NOT NULL,
-			table_name TEXT NOT NULL,
-			created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-		)`); err != nil {
-		_ = db.Close()
-		return nil, fmt.Errorf("creating kpi_registry table: %w", err)
-	}
-
 	return db, nil
 }
 
@@ -150,20 +139,7 @@ func (sqlite_db *SQLiteDB) EnsureCategoryTable(db *sql.DB, category string, kpiI
 	tableName := CategoryTableName(category)
 
 	if _, ok := sqlite_db.knownTables.Load(tableName); !ok {
-		ddl := fmt.Sprintf(`
-			CREATE TABLE IF NOT EXISTS %s (
-				id INTEGER PRIMARY KEY AUTOINCREMENT,
-				kpi_id TEXT NOT NULL,
-				metric_value REAL,
-				timestamp_value REAL,
-				cluster_id INTEGER NOT NULL REFERENCES clusters(id),
-				execution_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-				created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-				metric_labels TEXT
-			);
-			CREATE UNIQUE INDEX IF NOT EXISTS idx_%s_dedup
-			ON %s(kpi_id, cluster_id, timestamp_value, metric_labels)`,
-			tableName, tableName, tableName)
+		ddl := fmt.Sprintf(schema.SQLiteCategoryTableFmt, tableName, tableName, tableName)
 
 		if _, err := db.Exec(ddl); err != nil {
 			return "", fmt.Errorf("create table %s: %w", tableName, err)
@@ -172,10 +148,7 @@ func (sqlite_db *SQLiteDB) EnsureCategoryTable(db *sql.DB, category string, kpiI
 		sqlite_db.knownTables.Store(tableName, true)
 	}
 
-	_, err := db.Exec(`
-		INSERT INTO kpi_registry (kpi_id, category, table_name) VALUES (?, ?, ?)
-		ON CONFLICT(kpi_id) DO NOTHING`,
-		kpiID, category, tableName)
+	_, err := db.Exec(schema.SQLiteUpsertRegistry, kpiID, category, tableName)
 	if err != nil {
 		return "", fmt.Errorf("register kpi '%s' in kpi_registry: %w", kpiID, err)
 	}
@@ -188,7 +161,7 @@ func (sqlite_db *SQLiteDB) EnsureCategoryTable(db *sql.DB, category string, kpiI
 // recorded. This prevents silent data orphaning when a user changes categories
 // between runs.
 func (sqlite_db *SQLiteDB) ValidateCategoryConsistency(db *sql.DB, kpis []config.Query) error {
-	rows, err := db.Query("SELECT kpi_id, category FROM kpi_registry")
+	rows, err := db.Query(schema.SQLiteSelectRegistryAll)
 	if err != nil {
 		return fmt.Errorf("query kpi_registry: %w", err)
 	}
@@ -225,11 +198,7 @@ func (sqlite_db *SQLiteDB) ValidateCategoryConsistency(db *sql.DB, kpis []config
 // ListCategories returns all distinct categories registered in kpi_registry,
 // along with the number of KPIs in each category.
 func (sqlite_db *SQLiteDB) ListCategories(db *sql.DB) ([]CategoryInfo, error) {
-	rows, err := db.Query(`
-		SELECT category, table_name, COUNT(*) as kpi_count
-		FROM kpi_registry
-		GROUP BY category, table_name
-		ORDER BY category`)
+	rows, err := db.Query(schema.SQLiteSelectRegistryCategories)
 	if err != nil {
 		return nil, fmt.Errorf("query kpi_registry: %w", err)
 	}
@@ -251,8 +220,7 @@ func (sqlite_db *SQLiteDB) ListCategories(db *sql.DB) ([]CategoryInfo, error) {
 // Returns empty strings when the KPI has no registry entry (uncategorized).
 func (sqlite_db *SQLiteDB) LookupCategoryForKPI(db *sql.DB, kpiID string) (string, string, error) {
 	var category, tableName string
-	err := db.QueryRow("SELECT category, table_name FROM kpi_registry WHERE kpi_id = ?", kpiID).
-		Scan(&category, &tableName)
+	err := db.QueryRow(schema.SQLiteSelectRegistryByKPI, kpiID).Scan(&category, &tableName)
 
 	if err == sql.ErrNoRows {
 		return "", "", nil
@@ -275,7 +243,7 @@ func (sqlite_db *SQLiteDB) DeleteByCategory(db *sql.DB, category string) (int64,
 	}
 	deleted, _ := result.RowsAffected()
 
-	_, err = db.Exec("DELETE FROM kpi_registry WHERE category = ?", category)
+	_, err = db.Exec(schema.SQLiteDeleteRegistryByCategory, category)
 	if err != nil {
 		return deleted, fmt.Errorf("clean kpi_registry for category '%s': %w", category, err)
 	}
@@ -290,12 +258,7 @@ func (sqlite_db *SQLiteDB) storeVectorResults(db *sql.DB, clusterID int64, query
 	}
 	defer func() { _ = transaction.Rollback() }()
 
-	insertSQL := fmt.Sprintf(`INSERT INTO %s
-		(kpi_id, metric_value, timestamp_value, cluster_id, metric_labels)
-		VALUES (?, ?, ?, ?, ?)
-		ON CONFLICT(kpi_id, cluster_id, timestamp_value, metric_labels) DO NOTHING`, table)
-
-	preparedStatement, err := transaction.Prepare(insertSQL)
+	preparedStatement, err := transaction.Prepare(fmt.Sprintf(schema.SQLiteInsertResultFmt, table))
 	if err != nil {
 		return fmt.Errorf("prepare statement: %w", err)
 	}
@@ -327,12 +290,7 @@ func (sqlite_db *SQLiteDB) storeMatrixResults(db *sql.DB, clusterID int64, query
 	}
 	defer func() { _ = transaction.Rollback() }()
 
-	insertSQL := fmt.Sprintf(`INSERT INTO %s
-		(kpi_id, metric_value, timestamp_value, cluster_id, metric_labels)
-		VALUES (?, ?, ?, ?, ?)
-		ON CONFLICT(kpi_id, cluster_id, timestamp_value, metric_labels) DO NOTHING`, table)
-
-	preparedStatement, err := transaction.Prepare(insertSQL)
+	preparedStatement, err := transaction.Prepare(fmt.Sprintf(schema.SQLiteInsertResultFmt, table))
 	if err != nil {
 		return fmt.Errorf("prepare statement: %w", err)
 	}

--- a/internal/database/sqlite_test.go
+++ b/internal/database/sqlite_test.go
@@ -252,5 +252,93 @@ var _ = Describe("Sqlite", func() {
 		})
 	})
 
+	Describe("ListCategories", func() {
+		It("should return empty list when no categories exist", func() {
+			categories, err := sqliteDB.ListCategories(db)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(categories).To(BeEmpty())
+		})
+
+		It("should return all distinct categories", func() {
+			_, err := sqliteDB.EnsureCategoryTable(db, "cpu", "node-cpu")
+			Expect(err).NotTo(HaveOccurred())
+			_, err = sqliteDB.EnsureCategoryTable(db, "cpu", "container-cpu")
+			Expect(err).NotTo(HaveOccurred())
+			_, err = sqliteDB.EnsureCategoryTable(db, "memory", "mem-usage")
+			Expect(err).NotTo(HaveOccurred())
+
+			categories, err := sqliteDB.ListCategories(db)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(categories).To(HaveLen(2))
+			Expect(categories[0].Category).To(Equal("cpu"))
+			Expect(categories[0].TableName).To(Equal("kpi_cpu"))
+			Expect(categories[1].Category).To(Equal("memory"))
+			Expect(categories[1].TableName).To(Equal("kpi_memory"))
+		})
+	})
+
+	Describe("LookupCategoryForKPI", func() {
+		It("should return empty strings for an unregistered KPI", func() {
+			cat, table, err := sqliteDB.LookupCategoryForKPI(db, "unknown-kpi")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cat).To(BeEmpty())
+			Expect(table).To(BeEmpty())
+		})
+
+		It("should return category and table for a registered KPI", func() {
+			_, err := sqliteDB.EnsureCategoryTable(db, "cpu", "node-cpu")
+			Expect(err).NotTo(HaveOccurred())
+
+			cat, table, err := sqliteDB.LookupCategoryForKPI(db, "node-cpu")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cat).To(Equal("cpu"))
+			Expect(table).To(Equal("kpi_cpu"))
+		})
+	})
+
+	Describe("DeleteByCategory", func() {
+		var clusterID int64
+
+		BeforeEach(func() {
+			var err error
+			clusterID, err = sqliteDB.GetOrCreateCluster(db, "del-cluster", "ran")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should delete all rows from the category table and clean registry", func() {
+			vector := model.Vector{
+				&model.Sample{
+					Metric:    model.Metric{"__name__": "cpu_usage"},
+					Value:     model.SampleValue(0.5),
+					Timestamp: model.Time(time.Now().Unix() * 1000),
+				},
+			}
+			err := sqliteDB.StoreQueryResults(db, clusterID, "cpu-kpi", "cpu", vector)
+			Expect(err).NotTo(HaveOccurred())
+
+			deleted, err := sqliteDB.DeleteByCategory(db, "cpu")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(deleted).To(Equal(int64(1)))
+
+			var count int
+			err = db.QueryRow("SELECT COUNT(*) FROM kpi_cpu").Scan(&count)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(count).To(Equal(0))
+
+			err = db.QueryRow("SELECT COUNT(*) FROM kpi_registry WHERE category = 'cpu'").Scan(&count)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(count).To(Equal(0))
+		})
+
+		It("should return 0 when category table is empty", func() {
+			_, err := sqliteDB.EnsureCategoryTable(db, "network", "net-kpi")
+			Expect(err).NotTo(HaveOccurred())
+
+			deleted, err := sqliteDB.DeleteByCategory(db, "network")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(deleted).To(Equal(int64(0)))
+		})
+	})
+
 	RunDatabaseInterfaceTests(func() (Database, *sql.DB) { return sqliteDB, db })
 })

--- a/internal/database/sqlite_test.go
+++ b/internal/database/sqlite_test.go
@@ -9,6 +9,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/prometheus/common/model"
+	"github.com/redhat-best-practices-for-k8s/kpi-collection-tool/internal/config"
 )
 
 var _ = Describe("Sqlite", func() {
@@ -188,6 +189,66 @@ var _ = Describe("Sqlite", func() {
 			err = db.QueryRow("SELECT COUNT(*) FROM kpi_memory WHERE kpi_id = 'mem-kpi'").Scan(&count)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(count).To(Equal(1))
+		})
+	})
+
+	Describe("ValidateCategoryConsistency", func() {
+		BeforeEach(func() {
+			_, err := sqliteDB.EnsureCategoryTable(db, "cpu", "node-cpu")
+			Expect(err).NotTo(HaveOccurred())
+			_, err = sqliteDB.EnsureCategoryTable(db, "memory", "mem-usage")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should pass when categories match", func() {
+			kpis := []config.Query{
+				{ID: "node-cpu", Category: "cpu"},
+				{ID: "mem-usage", Category: "memory"},
+			}
+			err := sqliteDB.ValidateCategoryConsistency(db, kpis)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should pass for new KPIs not yet in registry", func() {
+			kpis := []config.Query{
+				{ID: "node-cpu", Category: "cpu"},
+				{ID: "brand-new-kpi", Category: "network"},
+			}
+			err := sqliteDB.ValidateCategoryConsistency(db, kpis)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should error when a KPI changes category", func() {
+			kpis := []config.Query{
+				{ID: "node-cpu", Category: "networking"},
+			}
+			err := sqliteDB.ValidateCategoryConsistency(db, kpis)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("node-cpu"))
+			Expect(err.Error()).To(ContainSubstring(`"cpu"`))
+			Expect(err.Error()).To(ContainSubstring(`"networking"`))
+		})
+
+		It("should error when a categorised KPI becomes uncategorised", func() {
+			kpis := []config.Query{
+				{ID: "node-cpu", Category: ""},
+			}
+			err := sqliteDB.ValidateCategoryConsistency(db, kpis)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("node-cpu"))
+		})
+
+		It("should pass on an empty registry", func() {
+			freshDB := NewSQLiteDB()
+			freshConn, err := freshDB.InitDB()
+			Expect(err).NotTo(HaveOccurred())
+			defer func() { _ = freshConn.Close() }()
+
+			kpis := []config.Query{
+				{ID: "any-kpi", Category: "whatever"},
+			}
+			err = freshDB.ValidateCategoryConsistency(freshConn, kpis)
+			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 

--- a/internal/database/sqlite_test.go
+++ b/internal/database/sqlite_test.go
@@ -4,9 +4,11 @@ import (
 	"database/sql"
 	"os"
 	"path/filepath"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/prometheus/common/model"
 )
 
 var _ = Describe("Sqlite", func() {
@@ -78,6 +80,114 @@ var _ = Describe("Sqlite", func() {
 			dbFile := filepath.Join(tmpDir, DefaultOutputDir, DefaultDBFileName)
 			_, err := os.Stat(dbFile)
 			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Describe("Category Tables", func() {
+		var clusterID int64
+
+		BeforeEach(func() {
+			var err error
+			clusterID, err = sqliteDB.GetOrCreateCluster(db, "cat-cluster", "ran")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should create the kpi_registry table at init", func() {
+			var name string
+			err := db.QueryRow("SELECT name FROM sqlite_master WHERE type='table' AND name='kpi_registry'").Scan(&name)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(name).To(Equal("kpi_registry"))
+		})
+
+		It("should create a category table and register the KPI", func() {
+			tableName, err := sqliteDB.EnsureCategoryTable(db, "cpu", "node-cpu-usage")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(tableName).To(Equal("kpi_cpu"))
+
+			var name string
+			err = db.QueryRow("SELECT name FROM sqlite_master WHERE type='table' AND name='kpi_cpu'").Scan(&name)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(name).To(Equal("kpi_cpu"))
+
+			var kpiID, category, regTable string
+			err = db.QueryRow("SELECT kpi_id, category, table_name FROM kpi_registry WHERE kpi_id = 'node-cpu-usage'").
+				Scan(&kpiID, &category, &regTable)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(category).To(Equal("cpu"))
+			Expect(regTable).To(Equal("kpi_cpu"))
+		})
+
+		It("should be idempotent for the same category", func() {
+			_, err := sqliteDB.EnsureCategoryTable(db, "memory", "mem-usage-1")
+			Expect(err).NotTo(HaveOccurred())
+			_, err = sqliteDB.EnsureCategoryTable(db, "memory", "mem-usage-2")
+			Expect(err).NotTo(HaveOccurred())
+
+			var count int
+			err = db.QueryRow("SELECT COUNT(*) FROM kpi_registry WHERE category = 'memory'").Scan(&count)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(count).To(Equal(2))
+		})
+
+		It("should route categorised writes to the category table", func() {
+			vector := model.Vector{
+				&model.Sample{
+					Metric:    model.Metric{"__name__": "cpu_seconds"},
+					Value:     model.SampleValue(0.75),
+					Timestamp: model.Time(time.Now().Unix() * 1000),
+				},
+			}
+
+			err := sqliteDB.StoreQueryResults(db, clusterID, "node-cpu", "cpu", vector)
+			Expect(err).NotTo(HaveOccurred())
+
+			var count int
+			err = db.QueryRow("SELECT COUNT(*) FROM kpi_cpu WHERE kpi_id = 'node-cpu'").Scan(&count)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(count).To(Equal(1))
+
+			err = db.QueryRow("SELECT COUNT(*) FROM query_results WHERE kpi_id = 'node-cpu'").Scan(&count)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(count).To(Equal(0))
+		})
+
+		It("should route uncategorised writes to query_results", func() {
+			vector := model.Vector{
+				&model.Sample{
+					Metric:    model.Metric{"__name__": "up"},
+					Value:     model.SampleValue(1),
+					Timestamp: model.Time(time.Now().Unix() * 1000),
+				},
+			}
+
+			err := sqliteDB.StoreQueryResults(db, clusterID, "cluster-up", "", vector)
+			Expect(err).NotTo(HaveOccurred())
+
+			var count int
+			err = db.QueryRow("SELECT COUNT(*) FROM query_results WHERE kpi_id = 'cluster-up'").Scan(&count)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(count).To(Equal(1))
+		})
+
+		It("should enforce dedup on category tables", func() {
+			ts := model.Time(time.Now().Unix() * 1000)
+			vector := model.Vector{
+				&model.Sample{
+					Metric:    model.Metric{"__name__": "mem_bytes"},
+					Value:     model.SampleValue(1024),
+					Timestamp: ts,
+				},
+			}
+
+			err := sqliteDB.StoreQueryResults(db, clusterID, "mem-kpi", "memory", vector)
+			Expect(err).NotTo(HaveOccurred())
+			err = sqliteDB.StoreQueryResults(db, clusterID, "mem-kpi", "memory", vector)
+			Expect(err).NotTo(HaveOccurred())
+
+			var count int
+			err = db.QueryRow("SELECT COUNT(*) FROM kpi_memory WHERE kpi_id = 'mem-kpi'").Scan(&count)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(count).To(Equal(1))
 		})
 	})
 

--- a/internal/database/sqlite_test.go
+++ b/internal/database/sqlite_test.go
@@ -259,7 +259,7 @@ var _ = Describe("Sqlite", func() {
 			Expect(categories).To(BeEmpty())
 		})
 
-		It("should return all distinct categories", func() {
+		It("should return all distinct categories with KPI counts", func() {
 			_, err := sqliteDB.EnsureCategoryTable(db, "cpu", "node-cpu")
 			Expect(err).NotTo(HaveOccurred())
 			_, err = sqliteDB.EnsureCategoryTable(db, "cpu", "container-cpu")
@@ -272,8 +272,10 @@ var _ = Describe("Sqlite", func() {
 			Expect(categories).To(HaveLen(2))
 			Expect(categories[0].Category).To(Equal("cpu"))
 			Expect(categories[0].TableName).To(Equal("kpi_cpu"))
+			Expect(categories[0].KPICount).To(Equal(2))
 			Expect(categories[1].Category).To(Equal("memory"))
 			Expect(categories[1].TableName).To(Equal("kpi_memory"))
+			Expect(categories[1].KPICount).To(Equal(1))
 		})
 	})
 

--- a/internal/output/collection_printer.go
+++ b/internal/output/collection_printer.go
@@ -12,6 +12,7 @@ var printMutex sync.Mutex
 type QueryInfo struct {
 	QueryID      string
 	PromQuery    string
+	Category     string
 	Frequency    time.Duration
 	SampleNumber int
 	TotalSamples int
@@ -42,6 +43,9 @@ func PrintQueryResult(info QueryInfo, result QueryResult) {
 	}
 
 	fmt.Printf("  Query: %s\n", info.PromQuery)
+	if info.Category != "" {
+		fmt.Printf("  Category: %s\n", info.Category)
+	}
 	if info.QueryType == "range" {
 		fmt.Printf("  Query Type: range (step: %s, since: %s, until: %s)\n",
 			info.Step, info.Since.Format(time.RFC3339), info.Until.Format(time.RFC3339))

--- a/internal/output/csv.go
+++ b/internal/output/csv.go
@@ -10,17 +10,16 @@ func (p *Printer) printKPIsCSV(records []KPIRecord) error {
 	w := csv.NewWriter(p.writer)
 	defer w.Flush()
 
-	// Write header
-	if err := w.Write([]string{"id", "kpi_name", "cluster", "value", "timestamp", "execution_time", "labels"}); err != nil {
+	if err := w.Write([]string{"id", "kpi_name", "category", "cluster", "value", "timestamp", "execution_time", "labels"}); err != nil {
 		return err
 	}
 
-	// Write records
 	for _, r := range records {
 		labelsJSON, _ := json.Marshal(r.Labels)
 		row := []string{
 			strconv.FormatInt(r.ID, 10),
 			r.KPIName,
+			r.Category,
 			r.Cluster,
 			strconv.FormatFloat(r.Value, 'f', 6, 64),
 			strconv.FormatFloat(r.Timestamp, 'f', 0, 64),

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -36,6 +36,7 @@ func ParseFormat(s string) (Format, error) {
 type KPIRecord struct {
 	ID            int64             `json:"id"`
 	KPIName       string            `json:"kpi_name"`
+	Category      string            `json:"category,omitempty"`
 	Cluster       string            `json:"cluster"`
 	Value         float64           `json:"value"`
 	Timestamp     float64           `json:"timestamp"`

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -59,6 +59,13 @@ type ErrorRecord struct {
 	ErrorCount int    `json:"error_count"`
 }
 
+// CategoryRecord represents a category info record for output
+type CategoryRecord struct {
+	Category  string `json:"category"`
+	TableName string `json:"table_name"`
+	KPICount  int    `json:"kpi_count"`
+}
+
 // Printer handles output formatting
 type Printer struct {
 	format     Format

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -12,33 +12,30 @@ func (p *Printer) printKPIsTable(records []KPIRecord) error {
 	w := tabwriter.NewWriter(p.writer, 0, 0, 2, ' ', 0)
 
 	if p.noTruncate {
-		// Display without labels column, print pretty JSON below each entry
-		_, _ = fmt.Fprintln(w, "ID\tKPI_NAME\tCLUSTER\tVALUE\tTIMESTAMP\tEXECUTION_TIME")
-		_, _ = fmt.Fprintln(w, "---\t---\t---\t---\t---\t---")
+		_, _ = fmt.Fprintln(w, "ID\tKPI_NAME\tCATEGORY\tCLUSTER\tVALUE\tTIMESTAMP\tEXECUTION_TIME")
+		_, _ = fmt.Fprintln(w, "---\t---\t---\t---\t---\t---\t---")
 
 		for _, r := range records {
-			_, _ = fmt.Fprintf(w, "%d\t%s\t%s\t%.6f\t%.0f\t%s\n",
-				r.ID, r.KPIName, r.Cluster, r.Value,
+			_, _ = fmt.Fprintf(w, "%d\t%s\t%s\t%s\t%.6f\t%.0f\t%s\n",
+				r.ID, r.KPIName, categoryDisplay(r.Category), r.Cluster, r.Value,
 				r.Timestamp, r.ExecutionTime.Format("2006-01-02 15:04:05"))
 			_ = w.Flush()
 
-			// Print pretty labels below the entry
 			_, _ = fmt.Fprintln(p.writer, "  Labels:")
 			p.printPrettyLabels(r.Labels)
 			_, _ = fmt.Fprintln(p.writer)
 		}
 	} else {
-		// Default: display with truncated labels in table
-		_, _ = fmt.Fprintln(w, "ID\tKPI_NAME\tCLUSTER\tVALUE\tTIMESTAMP\tEXECUTION_TIME\tLABELS")
-		_, _ = fmt.Fprintln(w, "---\t---\t---\t---\t---\t---\t---")
+		_, _ = fmt.Fprintln(w, "ID\tKPI_NAME\tCATEGORY\tCLUSTER\tVALUE\tTIMESTAMP\tEXECUTION_TIME\tLABELS")
+		_, _ = fmt.Fprintln(w, "---\t---\t---\t---\t---\t---\t---\t---")
 
 		for _, r := range records {
 			labels := r.LabelsRaw
 			if len(labels) > 50 {
 				labels = labels[:47] + "..."
 			}
-			_, _ = fmt.Fprintf(w, "%d\t%s\t%s\t%.6f\t%.0f\t%s\t%s\n",
-				r.ID, r.KPIName, r.Cluster, r.Value,
+			_, _ = fmt.Fprintf(w, "%d\t%s\t%s\t%s\t%.6f\t%.0f\t%s\t%s\n",
+				r.ID, r.KPIName, categoryDisplay(r.Category), r.Cluster, r.Value,
 				r.Timestamp, r.ExecutionTime.Format("2006-01-02 15:04:05"), labels)
 		}
 		_ = w.Flush()
@@ -46,6 +43,13 @@ func (p *Printer) printKPIsTable(records []KPIRecord) error {
 
 	_, _ = fmt.Fprintf(p.writer, "\nTotal results: %d\n", len(records))
 	return nil
+}
+
+func categoryDisplay(category string) string {
+	if category == "" {
+		return "-"
+	}
+	return category
 }
 
 func (p *Printer) printPrettyLabels(labels map[string]string) {

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -86,3 +86,15 @@ func PrintErrorsTable(records []ErrorRecord) {
 	}
 	_ = w.Flush()
 }
+
+// PrintCategoriesTable prints category records as a table to stdout
+func PrintCategoriesTable(records []CategoryRecord) {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(w, "CATEGORY\tTABLE\tKPIS")
+	_, _ = fmt.Fprintln(w, "---\t---\t---")
+
+	for _, c := range records {
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%d\n", c.Category, c.TableName, c.KPICount)
+	}
+	_ = w.Flush()
+}

--- a/internal/prometheus/client.go
+++ b/internal/prometheus/client.go
@@ -88,6 +88,7 @@ func RunQueries(kpisToRun config.KPIs, flags config.InputFlags, sampleNumber int
 		queryInfo := output.QueryInfo{
 			QueryID:      query.ID,
 			PromQuery:    query.PromQuery,
+			Category:     query.Category,
 			Frequency:    frequency,
 			SampleNumber: sampleNumber,
 			TotalSamples: totalSamples,
@@ -186,7 +187,7 @@ func executeQuery(ctx context.Context, v1api promv1.API, db *sql.DB, dbImpl data
 
 	log.Printf("[%s] Database write starting", info.QueryID)
 	storeStart := time.Now()
-	err = dbImpl.StoreQueryResults(db, clusterID, info.QueryID, result)
+	err = dbImpl.StoreQueryResults(db, clusterID, info.QueryID, info.Category, result)
 	storeDuration := time.Since(storeStart)
 	log.Printf("[%s] Database write completed in %s", info.QueryID, storeDuration.Round(time.Millisecond))
 

--- a/internal/prometheus/client.go
+++ b/internal/prometheus/client.go
@@ -77,6 +77,11 @@ func RunQueries(kpisToRun config.KPIs, flags config.InputFlags, sampleNumber int
 		return fmt.Errorf("failed to get cluster ID: %v", err)
 	}
 
+	// Verify that no KPI has changed its category since the last run
+	if err := dbImpl.ValidateCategoryConsistency(db, kpisToRun.Queries); err != nil {
+		return fmt.Errorf("category consistency check failed: %w", err)
+	}
+
 	// Create Prometheus client
 	v1api, err := setupPromClient(flags.ThanosURL, flags.BearerToken, flags.InsecureTLS)
 	if err != nil {

--- a/kpi-profiles/README.md
+++ b/kpi-profiles/README.md
@@ -88,12 +88,19 @@ kpi-collector kpis generate --profile hub --all -f /path/to/hub-kpis.yaml
 
 # Overwrite an existing file
 kpi-collector kpis generate --profile ran --all --overwrite
+
+# Generate without category fields (single-table storage)
+kpi-collector kpis generate --profile ran --all --uncategorized
 ```
 
 By default the output file is named `<profile>-kpis.yaml` in the current
 directory. If the file already exists, the command will refuse to overwrite it
 unless you pass `--overwrite`. In interactive mode (the default), you are
 prompted per category — use `--all` to skip prompts and include everything.
+
+Generated KPIs include a `category` field by default, which routes metrics into
+separate database tables for better query performance. Pass `--uncategorized`
+to omit the `category` field and store all metrics in a single table.
 
 Once generated, you can edit the file to fine-tune individual KPIs before
 passing it to the collector.

--- a/kpi-profiles/kpis-core.yaml
+++ b/kpi-profiles/kpis-core.yaml
@@ -15,16 +15,19 @@ kpis:
   # Unit: seconds. Excludes WATCH (long-poll) requests which skew the histogram.
   - id: apiserver-request-duration-99p
     promquery: histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket{verb!="WATCH"}[5m])) by (verb, le))
+    category: apiserver
 
   # API request throughput by verb and HTTP status code.
   # Unit: requests/second.
   - id: apiserver-request-rate
     promquery: sum(rate(apiserver_request_total[5m])) by (verb, code)
+    category: apiserver
 
   # API server 5xx error rate by verb.
   # Unit: errors/second. Non-zero values indicate server-side failures.
   - id: apiserver-error-rate
     promquery: sum(rate(apiserver_request_total{code=~"5.."}[5m])) by (verb)
+    category: apiserver
 
   # --- etcd ---
 
@@ -32,11 +35,13 @@ kpis:
   # Unit: bytes. Growth over time can indicate excessive object churn or missing compaction.
   - id: etcd-db-size
     promquery: etcd_mvcc_db_total_size_in_bytes
+    category: etcd
 
   # 99th-percentile WAL fsync latency — time to flush writes to disk.
   # Unit: seconds. Values above 10 ms often correlate with disk I/O bottlenecks.
   - id: etcd-disk-wal-fsync-duration-99p
     promquery: histogram_quantile(0.99, sum(rate(etcd_disk_wal_fsync_duration_seconds_bucket[5m])) by (le))
+    category: etcd
 
   # Number of etcd leader elections in the past hour.
   # Unit: count. Frequent changes suggest network instability or slow disks.
@@ -44,6 +49,7 @@ kpis:
   - id: etcd-leader-changes
     promquery: increase(etcd_server_leader_changes_seen_total[1h])
     sample-frequency: 5m
+    category: etcd
 
   # --- CPU ---
 
@@ -51,11 +57,13 @@ kpis:
   # Unit: percentage (0–100).
   - id: cpu-node-total
     promquery: 100 - (avg by (instance) (rate(node_cpu_seconds_total{mode="idle"}[5m])) * 100)
+    category: cpu
 
   # CPU usage summed by namespace to identify noisy tenants.
   # Unit: cores. Excludes infra containers (pause/"POD").
   - id: cpu-usage-by-namespace
     promquery: sort_desc(sum(rate(container_cpu_usage_seconds_total{container!="",container!="POD"}[5m])) by (namespace))
+    category: cpu
 
   # --- Memory ---
 
@@ -63,11 +71,13 @@ kpis:
   # Unit: percentage (0–100).
   - id: memory-node-used-percentage
     promquery: 100 * (1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes))
+    category: memory
 
   # Working-set memory summed by namespace.
   # Unit: bytes. Helps find namespaces consuming the most memory.
   - id: memory-usage-by-namespace
     promquery: sort_desc(sum(container_memory_working_set_bytes{container!="",container!="POD"}) by (namespace))
+    category: memory
 
   # --- Network ---
 
@@ -75,11 +85,13 @@ kpis:
   # Unit: bytes/second. Excludes loopback, veth, bridge, and OVS virtual interfaces.
   - id: network-node-rx-bytes
     promquery: sort_desc(rate(node_network_receive_bytes_total{device!~"lo|veth.*|br.*|ovs.*"}[5m]))
+    category: network
 
   # Bytes transmitted per second on physical node interfaces.
   # Unit: bytes/second.
   - id: network-node-tx-bytes
     promquery: sort_desc(rate(node_network_transmit_bytes_total{device!~"lo|veth.*|br.*|ovs.*"}[5m]))
+    category: network
 
   # --- Ingress ---
 
@@ -88,6 +100,7 @@ kpis:
   # Requires: openshift-router (HAProxy-based, default ingress controller).
   - id: ingress-request-rate
     promquery: sum(rate(haproxy_server_http_responses_total[5m])) by (code)
+    category: network
 
   # --- Disk / Storage ---
 
@@ -95,21 +108,25 @@ kpis:
   # Unit: percentage (0–100). Monitors the / mountpoint, excludes tmpfs.
   - id: disk-usage-percentage
     promquery: 100 - ((node_filesystem_avail_bytes{mountpoint="/",fstype!="tmpfs"} / node_filesystem_size_bytes{mountpoint="/",fstype!="tmpfs"}) * 100)
+    category: disk
 
   # PersistentVolume usage as a percentage of capacity.
   # Unit: percentage (0–100). Covers all PVCs mounted by the kubelet.
   - id: pv-usage-percentage
     promquery: 100 * (1 - (kubelet_volume_stats_available_bytes / kubelet_volume_stats_capacity_bytes))
+    category: disk
 
   # Bytes read per second from physical block devices.
   # Unit: bytes/second. Excludes device-mapper (dm-*) virtual devices.
   - id: disk-io-read-bytes
     promquery: sort_desc(rate(node_disk_read_bytes_total{device!~"dm-.*"}[5m]))
+    category: disk
 
   # Bytes written per second to physical block devices.
   # Unit: bytes/second.
   - id: disk-io-write-bytes
     promquery: sort_desc(rate(node_disk_written_bytes_total{device!~"dm-.*"}[5m]))
+    category: disk
 
   # --- System Load ---
 
@@ -117,11 +134,13 @@ kpis:
   # Unit: dimensionless (approximate number of runnable + uninterruptible tasks).
   - id: node-load-1min
     promquery: node_load1
+    category: system
 
   # 5-minute load average. Smoother than the 1-min value.
   # Unit: dimensionless.
   - id: node-load-5min
     promquery: node_load5
+    category: system
 
   # --- Pod Health ---
 
@@ -129,11 +148,13 @@ kpis:
   # Unit: count (monotonically increasing). Sorted to surface crashlooping pods.
   - id: pod-restart-count
     promquery: sort_desc(sum(kube_pod_container_status_restarts_total) by (namespace, pod))
+    category: pod-health
 
   # Number of pods in Pending or Failed phase, grouped by namespace and phase.
   # Unit: count. Non-zero values indicate scheduling or runtime issues.
   - id: pod-status-not-ready
     promquery: count(kube_pod_status_phase{phase=~"Pending|Failed"}) by (namespace, phase)
+    category: pod-health
 
   # --- Cluster Info ---
 
@@ -142,3 +163,4 @@ kpis:
   - id: cluster-uptime
     promquery: max(time() - process_start_time_seconds{job="kubelet"})
     run-once: true
+    category: cluster

--- a/kpi-profiles/kpis-hub.yaml
+++ b/kpi-profiles/kpis-hub.yaml
@@ -15,16 +15,19 @@ kpis:
   # Unit: seconds. Excludes WATCH (long-poll) requests which skew the histogram.
   - id: apiserver-request-duration-99p
     promquery: histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket{verb!="WATCH"}[5m])) by (verb, le))
+    category: apiserver
 
   # API request throughput by verb and HTTP status code.
   # Unit: requests/second.
   - id: apiserver-request-rate
     promquery: sum(rate(apiserver_request_total[5m])) by (verb, code)
+    category: apiserver
 
   # API server 5xx error rate by verb.
   # Unit: errors/second. Non-zero values indicate server-side failures.
   - id: apiserver-error-rate
     promquery: sum(rate(apiserver_request_total{code=~"5.."}[5m])) by (verb)
+    category: apiserver
 
   # --- etcd ---
 
@@ -32,11 +35,13 @@ kpis:
   # Unit: bytes. Growth over time can indicate excessive object churn or missing compaction.
   - id: etcd-db-size
     promquery: etcd_mvcc_db_total_size_in_bytes
+    category: etcd
 
   # 99th-percentile WAL fsync latency — time to flush writes to disk.
   # Unit: seconds. Values above 10 ms often correlate with disk I/O bottlenecks.
   - id: etcd-disk-wal-fsync-duration-99p
     promquery: histogram_quantile(0.99, sum(rate(etcd_disk_wal_fsync_duration_seconds_bucket[5m])) by (le))
+    category: etcd
 
   # Number of etcd leader elections in the past hour.
   # Unit: count. Frequent changes suggest network instability or slow disks.
@@ -44,6 +49,7 @@ kpis:
   - id: etcd-leader-changes
     promquery: increase(etcd_server_leader_changes_seen_total[1h])
     sample-frequency: 5m
+    category: etcd
 
   # --- CPU ---
 
@@ -51,6 +57,7 @@ kpis:
   # Unit: percentage (0–100).
   - id: cpu-node-total
     promquery: 100 - (avg by (instance) (rate(node_cpu_seconds_total{mode="idle"}[5m])) * 100)
+    category: cpu
 
   # --- Memory ---
 
@@ -58,6 +65,7 @@ kpis:
   # Unit: percentage (0–100).
   - id: memory-node-used-percentage
     promquery: 100 * (1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes))
+    category: memory
 
   # --- ACM (Advanced Cluster Management) ---
   # Requires: ACM operator installed (open-cluster-management, multicluster-engine namespaces).
@@ -66,17 +74,20 @@ kpis:
   # Unit: cores. Sorted descending to surface top consumers.
   - id: acm-cpu-usage
     promquery: sort_desc(sum(rate(container_cpu_usage_seconds_total{container!="",container!="POD",namespace=~"open-cluster-management.*|multicluster-engine"}[5m])) by (namespace, pod))
+    category: acm
 
   # Working-set memory per pod in ACM and multicluster-engine namespaces.
   # Unit: bytes.
   - id: acm-memory-usage
     promquery: sort_desc(sum(container_memory_working_set_bytes{container!="",container!="POD",namespace=~"open-cluster-management.*|multicluster-engine"}) by (namespace, pod))
+    category: acm
 
   # Total number of clusters managed by ACM.
   # Unit: count. Sampled every 5 min since fleet size changes infrequently.
   - id: acm-managed-clusters
     promquery: count(acm_managed_cluster_info)
     sample-frequency: 5m
+    category: acm
 
   # Number of root governance policies in NonCompliant state.
   # Unit: count. Non-zero means one or more policies are violated.
@@ -85,6 +96,7 @@ kpis:
   - id: acm-policy-noncompliant
     promquery: count(policy_governance_info{type="root",compliant="NonCompliant"})
     sample-frequency: 5m
+    category: acm
 
   # --- GitOps ---
   # Requires: OpenShift GitOps operator installed (openshift-gitops namespace).
@@ -93,11 +105,13 @@ kpis:
   # Unit: cores.
   - id: gitops-cpu-usage
     promquery: sort_desc(sum(rate(container_cpu_usage_seconds_total{container!="",container!="POD",namespace=~"openshift-gitops.*"}[5m])) by (namespace, pod))
+    category: gitops
 
   # Working-set memory per pod in OpenShift GitOps namespaces.
   # Unit: bytes.
   - id: gitops-memory-usage
     promquery: sort_desc(sum(container_memory_working_set_bytes{container!="",container!="POD",namespace=~"openshift-gitops.*"}) by (namespace, pod))
+    category: gitops
 
   # --- Disk / Storage ---
 
@@ -105,11 +119,13 @@ kpis:
   # Unit: percentage (0–100). Monitors the / mountpoint, excludes tmpfs.
   - id: disk-usage-percentage
     promquery: 100 - ((node_filesystem_avail_bytes{mountpoint="/",fstype!="tmpfs"} / node_filesystem_size_bytes{mountpoint="/",fstype!="tmpfs"}) * 100)
+    category: disk
 
   # PersistentVolume usage as a percentage of capacity.
   # Unit: percentage (0–100). Covers all PVCs mounted by the kubelet.
   - id: pv-usage-percentage
     promquery: 100 * (1 - (kubelet_volume_stats_available_bytes / kubelet_volume_stats_capacity_bytes))
+    category: disk
 
   # --- Network ---
 
@@ -117,11 +133,13 @@ kpis:
   # Unit: bytes/second. Excludes loopback, veth, bridge, and OVS virtual interfaces.
   - id: network-node-rx-bytes
     promquery: sort_desc(rate(node_network_receive_bytes_total{device!~"lo|veth.*|br.*|ovs.*"}[5m]))
+    category: network
 
   # Bytes transmitted per second on physical node interfaces.
   # Unit: bytes/second.
   - id: network-node-tx-bytes
     promquery: sort_desc(rate(node_network_transmit_bytes_total{device!~"lo|veth.*|br.*|ovs.*"}[5m]))
+    category: network
 
   # --- System Load ---
 
@@ -129,6 +147,7 @@ kpis:
   # Unit: dimensionless (approximate number of runnable + uninterruptible tasks).
   - id: node-load-1min
     promquery: node_load1
+    category: system
 
   # --- Pod Health ---
 
@@ -136,11 +155,13 @@ kpis:
   # Unit: count (monotonically increasing). Sorted to surface crashlooping pods.
   - id: pod-restart-count
     promquery: sort_desc(sum(kube_pod_container_status_restarts_total) by (namespace, pod))
+    category: pod-health
 
   # Number of pods in Pending or Failed phase, grouped by namespace and phase.
   # Unit: count. Non-zero values indicate scheduling or runtime issues.
   - id: pod-status-not-ready
     promquery: count(kube_pod_status_phase{phase=~"Pending|Failed"}) by (namespace, phase)
+    category: pod-health
 
   # --- Cluster Info ---
 
@@ -149,3 +170,4 @@ kpis:
   - id: cluster-uptime
     promquery: max(time() - process_start_time_seconds{job="kubelet"})
     run-once: true
+    category: cluster

--- a/kpi-profiles/kpis-ran.yaml
+++ b/kpi-profiles/kpis-ran.yaml
@@ -16,33 +16,39 @@ kpis:
   # Unit: ratio 0–1 (multiply by 100 for percentage).
   - id: cpu-reserved-cores
     promquery: avg by (cpu) (rate(node_cpu_seconds_total{cpu=~"{{RESERVED_CPUS}}",mode!="idle"}[5m]))
+    category: cpu
 
   # Average per-core utilization of isolated (workload) CPUs.
   # Unit: ratio 0–1.
   - id: cpu-isolated-cores
     promquery: avg by (cpu) (rate(node_cpu_seconds_total{cpu=~"{{ISOLATED_CPUS}}",mode!="idle"}[5m]))
+    category: cpu
 
   # Overall node CPU usage averaged across all cores.
   # Unit: percentage (0–100).
   # Subtracts idle ratio from 100 to get busy percentage.
   - id: cpu-node-total
     promquery: 100 - (avg by (instance) (rate(node_cpu_seconds_total{mode="idle"}[5m])) * 100)
+    category: cpu
 
   # CPU usage of cgroup processes under /system.slice (systemd services like kubelet, crio).
   # Unit: cores (seconds/second). Sorted descending to surface top consumers.
   - id: cpu-system-slice
     promquery: sort_desc(rate(container_cpu_usage_seconds_total{id=~"/system.slice/.*"}[5m]))
+    category: cpu
 
   # CPU usage of cgroup processes under /ovs.slice (Open vSwitch daemons).
   # Unit: cores. Helps track OVS overhead on the data plane.
   # Requires: OVS running under a dedicated cgroup slice.
   - id: cpu-ovs-slice
     promquery: sort_desc(rate(container_cpu_usage_seconds_total{id=~"/ovs.slice/.*"}[5m]))
+    category: cpu
 
   # Average CPU consumed per pod over a 5-minute window.
   # Unit: cores. Uses the pre-computed recording rule pod:container_cpu_usage:sum.
   - id: cpu-pods-average
     promquery: sort_desc(avg_over_time(pod:container_cpu_usage:sum[5m]))
+    category: cpu
 
   # --- Memory ---
 
@@ -50,17 +56,20 @@ kpis:
   # Unit: percentage (0–100).
   - id: memory-node-used-percentage
     promquery: 100 * (1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes))
+    category: memory
 
   # Working-set memory per pod (RSS + cache in active use, excludes reclaimable cache).
   # Unit: bytes. Grouped by pod and namespace.
   # Filters out the pause container ("POD") and empty container names.
   - id: memory-working-set-by-pod
     promquery: sort_desc(sum(container_memory_working_set_bytes{container!="",container!="POD"}) by (pod, namespace))
+    category: memory
 
   # Resident Set Size (RSS) per pod — physical memory that cannot be reclaimed.
   # Unit: bytes. Better indicator of true memory pressure than working set.
   - id: memory-rss-by-pod
     promquery: sort_desc(sum(container_memory_rss{container!="",container!="POD"}) by (pod, namespace))
+    category: memory
 
   # --- Hugepages ---
   # Unit: count of pages. hugepagesize filter is in KiB (1048576 = 1 GiB, 2048 = 2 MiB).
@@ -69,18 +78,22 @@ kpis:
   # Free 1 GiB hugepages on each node.
   - id: hugepages-1g-free
     promquery: node_hugepages_free{hugepagesize="1048576"}
+    category: memory
 
   # Total 1 GiB hugepages allocated on each node.
   - id: hugepages-1g-total
     promquery: node_hugepages_total{hugepagesize="1048576"}
+    category: memory
 
   # Free 2 MiB hugepages on each node.
   - id: hugepages-2m-free
     promquery: node_hugepages_free{hugepagesize="2048"}
+    category: memory
 
   # Total 2 MiB hugepages allocated on each node.
   - id: hugepages-2m-total
     promquery: node_hugepages_total{hugepagesize="2048"}
+    category: memory
 
   # --- Network (node) ---
   # All node network KPIs exclude virtual interfaces (loopback, veth, bridge, OVS)
@@ -89,29 +102,35 @@ kpis:
   # Bytes received per second. Unit: bytes/second.
   - id: network-node-rx-bytes
     promquery: sort_desc(rate(node_network_receive_bytes_total{device!~"lo|veth.*|br.*|ovs.*"}[5m]))
+    category: network
 
   # Bytes transmitted per second. Unit: bytes/second.
   - id: network-node-tx-bytes
     promquery: sort_desc(rate(node_network_transmit_bytes_total{device!~"lo|veth.*|br.*|ovs.*"}[5m]))
+    category: network
 
   # Receive errors per second. Unit: errors/second.
   # Non-zero values may indicate NIC, driver, or cable issues.
   - id: network-node-rx-errors
     promquery: sort_desc(rate(node_network_receive_errs_total{device!~"lo|veth.*|br.*|ovs.*"}[5m]))
+    category: network
 
   # Transmit errors per second. Unit: errors/second.
   - id: network-node-tx-errors
     promquery: sort_desc(rate(node_network_transmit_errs_total{device!~"lo|veth.*|br.*|ovs.*"}[5m]))
+    category: network
 
   # Bytes received per second on the primary container interface (eth0).
   # Unit: bytes/second. Shows per-pod network ingress.
   - id: network-container-rx-bytes
     promquery: sort_desc(rate(container_network_receive_bytes_total{interface="eth0"}[5m]))
+    category: network
 
   # Bytes transmitted per second on the primary container interface (eth0).
   # Unit: bytes/second. Shows per-pod network egress.
   - id: network-container-tx-bytes
     promquery: sort_desc(rate(container_network_transmit_bytes_total{interface="eth0"}[5m]))
+    category: network
 
   # --- PTP (Precision Time Protocol) ---
   # Requires: ptp-operator with linuxptp daemons (ptp4l, phc2sys) running.
@@ -120,21 +139,25 @@ kpis:
   # Unit: nanoseconds. iface=CLOCK_REALTIME means system clock vs PTP hardware clock.
   - id: ptp-offset-master
     promquery: openshift_ptp_offset_ns{iface="CLOCK_REALTIME",process="phc2sys"}
+    category: ptp
 
   # Maximum PTP offset observed since the last metric reset.
   # Unit: nanoseconds. Useful for detecting worst-case clock drift.
   - id: ptp-max-offset-master
     promquery: openshift_ptp_max_offset_ns{iface="CLOCK_REALTIME",process="phc2sys"}
+    category: ptp
 
   # PTP clock synchronization state per node.
   # Unit: enum (0=FREERUN, 1=LOCKED, 2=HOLDOVER). LOCKED means synchronized.
   - id: ptp-clock-state
     promquery: openshift_ptp_clock_state
+    category: ptp
 
   # Role of each PTP-capable interface (master, slave, passive, listening).
   # Unit: enum (role label). Helps verify expected PTP topology.
   - id: ptp-interface-role
     promquery: openshift_ptp_interface_role
+    category: ptp
 
   # --- Disk I/O ---
 
@@ -142,16 +165,19 @@ kpis:
   # Unit: bytes/second. Excludes device-mapper (dm-*) virtual devices.
   - id: disk-io-read-bytes
     promquery: sort_desc(rate(node_disk_read_bytes_total{device!~"dm-.*"}[5m]))
+    category: disk
 
   # Bytes written per second to physical block devices.
   # Unit: bytes/second.
   - id: disk-io-write-bytes
     promquery: sort_desc(rate(node_disk_written_bytes_total{device!~"dm-.*"}[5m]))
+    category: disk
 
   # Root filesystem usage as a percentage.
   # Unit: percentage (0–100). Monitors the / mountpoint, excludes tmpfs.
   - id: disk-usage-percentage
     promquery: 100 - ((node_filesystem_avail_bytes{mountpoint="/",fstype!="tmpfs"} / node_filesystem_size_bytes{mountpoint="/",fstype!="tmpfs"}) * 100)
+    category: disk
 
   # --- OVN-Kubernetes ---
   # Requires: OVN-Kubernetes network plugin (default on OpenShift 4.x).
@@ -160,11 +186,13 @@ kpis:
   # Unit: cores.
   - id: ovn-controller-cpu
     promquery: rate(container_cpu_usage_seconds_total{container="ovn-controller"}[5m])
+    category: network
 
   # Working-set memory of the ovn-controller container.
   # Unit: bytes.
   - id: ovn-controller-memory
     promquery: container_memory_working_set_bytes{container="ovn-controller"}
+    category: network
 
   # --- Kernel Scheduling ---
 
@@ -172,11 +200,13 @@ kpis:
   # Unit: switches/second. High values may indicate excessive scheduling overhead.
   - id: node-context-switches
     promquery: rate(node_context_switches_total[5m])
+    category: system
 
   # Hardware and software interrupts per second.
   # Unit: interrupts/second. Spikes may correlate with network traffic or device activity.
   - id: node-interrupts
     promquery: rate(node_intr_total[5m])
+    category: system
 
   # --- Pod Health ---
 
@@ -184,3 +214,4 @@ kpis:
   # Unit: count (monotonically increasing). Sorted to surface crashlooping pods.
   - id: pod-restart-count
     promquery: sort_desc(sum(kube_pod_container_status_restarts_total) by (namespace, pod))
+    category: pod-health

--- a/kpis.yaml.template
+++ b/kpis.yaml.template
@@ -7,6 +7,8 @@
 #   id:               Unique identifier (used in database and output)
 #   promquery:        PromQL query to execute against Prometheus/Thanos
 #   sample-frequency: (Optional) Override global --frequency for this KPI
+#   category:         (Optional) Storage category — routes metrics to a dedicated kpi_<category>
+#                     table for better query performance at scale
 #   query-type:       (Optional) "instant" (default) or "range"
 #   range:            (Required for range) Nested object with step, since, and optionally until
 #     step:           Resolution between points in query_range (e.g. 30s)
@@ -32,8 +34,10 @@ kpis:
     promquery: avg by (instance) (rate(node_cpu_seconds_total{mode!="idle"}[5m]))
 
   # Memory currently in use per node — sampled less frequently (every 2 min)
+  # The category field routes this KPI to the kpi_memory table
   - id: node-memory-usage
     promquery: node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes
+    category: memory
     sample-frequency: 120
 
   # CPU usage on reserved cores (dynamically fetched from PerformanceProfile)


### PR DESCRIPTION
Final merge of the `category-tables` feature branch. Adds an optional `category` field to KPI definitions that routes metrics into dedicated `kpi_<category>` database tables instead of the shared `query_results` table, improving query performance at scale.
This branch was developed across 8 PRs (#109, #114-#120), each reviewed and merged into `category-tables`. This PR merges the complete feature into `main`.

### What's included
- **Config**: `category` field on KPI YAML entries with sanitization and 32-char limit
- **Write path**: `EnsureCategoryTable` creates per-category tables on demand; `kpi_registry` tracks KPI-to-table mappings
- **Read path**: `db show kpis` queries all tables (UNION ALL) or filters by `--category`/`--name`; `db show categories` lists registered categories
- **Delete path**: `db remove kpis --category` drops data from a single category table
- **Validation**: startup check prevents category changes between runs
- **Grafana**: both SQLite and PostgreSQL dashboards support a Category variable with `${_table}` routing
- **KPI profiles**: all built-in profiles (`ran`, `core`, `hub`) tagged with categories; `--uncategorized` flag to opt out
- **Schema package**: all category DDL and DML centralized in `internal/database/schema/`
- **Both backends**: full SQLite and PostgreSQL support with integration tests
