### PR TITLE
Grafana: replaced hardcoded label filters with dynamic key/value pairs

### DIFF
--- a/grafana-templates/postgres-dashboard.json
+++ b/grafana-templates/postgres-dashboard.json
@@ -290,7 +290,7 @@
             "uid": "kpi-datasource"
           },
           "format": "table",
-          "rawSql": "SELECT to_timestamp(timestamp_value) AS time, metric_value, metric_labels FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR metric_labels->>'node' = '${node}' OR metric_labels->>'instance' = '${node}') AND ('${job}' = 'All' OR metric_labels->>'job' = '${job}') AND ('${pod}' = 'All' OR metric_labels->>'pod' = '${pod}') AND ('${container}' = 'All' OR metric_labels->>'container' = '${container}') AND timestamp_value >= $__from / 1000 AND timestamp_value < $__to / 1000 ORDER BY time ASC",
+          "rawSql": "SELECT to_timestamp(timestamp_value) AS time, metric_value, metric_labels FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${filter1_key}' = 'All' OR '${filter1_value}' = 'All' OR metric_labels->>'${filter1_key}' = '${filter1_value}') AND ('${filter2_key}' = 'All' OR '${filter2_value}' = 'All' OR metric_labels->>'${filter2_key}' = '${filter2_value}') AND ('${filter3_key}' = 'All' OR '${filter3_value}' = 'All' OR metric_labels->>'${filter3_key}' = '${filter3_value}') AND timestamp_value >= $__from / 1000 AND timestamp_value < $__to / 1000 ORDER BY time ASC",
           "refId": "A",
           "timeColumns": [
             "time",
@@ -303,7 +303,7 @@
             "uid": "kpi-datasource"
           },
           "format": "table",
-          "rawSql": "SELECT 'Max Value' AS metric_labels, MAX(metric_value) AS metric_value, to_timestamp($__from/1000) AS time FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR metric_labels->>'node' = '${node}' OR metric_labels->>'instance' = '${node}') AND ('${job}' = 'All' OR metric_labels->>'job' = '${job}') AND ('${pod}' = 'All' OR metric_labels->>'pod' = '${pod}') AND ('${container}' = 'All' OR metric_labels->>'container' = '${container}')",
+          "rawSql": "SELECT 'Max Value' AS metric_labels, MAX(metric_value) AS metric_value, to_timestamp($__from/1000) AS time FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${filter1_key}' = 'All' OR '${filter1_value}' = 'All' OR metric_labels->>'${filter1_key}' = '${filter1_value}') AND ('${filter2_key}' = 'All' OR '${filter2_value}' = 'All' OR metric_labels->>'${filter2_key}' = '${filter2_value}') AND ('${filter3_key}' = 'All' OR '${filter3_value}' = 'All' OR metric_labels->>'${filter3_key}' = '${filter3_value}')",
           "refId": "B",
           "legendFormat": "Max Value",
           "timeColumns": [
@@ -317,7 +317,7 @@
             "uid": "kpi-datasource"
           },
           "format": "table",
-          "rawSql": "SELECT 'Min Value' AS metric_labels, MIN(metric_value) AS metric_value, to_timestamp($__from/1000) AS time FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR metric_labels->>'node' = '${node}' OR metric_labels->>'instance' = '${node}') AND ('${job}' = 'All' OR metric_labels->>'job' = '${job}') AND ('${pod}' = 'All' OR metric_labels->>'pod' = '${pod}') AND ('${container}' = 'All' OR metric_labels->>'container' = '${container}')",
+          "rawSql": "SELECT 'Min Value' AS metric_labels, MIN(metric_value) AS metric_value, to_timestamp($__from/1000) AS time FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${filter1_key}' = 'All' OR '${filter1_value}' = 'All' OR metric_labels->>'${filter1_key}' = '${filter1_value}') AND ('${filter2_key}' = 'All' OR '${filter2_value}' = 'All' OR metric_labels->>'${filter2_key}' = '${filter2_value}') AND ('${filter3_key}' = 'All' OR '${filter3_value}' = 'All' OR metric_labels->>'${filter3_key}' = '${filter3_value}')",
           "refId": "C",
           "legendFormat": "Min Value",
           "timeColumns": [
@@ -331,7 +331,7 @@
             "uid": "kpi-datasource"
           },
           "format": "table",
-          "rawSql": "SELECT 'Average Value' AS metric_labels, AVG(metric_value) AS metric_value, to_timestamp($__from/1000) AS time FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR metric_labels->>'node' = '${node}' OR metric_labels->>'instance' = '${node}') AND ('${job}' = 'All' OR metric_labels->>'job' = '${job}') AND ('${pod}' = 'All' OR metric_labels->>'pod' = '${pod}') AND ('${container}' = 'All' OR metric_labels->>'container' = '${container}')",
+          "rawSql": "SELECT 'Average Value' AS metric_labels, AVG(metric_value) AS metric_value, to_timestamp($__from/1000) AS time FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${filter1_key}' = 'All' OR '${filter1_value}' = 'All' OR metric_labels->>'${filter1_key}' = '${filter1_value}') AND ('${filter2_key}' = 'All' OR '${filter2_value}' = 'All' OR metric_labels->>'${filter2_key}' = '${filter2_value}') AND ('${filter3_key}' = 'All' OR '${filter3_value}' = 'All' OR metric_labels->>'${filter3_key}' = '${filter3_value}')",
           "refId": "D",
           "legendFormat": "Average Value",
           "timeColumns": [
@@ -446,7 +446,7 @@
             "uid": "kpi-datasource"
           },
           "format": "table",
-          "rawSql": "SELECT metric_labels, ROUND(CAST(AVG(metric_value) AS numeric), 6) AS avg_value, ROUND(CAST(MIN(metric_value) AS numeric), 6) AS min_value, ROUND(CAST(MAX(metric_value) AS numeric), 6) AS max_value, COUNT(*) AS samples FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR metric_labels->>'node' = '${node}' OR metric_labels->>'instance' = '${node}') AND ('${job}' = 'All' OR metric_labels->>'job' = '${job}') AND ('${pod}' = 'All' OR metric_labels->>'pod' = '${pod}') AND ('${container}' = 'All' OR metric_labels->>'container' = '${container}') GROUP BY metric_labels ORDER BY avg_value DESC LIMIT 100",
+          "rawSql": "SELECT metric_labels, ROUND(CAST(AVG(metric_value) AS numeric), 6) AS avg_value, ROUND(CAST(MIN(metric_value) AS numeric), 6) AS min_value, ROUND(CAST(MAX(metric_value) AS numeric), 6) AS max_value, COUNT(*) AS samples FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${filter1_key}' = 'All' OR '${filter1_value}' = 'All' OR metric_labels->>'${filter1_key}' = '${filter1_value}') AND ('${filter2_key}' = 'All' OR '${filter2_value}' = 'All' OR metric_labels->>'${filter2_key}' = '${filter2_value}') AND ('${filter3_key}' = 'All' OR '${filter3_value}' = 'All' OR metric_labels->>'${filter3_key}' = '${filter3_value}') GROUP BY metric_labels ORDER BY avg_value DESC LIMIT 100",
           "refId": "A"
         }
       ],
@@ -589,7 +589,7 @@
             "uid": "kpi-datasource"
           },
           "format": "table",
-          "rawSql": "SELECT kpi_id, COUNT(*) AS sample_count, ROUND(CAST(AVG(metric_value) AS numeric), 6) AS avg_value, ROUND(CAST(MIN(metric_value) AS numeric), 6) AS min_value, ROUND(CAST(MAX(metric_value) AS numeric), 6) AS max_value, ROUND(CAST(MAX(metric_value) - MIN(metric_value) AS numeric), 6) AS range, COUNT(DISTINCT metric_labels) AS unique_metrics FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR metric_labels->>'node' = '${node}' OR metric_labels->>'instance' = '${node}') AND ('${job}' = 'All' OR metric_labels->>'job' = '${job}') AND ('${pod}' = 'All' OR metric_labels->>'pod' = '${pod}') AND ('${container}' = 'All' OR metric_labels->>'container' = '${container}') GROUP BY kpi_id ORDER BY kpi_id",
+          "rawSql": "SELECT kpi_id, COUNT(*) AS sample_count, ROUND(CAST(AVG(metric_value) AS numeric), 6) AS avg_value, ROUND(CAST(MIN(metric_value) AS numeric), 6) AS min_value, ROUND(CAST(MAX(metric_value) AS numeric), 6) AS max_value, ROUND(CAST(MAX(metric_value) - MIN(metric_value) AS numeric), 6) AS range, COUNT(DISTINCT metric_labels) AS unique_metrics FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${filter1_key}' = 'All' OR '${filter1_value}' = 'All' OR metric_labels->>'${filter1_key}' = '${filter1_value}') AND ('${filter2_key}' = 'All' OR '${filter2_value}' = 'All' OR metric_labels->>'${filter2_key}' = '${filter2_value}') AND ('${filter3_key}' = 'All' OR '${filter3_value}' = 'All' OR metric_labels->>'${filter3_key}' = '${filter3_value}') GROUP BY kpi_id ORDER BY kpi_id",
           "refId": "A"
         }
       ]
@@ -644,7 +644,7 @@
             "uid": "kpi-datasource"
           },
           "format": "table",
-          "rawSql": "SELECT c.cluster_name, c.cluster_type, COUNT(DISTINCT qr.kpi_id) AS kpi_count, COUNT(*) AS total_samples, MAX(qr.created_at) AS last_collection FROM clusters c LEFT JOIN query_results qr ON c.id = qr.cluster_id WHERE ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${node}' = 'All' OR qr.metric_labels->>'node' = '${node}' OR qr.metric_labels->>'instance' = '${node}') AND ('${job}' = 'All' OR qr.metric_labels->>'job' = '${job}') AND ('${pod}' = 'All' OR qr.metric_labels->>'pod' = '${pod}') AND ('${container}' = 'All' OR qr.metric_labels->>'container' = '${container}') GROUP BY c.cluster_name, c.cluster_type ORDER BY c.cluster_name",
+          "rawSql": "SELECT c.cluster_name, c.cluster_type, COUNT(DISTINCT qr.kpi_id) AS kpi_count, COUNT(*) AS total_samples, MAX(qr.created_at) AS last_collection FROM clusters c LEFT JOIN query_results qr ON c.id = qr.cluster_id WHERE ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${filter1_key}' = 'All' OR '${filter1_value}' = 'All' OR qr.metric_labels->>'${filter1_key}' = '${filter1_value}') AND ('${filter2_key}' = 'All' OR '${filter2_value}' = 'All' OR qr.metric_labels->>'${filter2_key}' = '${filter2_value}') AND ('${filter3_key}' = 'All' OR '${filter3_value}' = 'All' OR qr.metric_labels->>'${filter3_key}' = '${filter3_value}') GROUP BY c.cluster_name, c.cluster_type ORDER BY c.cluster_name",
           "refId": "A"
         }
       ]
@@ -712,14 +712,14 @@
         "refresh": 1
       },
       {
-        "name": "node",
+        "name": "filter1_key",
         "type": "query",
-        "label": "Node",
+        "label": "Filter 1 Label",
         "datasource": {
           "type": "postgres",
           "uid": "kpi-datasource"
         },
-        "query": "SELECT node FROM (SELECT 'All' AS node, 1 AS sort_order UNION ALL SELECT DISTINCT COALESCE(metric_labels->>'node', metric_labels->>'instance'), 2 FROM query_results WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND metric_labels IS NOT NULL AND COALESCE(metric_labels->>'node', metric_labels->>'instance') IS NOT NULL AND COALESCE(metric_labels->>'node', metric_labels->>'instance') <> '') AS t ORDER BY sort_order, node;",
+        "query": "SELECT key FROM (SELECT 'All' AS key, 1 AS sort_order UNION ALL SELECT DISTINCT key, 2 FROM query_results, jsonb_object_keys(metric_labels) AS key WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND metric_labels IS NOT NULL AND key <> '__name__') AS t ORDER BY sort_order, key;",
         "includeAll": false,
         "multi": false,
         "current": {
@@ -729,14 +729,14 @@
         "refresh": 1
       },
       {
-        "name": "job",
+        "name": "filter1_value",
         "type": "query",
-        "label": "Job",
+        "label": "Filter 1 Value",
         "datasource": {
           "type": "postgres",
           "uid": "kpi-datasource"
         },
-        "query": "SELECT job FROM (SELECT 'All' AS job, 1 AS sort_order UNION ALL SELECT DISTINCT metric_labels->>'job', 2 FROM query_results WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND metric_labels IS NOT NULL AND metric_labels->>'job' IS NOT NULL AND metric_labels->>'job' <> '') AS t ORDER BY sort_order, job;",
+        "query": "SELECT value FROM (SELECT 'All' AS value, 1 AS sort_order UNION ALL SELECT DISTINCT metric_labels->>'${filter1_key}', 2 FROM query_results WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND '${filter1_key}' <> 'All' AND metric_labels IS NOT NULL AND metric_labels->>'${filter1_key}' IS NOT NULL AND metric_labels->>'${filter1_key}' <> '') AS t ORDER BY sort_order, value;",
         "includeAll": false,
         "multi": false,
         "current": {
@@ -746,14 +746,14 @@
         "refresh": 1
       },
       {
-        "name": "pod",
+        "name": "filter2_key",
         "type": "query",
-        "label": "Pod",
+        "label": "Filter 2 Label",
         "datasource": {
           "type": "postgres",
           "uid": "kpi-datasource"
         },
-        "query": "SELECT pod FROM (SELECT 'All' AS pod, 1 AS sort_order UNION ALL SELECT DISTINCT metric_labels->>'pod', 2 FROM query_results WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND metric_labels IS NOT NULL AND metric_labels->>'pod' IS NOT NULL AND metric_labels->>'pod' <> '') AS t ORDER BY sort_order, pod;",
+        "query": "SELECT key FROM (SELECT 'All' AS key, 1 AS sort_order UNION ALL SELECT DISTINCT key, 2 FROM query_results, jsonb_object_keys(metric_labels) AS key WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND metric_labels IS NOT NULL AND key <> '__name__') AS t ORDER BY sort_order, key;",
         "includeAll": false,
         "multi": false,
         "current": {
@@ -763,14 +763,48 @@
         "refresh": 1
       },
       {
-        "name": "container",
+        "name": "filter2_value",
         "type": "query",
-        "label": "Container",
+        "label": "Filter 2 Value",
         "datasource": {
           "type": "postgres",
           "uid": "kpi-datasource"
         },
-        "query": "SELECT container FROM (SELECT 'All' AS container, 1 AS sort_order UNION ALL SELECT DISTINCT metric_labels->>'container', 2 FROM query_results WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND metric_labels IS NOT NULL AND metric_labels->>'container' IS NOT NULL AND metric_labels->>'container' <> '') AS t ORDER BY sort_order, container;",
+        "query": "SELECT value FROM (SELECT 'All' AS value, 1 AS sort_order UNION ALL SELECT DISTINCT metric_labels->>'${filter2_key}', 2 FROM query_results WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND '${filter2_key}' <> 'All' AND metric_labels IS NOT NULL AND metric_labels->>'${filter2_key}' IS NOT NULL AND metric_labels->>'${filter2_key}' <> '') AS t ORDER BY sort_order, value;",
+        "includeAll": false,
+        "multi": false,
+        "current": {
+          "text": "All",
+          "value": "All"
+        },
+        "refresh": 1
+      },
+      {
+        "name": "filter3_key",
+        "type": "query",
+        "label": "Filter 3 Label",
+        "datasource": {
+          "type": "postgres",
+          "uid": "kpi-datasource"
+        },
+        "query": "SELECT key FROM (SELECT 'All' AS key, 1 AS sort_order UNION ALL SELECT DISTINCT key, 2 FROM query_results, jsonb_object_keys(metric_labels) AS key WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND metric_labels IS NOT NULL AND key <> '__name__') AS t ORDER BY sort_order, key;",
+        "includeAll": false,
+        "multi": false,
+        "current": {
+          "text": "All",
+          "value": "All"
+        },
+        "refresh": 1
+      },
+      {
+        "name": "filter3_value",
+        "type": "query",
+        "label": "Filter 3 Value",
+        "datasource": {
+          "type": "postgres",
+          "uid": "kpi-datasource"
+        },
+        "query": "SELECT value FROM (SELECT 'All' AS value, 1 AS sort_order UNION ALL SELECT DISTINCT metric_labels->>'${filter3_key}', 2 FROM query_results WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND '${filter3_key}' <> 'All' AND metric_labels IS NOT NULL AND metric_labels->>'${filter3_key}' IS NOT NULL AND metric_labels->>'${filter3_key}' <> '') AS t ORDER BY sort_order, value;",
         "includeAll": false,
         "multi": false,
         "current": {
@@ -786,7 +820,7 @@
           "type": "postgres",
           "uid": "kpi-datasource"
         },
-        "query": "SELECT COALESCE(COUNT(*), 0) FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR metric_labels->>'node' = '${node}' OR metric_labels->>'instance' = '${node}') AND ('${job}' = 'All' OR metric_labels->>'job' = '${job}') AND ('${pod}' = 'All' OR metric_labels->>'pod' = '${pod}') AND ('${container}' = 'All' OR metric_labels->>'container' = '${container}')",
+        "query": "SELECT COALESCE(COUNT(*), 0) FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${filter1_key}' = 'All' OR '${filter1_value}' = 'All' OR metric_labels->>'${filter1_key}' = '${filter1_value}') AND ('${filter2_key}' = 'All' OR '${filter2_value}' = 'All' OR metric_labels->>'${filter2_key}' = '${filter2_value}') AND ('${filter3_key}' = 'All' OR '${filter3_value}' = 'All' OR metric_labels->>'${filter3_key}' = '${filter3_value}')",
         "includeAll": false,
         "multi": false,
         "current": {
@@ -803,7 +837,7 @@
           "type": "postgres",
           "uid": "kpi-datasource"
         },
-        "query": "SELECT COALESCE(ROUND(CAST(AVG(metric_value) AS numeric), 6)::text, 'N/A') FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR metric_labels->>'node' = '${node}' OR metric_labels->>'instance' = '${node}') AND ('${job}' = 'All' OR metric_labels->>'job' = '${job}') AND ('${pod}' = 'All' OR metric_labels->>'pod' = '${pod}') AND ('${container}' = 'All' OR metric_labels->>'container' = '${container}')",
+        "query": "SELECT COALESCE(ROUND(CAST(AVG(metric_value) AS numeric), 6)::text, 'N/A') FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${filter1_key}' = 'All' OR '${filter1_value}' = 'All' OR metric_labels->>'${filter1_key}' = '${filter1_value}') AND ('${filter2_key}' = 'All' OR '${filter2_value}' = 'All' OR metric_labels->>'${filter2_key}' = '${filter2_value}') AND ('${filter3_key}' = 'All' OR '${filter3_value}' = 'All' OR metric_labels->>'${filter3_key}' = '${filter3_value}')",
         "includeAll": false,
         "multi": false,
         "current": {
@@ -820,7 +854,7 @@
           "type": "postgres",
           "uid": "kpi-datasource"
         },
-        "query": "SELECT COALESCE(ROUND(CAST(MIN(metric_value) AS numeric), 6)::text, 'N/A') FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR metric_labels->>'node' = '${node}' OR metric_labels->>'instance' = '${node}') AND ('${job}' = 'All' OR metric_labels->>'job' = '${job}') AND ('${pod}' = 'All' OR metric_labels->>'pod' = '${pod}') AND ('${container}' = 'All' OR metric_labels->>'container' = '${container}')",
+        "query": "SELECT COALESCE(ROUND(CAST(MIN(metric_value) AS numeric), 6)::text, 'N/A') FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${filter1_key}' = 'All' OR '${filter1_value}' = 'All' OR metric_labels->>'${filter1_key}' = '${filter1_value}') AND ('${filter2_key}' = 'All' OR '${filter2_value}' = 'All' OR metric_labels->>'${filter2_key}' = '${filter2_value}') AND ('${filter3_key}' = 'All' OR '${filter3_value}' = 'All' OR metric_labels->>'${filter3_key}' = '${filter3_value}')",
         "includeAll": false,
         "multi": false,
         "current": {
@@ -837,7 +871,7 @@
           "type": "postgres",
           "uid": "kpi-datasource"
         },
-        "query": "SELECT COALESCE(ROUND(CAST(MAX(metric_value) AS numeric), 6)::text, 'N/A') FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR metric_labels->>'node' = '${node}' OR metric_labels->>'instance' = '${node}') AND ('${job}' = 'All' OR metric_labels->>'job' = '${job}') AND ('${pod}' = 'All' OR metric_labels->>'pod' = '${pod}') AND ('${container}' = 'All' OR metric_labels->>'container' = '${container}')",
+        "query": "SELECT COALESCE(ROUND(CAST(MAX(metric_value) AS numeric), 6)::text, 'N/A') FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${filter1_key}' = 'All' OR '${filter1_value}' = 'All' OR metric_labels->>'${filter1_key}' = '${filter1_value}') AND ('${filter2_key}' = 'All' OR '${filter2_value}' = 'All' OR metric_labels->>'${filter2_key}' = '${filter2_value}') AND ('${filter3_key}' = 'All' OR '${filter3_value}' = 'All' OR metric_labels->>'${filter3_key}' = '${filter3_value}')",
         "includeAll": false,
         "multi": false,
         "current": {

--- a/grafana-templates/sqlite-dashboard.json
+++ b/grafana-templates/sqlite-dashboard.json
@@ -286,31 +286,31 @@
       "targets": [
         {
           "queryType": "table",
-          "rawQueryText": "SELECT timestamp_value AS time, metric_value, metric_labels FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR json_extract(metric_labels, '$.node') = '${node}' OR json_extract(metric_labels, '$.instance') = '${node}') AND ('${job}' = 'All' OR json_extract(metric_labels, '$.job') = '${job}') AND ('${pod}' = 'All' OR json_extract(metric_labels, '$.pod') = '${pod}') AND ('${container}' = 'All' OR json_extract(metric_labels, '$.container') = '${container}') AND timestamp_value >= $__from / 1000 AND timestamp_value < $__to / 1000 ORDER BY time ASC",
+          "rawQueryText": "SELECT timestamp_value AS time, metric_value, metric_labels FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${filter1_key}' = 'All' OR '${filter1_value}' = 'All' OR json_extract(metric_labels, '$.' || '${filter1_key}') = '${filter1_value}') AND ('${filter2_key}' = 'All' OR '${filter2_value}' = 'All' OR json_extract(metric_labels, '$.' || '${filter2_key}') = '${filter2_value}') AND ('${filter3_key}' = 'All' OR '${filter3_value}' = 'All' OR json_extract(metric_labels, '$.' || '${filter3_key}') = '${filter3_value}') AND timestamp_value >= $__from / 1000 AND timestamp_value < $__to / 1000 ORDER BY time ASC",
           "refId": "A",
           "timeColumns": [
             "time",
             "ts"
           ],
-          "legendFormat": "Node: {{node}} | Pod: {{pod}} | Job: {{job}} | Container: {{container}} | ID: {{id}}"
+          "legendFormat": ""
         },
         {
           "queryType": "table",
-          "rawQueryText": "SELECT 'Max Value' AS metric_labels, MAX(metric_value) AS metric_value, $__from/1000 AS time FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR json_extract(metric_labels, '$.node') = '${node}' OR json_extract(metric_labels, '$.instance') = '${node}') AND ('${job}' = 'All' OR json_extract(metric_labels, '$.job') = '${job}') AND ('${pod}' = 'All' OR json_extract(metric_labels, '$.pod') = '${pod}') AND ('${container}' = 'All' OR json_extract(metric_labels, '$.container') = '${container}')",
+          "rawQueryText": "SELECT 'Max Value' AS metric_labels, MAX(metric_value) AS metric_value, $__from/1000 AS time FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${filter1_key}' = 'All' OR '${filter1_value}' = 'All' OR json_extract(metric_labels, '$.' || '${filter1_key}') = '${filter1_value}') AND ('${filter2_key}' = 'All' OR '${filter2_value}' = 'All' OR json_extract(metric_labels, '$.' || '${filter2_key}') = '${filter2_value}') AND ('${filter3_key}' = 'All' OR '${filter3_value}' = 'All' OR json_extract(metric_labels, '$.' || '${filter3_key}') = '${filter3_value}')",
           "refId": "B",
           "legendFormat": "Max Value",
           "hide": true
         },
         {
           "queryType": "table",
-          "rawQueryText": "SELECT 'Min Value' AS metric_labels, MIN(metric_value) AS metric_value, $__from/1000 AS time FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR json_extract(metric_labels, '$.node') = '${node}' OR json_extract(metric_labels, '$.instance') = '${node}') AND ('${job}' = 'All' OR json_extract(metric_labels, '$.job') = '${job}') AND ('${pod}' = 'All' OR json_extract(metric_labels, '$.pod') = '${pod}') AND ('${container}' = 'All' OR json_extract(metric_labels, '$.container') = '${container}')",
+          "rawQueryText": "SELECT 'Min Value' AS metric_labels, MIN(metric_value) AS metric_value, $__from/1000 AS time FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${filter1_key}' = 'All' OR '${filter1_value}' = 'All' OR json_extract(metric_labels, '$.' || '${filter1_key}') = '${filter1_value}') AND ('${filter2_key}' = 'All' OR '${filter2_value}' = 'All' OR json_extract(metric_labels, '$.' || '${filter2_key}') = '${filter2_value}') AND ('${filter3_key}' = 'All' OR '${filter3_value}' = 'All' OR json_extract(metric_labels, '$.' || '${filter3_key}') = '${filter3_value}')",
           "refId": "C",
           "legendFormat": "Min Value",
           "hide": true
         },
         {
           "queryType": "table",
-          "rawQueryText": "SELECT 'Average Value' AS metric_labels, AVG(metric_value) AS metric_value, $__from/1000 AS time FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR json_extract(metric_labels, '$.node') = '${node}' OR json_extract(metric_labels, '$.instance') = '${node}') AND ('${job}' = 'All' OR json_extract(metric_labels, '$.job') = '${job}') AND ('${pod}' = 'All' OR json_extract(metric_labels, '$.pod') = '${pod}') AND ('${container}' = 'All' OR json_extract(metric_labels, '$.container') = '${container}')",
+          "rawQueryText": "SELECT 'Average Value' AS metric_labels, AVG(metric_value) AS metric_value, $__from/1000 AS time FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${filter1_key}' = 'All' OR '${filter1_value}' = 'All' OR json_extract(metric_labels, '$.' || '${filter1_key}') = '${filter1_value}') AND ('${filter2_key}' = 'All' OR '${filter2_value}' = 'All' OR json_extract(metric_labels, '$.' || '${filter2_key}') = '${filter2_value}') AND ('${filter3_key}' = 'All' OR '${filter3_value}' = 'All' OR json_extract(metric_labels, '$.' || '${filter3_key}') = '${filter3_value}')",
           "refId": "D",
           "legendFormat": "Average Value",
           "hide": true
@@ -418,7 +418,7 @@
       "targets": [
         {
           "queryType": "table",
-          "rawQueryText": "SELECT metric_labels, ROUND(AVG(metric_value), 6) AS avg_value, ROUND(MIN(metric_value), 6) AS min_value, ROUND(MAX(metric_value), 6) AS max_value, COUNT(*) AS samples FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR json_extract(metric_labels, '$.node') = '${node}' OR json_extract(metric_labels, '$.instance') = '${node}') AND ('${job}' = 'All' OR json_extract(metric_labels, '$.job') = '${job}') AND ('${pod}' = 'All' OR json_extract(metric_labels, '$.pod') = '${pod}') AND ('${container}' = 'All' OR json_extract(metric_labels, '$.container') = '${container}') GROUP BY metric_labels ORDER BY avg_value DESC LIMIT 100",
+          "rawQueryText": "SELECT metric_labels, ROUND(AVG(metric_value), 6) AS avg_value, ROUND(MIN(metric_value), 6) AS min_value, ROUND(MAX(metric_value), 6) AS max_value, COUNT(*) AS samples FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${filter1_key}' = 'All' OR '${filter1_value}' = 'All' OR json_extract(metric_labels, '$.' || '${filter1_key}') = '${filter1_value}') AND ('${filter2_key}' = 'All' OR '${filter2_value}' = 'All' OR json_extract(metric_labels, '$.' || '${filter2_key}') = '${filter2_value}') AND ('${filter3_key}' = 'All' OR '${filter3_value}' = 'All' OR json_extract(metric_labels, '$.' || '${filter3_key}') = '${filter3_value}') GROUP BY metric_labels ORDER BY avg_value DESC LIMIT 100",
           "refId": "A"
         }
       ],
@@ -553,7 +553,7 @@
       "targets": [
         {
           "queryType": "table",
-          "rawQueryText": "SELECT kpi_id, COUNT(*) AS sample_count, ROUND(AVG(metric_value), 6) AS avg_value, ROUND(MIN(metric_value), 6) AS min_value, ROUND(MAX(metric_value), 6) AS max_value, ROUND(MAX(metric_value) - MIN(metric_value), 6) AS range, COUNT(DISTINCT metric_labels) AS unique_metrics FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR json_extract(metric_labels, '$.node') = '${node}' OR json_extract(metric_labels, '$.instance') = '${node}') AND ('${job}' = 'All' OR json_extract(metric_labels, '$.job') = '${job}') AND ('${pod}' = 'All' OR json_extract(metric_labels, '$.pod') = '${pod}') AND ('${container}' = 'All' OR json_extract(metric_labels, '$.container') = '${container}') GROUP BY kpi_id ORDER BY kpi_id",
+          "rawQueryText": "SELECT kpi_id, COUNT(*) AS sample_count, ROUND(AVG(metric_value), 6) AS avg_value, ROUND(MIN(metric_value), 6) AS min_value, ROUND(MAX(metric_value), 6) AS max_value, ROUND(MAX(metric_value) - MIN(metric_value), 6) AS range, COUNT(DISTINCT metric_labels) AS unique_metrics FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${filter1_key}' = 'All' OR '${filter1_value}' = 'All' OR json_extract(metric_labels, '$.' || '${filter1_key}') = '${filter1_value}') AND ('${filter2_key}' = 'All' OR '${filter2_value}' = 'All' OR json_extract(metric_labels, '$.' || '${filter2_key}') = '${filter2_value}') AND ('${filter3_key}' = 'All' OR '${filter3_value}' = 'All' OR json_extract(metric_labels, '$.' || '${filter3_key}') = '${filter3_value}') GROUP BY kpi_id ORDER BY kpi_id",
           "refId": "A"
         }
       ]
@@ -604,7 +604,7 @@
       "targets": [
         {
           "queryType": "table",
-          "rawQueryText": "SELECT c.cluster_name, c.cluster_type, COUNT(DISTINCT qr.kpi_id) AS kpi_count, COUNT(*) AS total_samples, MAX(qr.created_at) AS last_collection FROM clusters c LEFT JOIN query_results qr ON c.id = qr.cluster_id WHERE ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${node}' = 'All' OR json_extract(qr.metric_labels, '$.node') = '${node}' OR json_extract(qr.metric_labels, '$.instance') = '${node}') AND ('${job}' = 'All' OR json_extract(qr.metric_labels, '$.job') = '${job}') AND ('${pod}' = 'All' OR json_extract(qr.metric_labels, '$.pod') = '${pod}') AND ('${container}' = 'All' OR json_extract(qr.metric_labels, '$.container') = '${container}') GROUP BY c.cluster_name, c.cluster_type ORDER BY c.cluster_name",
+          "rawQueryText": "SELECT c.cluster_name, c.cluster_type, COUNT(DISTINCT qr.kpi_id) AS kpi_count, COUNT(*) AS total_samples, MAX(qr.created_at) AS last_collection FROM clusters c LEFT JOIN query_results qr ON c.id = qr.cluster_id WHERE ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${filter1_key}' = 'All' OR '${filter1_value}' = 'All' OR json_extract(qr.metric_labels, '$.' || '${filter1_key}') = '${filter1_value}') AND ('${filter2_key}' = 'All' OR '${filter2_value}' = 'All' OR json_extract(qr.metric_labels, '$.' || '${filter2_key}') = '${filter2_value}') AND ('${filter3_key}' = 'All' OR '${filter3_value}' = 'All' OR json_extract(qr.metric_labels, '$.' || '${filter3_key}') = '${filter3_value}') GROUP BY c.cluster_name, c.cluster_type ORDER BY c.cluster_name",
           "refId": "A"
         }
       ]
@@ -672,14 +672,14 @@
         "refresh": 1
       },
       {
-        "name": "node",
+        "name": "filter1_key",
         "type": "query",
-        "label": "Node",
+        "label": "Filter 1 Label",
         "datasource": {
           "type": "frser-sqlite-datasource",
           "uid": "kpi-datasource"
         },
-        "query": "SELECT node FROM (SELECT 'All' AS node, 1 AS sort_order UNION ALL SELECT DISTINCT COALESCE(json_extract(metric_labels, '$.node'), json_extract(metric_labels, '$.instance')), 2 FROM query_results WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND metric_labels IS NOT NULL AND COALESCE(json_extract(metric_labels, '$.node'), json_extract(metric_labels, '$.instance')) IS NOT NULL AND COALESCE(json_extract(metric_labels, '$.node'), json_extract(metric_labels, '$.instance')) <> '') ORDER BY sort_order, node;",
+        "query": "SELECT key FROM (SELECT 'All' AS key, 1 AS sort_order UNION ALL SELECT DISTINCT je.key, 2 FROM query_results, json_each(metric_labels) AS je WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND metric_labels IS NOT NULL AND je.key <> '__name__') ORDER BY sort_order, key;",
         "includeAll": false,
         "multi": false,
         "current": {
@@ -689,14 +689,14 @@
         "refresh": 1
       },
       {
-        "name": "job",
+        "name": "filter1_value",
         "type": "query",
-        "label": "Job",
+        "label": "Filter 1 Value",
         "datasource": {
           "type": "frser-sqlite-datasource",
           "uid": "kpi-datasource"
         },
-        "query": "SELECT job FROM (SELECT 'All' AS job, 1 AS sort_order UNION ALL SELECT DISTINCT json_extract(metric_labels, '$.job'), 2 FROM query_results WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND metric_labels IS NOT NULL AND json_extract(metric_labels, '$.job') IS NOT NULL AND json_extract(metric_labels, '$.job') <> '') ORDER BY sort_order, job;",
+        "query": "SELECT value FROM (SELECT 'All' AS value, 1 AS sort_order UNION ALL SELECT DISTINCT json_extract(metric_labels, '$.' || '${filter1_key}'), 2 FROM query_results WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND '${filter1_key}' <> 'All' AND metric_labels IS NOT NULL AND json_extract(metric_labels, '$.' || '${filter1_key}') IS NOT NULL AND json_extract(metric_labels, '$.' || '${filter1_key}') <> '') ORDER BY sort_order, value;",
         "includeAll": false,
         "multi": false,
         "current": {
@@ -706,14 +706,14 @@
         "refresh": 1
       },
       {
-        "name": "pod",
+        "name": "filter2_key",
         "type": "query",
-        "label": "Pod",
+        "label": "Filter 2 Label",
         "datasource": {
           "type": "frser-sqlite-datasource",
           "uid": "kpi-datasource"
         },
-        "query": "SELECT pod FROM (SELECT 'All' AS pod, 1 AS sort_order UNION ALL SELECT DISTINCT json_extract(metric_labels, '$.pod'), 2 FROM query_results WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND metric_labels IS NOT NULL AND json_extract(metric_labels, '$.pod') IS NOT NULL AND json_extract(metric_labels, '$.pod') <> '') ORDER BY sort_order, pod;",
+        "query": "SELECT key FROM (SELECT 'All' AS key, 1 AS sort_order UNION ALL SELECT DISTINCT je.key, 2 FROM query_results, json_each(metric_labels) AS je WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND metric_labels IS NOT NULL AND je.key <> '__name__') ORDER BY sort_order, key;",
         "includeAll": false,
         "multi": false,
         "current": {
@@ -723,14 +723,48 @@
         "refresh": 1
       },
       {
-        "name": "container",
+        "name": "filter2_value",
         "type": "query",
-        "label": "Container",
+        "label": "Filter 2 Value",
         "datasource": {
           "type": "frser-sqlite-datasource",
           "uid": "kpi-datasource"
         },
-        "query": "SELECT container FROM (SELECT 'All' AS container, 1 AS sort_order UNION ALL SELECT DISTINCT json_extract(metric_labels, '$.container'), 2 FROM query_results WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND metric_labels IS NOT NULL AND json_extract(metric_labels, '$.container') IS NOT NULL AND json_extract(metric_labels, '$.container') <> '') ORDER BY sort_order, container;",
+        "query": "SELECT value FROM (SELECT 'All' AS value, 1 AS sort_order UNION ALL SELECT DISTINCT json_extract(metric_labels, '$.' || '${filter2_key}'), 2 FROM query_results WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND '${filter2_key}' <> 'All' AND metric_labels IS NOT NULL AND json_extract(metric_labels, '$.' || '${filter2_key}') IS NOT NULL AND json_extract(metric_labels, '$.' || '${filter2_key}') <> '') ORDER BY sort_order, value;",
+        "includeAll": false,
+        "multi": false,
+        "current": {
+          "text": "All",
+          "value": "All"
+        },
+        "refresh": 1
+      },
+      {
+        "name": "filter3_key",
+        "type": "query",
+        "label": "Filter 3 Label",
+        "datasource": {
+          "type": "frser-sqlite-datasource",
+          "uid": "kpi-datasource"
+        },
+        "query": "SELECT key FROM (SELECT 'All' AS key, 1 AS sort_order UNION ALL SELECT DISTINCT je.key, 2 FROM query_results, json_each(metric_labels) AS je WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND metric_labels IS NOT NULL AND je.key <> '__name__') ORDER BY sort_order, key;",
+        "includeAll": false,
+        "multi": false,
+        "current": {
+          "text": "All",
+          "value": "All"
+        },
+        "refresh": 1
+      },
+      {
+        "name": "filter3_value",
+        "type": "query",
+        "label": "Filter 3 Value",
+        "datasource": {
+          "type": "frser-sqlite-datasource",
+          "uid": "kpi-datasource"
+        },
+        "query": "SELECT value FROM (SELECT 'All' AS value, 1 AS sort_order UNION ALL SELECT DISTINCT json_extract(metric_labels, '$.' || '${filter3_key}'), 2 FROM query_results WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND '${filter3_key}' <> 'All' AND metric_labels IS NOT NULL AND json_extract(metric_labels, '$.' || '${filter3_key}') IS NOT NULL AND json_extract(metric_labels, '$.' || '${filter3_key}') <> '') ORDER BY sort_order, value;",
         "includeAll": false,
         "multi": false,
         "current": {
@@ -746,7 +780,7 @@
           "type": "frser-sqlite-datasource",
           "uid": "kpi-datasource"
         },
-        "query": "SELECT COALESCE(COUNT(*), 0) FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR json_extract(metric_labels, '$.node') = '${node}' OR json_extract(metric_labels, '$.instance') = '${node}') AND ('${job}' = 'All' OR json_extract(metric_labels, '$.job') = '${job}') AND ('${pod}' = 'All' OR json_extract(metric_labels, '$.pod') = '${pod}') AND ('${container}' = 'All' OR json_extract(metric_labels, '$.container') = '${container}')",
+        "query": "SELECT COALESCE(COUNT(*), 0) FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${filter1_key}' = 'All' OR '${filter1_value}' = 'All' OR json_extract(metric_labels, '$.' || '${filter1_key}') = '${filter1_value}') AND ('${filter2_key}' = 'All' OR '${filter2_value}' = 'All' OR json_extract(metric_labels, '$.' || '${filter2_key}') = '${filter2_value}') AND ('${filter3_key}' = 'All' OR '${filter3_value}' = 'All' OR json_extract(metric_labels, '$.' || '${filter3_key}') = '${filter3_value}')",
         "includeAll": false,
         "multi": false,
         "current": {
@@ -763,7 +797,7 @@
           "type": "frser-sqlite-datasource",
           "uid": "kpi-datasource"
         },
-        "query": "SELECT COALESCE(ROUND(AVG(metric_value), 6), 'N/A') FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR json_extract(metric_labels, '$.node') = '${node}' OR json_extract(metric_labels, '$.instance') = '${node}') AND ('${job}' = 'All' OR json_extract(metric_labels, '$.job') = '${job}') AND ('${pod}' = 'All' OR json_extract(metric_labels, '$.pod') = '${pod}') AND ('${container}' = 'All' OR json_extract(metric_labels, '$.container') = '${container}')",
+        "query": "SELECT COALESCE(ROUND(AVG(metric_value), 6), 'N/A') FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${filter1_key}' = 'All' OR '${filter1_value}' = 'All' OR json_extract(metric_labels, '$.' || '${filter1_key}') = '${filter1_value}') AND ('${filter2_key}' = 'All' OR '${filter2_value}' = 'All' OR json_extract(metric_labels, '$.' || '${filter2_key}') = '${filter2_value}') AND ('${filter3_key}' = 'All' OR '${filter3_value}' = 'All' OR json_extract(metric_labels, '$.' || '${filter3_key}') = '${filter3_value}')",
         "includeAll": false,
         "multi": false,
         "current": {
@@ -780,7 +814,7 @@
           "type": "frser-sqlite-datasource",
           "uid": "kpi-datasource"
         },
-        "query": "SELECT COALESCE(ROUND(MIN(metric_value), 6), 'N/A') FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR json_extract(metric_labels, '$.node') = '${node}' OR json_extract(metric_labels, '$.instance') = '${node}') AND ('${job}' = 'All' OR json_extract(metric_labels, '$.job') = '${job}') AND ('${pod}' = 'All' OR json_extract(metric_labels, '$.pod') = '${pod}') AND ('${container}' = 'All' OR json_extract(metric_labels, '$.container') = '${container}')",
+        "query": "SELECT COALESCE(ROUND(MIN(metric_value), 6), 'N/A') FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${filter1_key}' = 'All' OR '${filter1_value}' = 'All' OR json_extract(metric_labels, '$.' || '${filter1_key}') = '${filter1_value}') AND ('${filter2_key}' = 'All' OR '${filter2_value}' = 'All' OR json_extract(metric_labels, '$.' || '${filter2_key}') = '${filter2_value}') AND ('${filter3_key}' = 'All' OR '${filter3_value}' = 'All' OR json_extract(metric_labels, '$.' || '${filter3_key}') = '${filter3_value}')",
         "includeAll": false,
         "multi": false,
         "current": {
@@ -797,7 +831,7 @@
           "type": "frser-sqlite-datasource",
           "uid": "kpi-datasource"
         },
-        "query": "SELECT COALESCE(ROUND(MAX(metric_value), 6), 'N/A') FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${node}' = 'All' OR json_extract(metric_labels, '$.node') = '${node}' OR json_extract(metric_labels, '$.instance') = '${node}') AND ('${job}' = 'All' OR json_extract(metric_labels, '$.job') = '${job}') AND ('${pod}' = 'All' OR json_extract(metric_labels, '$.pod') = '${pod}') AND ('${container}' = 'All' OR json_extract(metric_labels, '$.container') = '${container}')",
+        "query": "SELECT COALESCE(ROUND(MAX(metric_value), 6), 'N/A') FROM query_results qr JOIN clusters c ON qr.cluster_id = c.id WHERE ('${kpi}' = 'All' OR kpi_id = '${kpi}') AND ('${cluster}' = 'All' OR c.cluster_name = '${cluster}') AND ('${cluster_type}' = 'All' OR c.cluster_type = '${cluster_type}') AND ('${filter1_key}' = 'All' OR '${filter1_value}' = 'All' OR json_extract(metric_labels, '$.' || '${filter1_key}') = '${filter1_value}') AND ('${filter2_key}' = 'All' OR '${filter2_value}' = 'All' OR json_extract(metric_labels, '$.' || '${filter2_key}') = '${filter2_value}') AND ('${filter3_key}' = 'All' OR '${filter3_value}' = 'All' OR json_extract(metric_labels, '$.' || '${filter3_key}') = '${filter3_value}')",
         "includeAll": false,
         "multi": false,
         "current": {


### PR DESCRIPTION
### Summary

Replaces the 4 hardcoded Grafana filter variables (Node, Job, Pod, Container) with 3 dynamic
"Filter by" key/value dropdown pairs. Label keys are discovered at query time from the
`metric_labels` JSON column using `json_each()` (SQLite) / `jsonb_object_keys()` (PostgreSQL),
so every KPI gets relevant filters regardless of its label schema.