### PR TITLE
Fix SQLITE_BUSY race condition by initializing database once

### DIFF
--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -6,6 +6,7 @@ package collector
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"log"
 	"os"
@@ -15,6 +16,7 @@ import (
 	"time"
 
 	"github.com/redhat-best-practices-for-k8s/kpi-collection-tool/internal/config"
+	"github.com/redhat-best-practices-for-k8s/kpi-collection-tool/internal/database"
 	"github.com/redhat-best-practices-for-k8s/kpi-collection-tool/internal/output"
 	"github.com/redhat-best-practices-for-k8s/kpi-collection-tool/internal/prometheus"
 )
@@ -28,11 +30,16 @@ const durationBuffer = 100 * time.Millisecond
 // It ignores frequency and duration settings entirely.
 // Returns an error if any queries failed.
 func RunOnce(kpis config.KPIs, flags config.InputFlags) error {
-	fmt.Printf("\nKPI Collection Started - Single run mode\n")
+	db, dbImpl, err := database.InitDatabaseWithConfig(flags.DatabaseType, flags.PostgresURL)
+	if err != nil {
+		return fmt.Errorf("failed to init database: %v", err)
+	}
+	defer closeDB(db)
 
+	fmt.Printf("\nKPI Collection Started - Single run mode\n")
 	log.Printf("Single run: executing %d KPIs", len(kpis.Queries))
 
-	err := prometheus.RunQueries(kpis, flags, 1, 1, 0)
+	err = prometheus.RunQueries(db, dbImpl, kpis, flags, 1, 1, 0)
 	if err != nil {
 		log.Printf("RunQueries failed in single-run mode: %v", err)
 	}
@@ -44,6 +51,12 @@ func RunOnce(kpis config.KPIs, flags config.InputFlags) error {
 // Run executes the KPI collection loop until duration expires or interrupted.
 // Returns an error if any query failures occurred during collection.
 func Run(kpis config.KPIs, flags config.InputFlags) error {
+	db, dbImpl, err := database.InitDatabaseWithConfig(flags.DatabaseType, flags.PostgresURL)
+	if err != nil {
+		return fmt.Errorf("failed to init database: %v", err)
+	}
+	defer closeDB(db)
+
 	var hadFailures atomic.Bool
 
 	runOnceKPIs, repeatingKPIs := splitRunOnceQueries(kpis)
@@ -53,7 +66,7 @@ func Run(kpis config.KPIs, flags config.InputFlags) error {
 		fmt.Printf("Executing %d run-once KPI(s) before starting collection loop\n", len(runOnceKPIs.Queries))
 		log.Printf("Executing %d run-once KPIs", len(runOnceKPIs.Queries))
 
-		if err := prometheus.RunQueries(runOnceKPIs, flags, 1, 1, 0); err != nil {
+		if err := prometheus.RunQueries(db, dbImpl, runOnceKPIs, flags, 1, 1, 0); err != nil {
 			log.Printf("RunQueries failed for run-once KPIs: %v", err)
 			hadFailures.Store(true)
 		}
@@ -76,7 +89,7 @@ func Run(kpis config.KPIs, flags config.InputFlags) error {
 	output.PrintStartup(flags.Duration.String(), time.Now().Add(flags.Duration).Format(time.RFC3339))
 
 	// Start repeating KPI goroutines grouped by frequency
-	cancel, wg := startKPIGoroutines(repeatingKPIs, flags, &hadFailures)
+	cancel, wg := startKPIGoroutines(db, dbImpl, repeatingKPIs, flags, &hadFailures)
 	defer cancel()
 
 	// Main goroutine only handles duration timer and interrupts
@@ -138,7 +151,9 @@ func groupKPIsByFrequency(kpis config.KPIs, defaultFreq time.Duration) map[time.
 }
 
 // startKPIGoroutines starts one goroutine per unique frequency for all KPIs
-func startKPIGoroutines(kpis config.KPIs, flags config.InputFlags, hadFailures *atomic.Bool) (context.CancelFunc, *sync.WaitGroup) {
+func startKPIGoroutines(db *sql.DB, dbImpl database.Database, kpis config.KPIs,
+	flags config.InputFlags, hadFailures *atomic.Bool) (context.CancelFunc, *sync.WaitGroup) {
+
 	ctx, cancel := context.WithCancel(context.Background())
 	var wg sync.WaitGroup
 
@@ -150,7 +165,7 @@ func startKPIGoroutines(kpis config.KPIs, flags config.InputFlags, hadFailures *
 		wg.Add(1)
 		go func(frequency time.Duration, kpiGroup config.KPIs) {
 			defer wg.Done()
-			runKPIGroupLoop(ctx, kpiGroup, frequency, flags, hadFailures)
+			runKPIGroupLoop(ctx, db, dbImpl, kpiGroup, frequency, flags, hadFailures)
 		}(freq, kpisForFreq)
 	}
 
@@ -163,7 +178,9 @@ func shutdown(cancel context.CancelFunc, wg *sync.WaitGroup) {
 }
 
 // runKPIGroupLoop runs a group of KPIs that share the same sampling frequency
-func runKPIGroupLoop(ctx context.Context, kpis config.KPIs, frequency time.Duration, flags config.InputFlags, hadFailures *atomic.Bool) {
+func runKPIGroupLoop(ctx context.Context, db *sql.DB, dbImpl database.Database,
+	kpis config.KPIs, frequency time.Duration, flags config.InputFlags, hadFailures *atomic.Bool) {
+
 	ticker := time.NewTicker(frequency)
 	defer ticker.Stop()
 
@@ -172,13 +189,13 @@ func runKPIGroupLoop(ctx context.Context, kpis config.KPIs, frequency time.Durat
 	log.Printf("Starting goroutine for %d KPIs with frequency %s (total samples: %d)", len(kpis.Queries), frequency, totalSamples)
 	// Run immediately on start
 	sampleCount++
-	runKPIs(kpis, flags, sampleCount, totalSamples, frequency, hadFailures)
+	runKPIs(db, dbImpl, kpis, flags, sampleCount, totalSamples, frequency, hadFailures)
 
 	for {
 		select {
 		case <-ticker.C:
 			sampleCount++
-			runKPIs(kpis, flags, sampleCount, totalSamples, frequency, hadFailures)
+			runKPIs(db, dbImpl, kpis, flags, sampleCount, totalSamples, frequency, hadFailures)
 
 		case <-ctx.Done():
 			log.Printf("KPI group (frequency %s) stopped after %d samples", frequency, sampleCount)
@@ -188,14 +205,16 @@ func runKPIGroupLoop(ctx context.Context, kpis config.KPIs, frequency time.Durat
 }
 
 // runKPIs executes a group of KPIs and logs the results
-func runKPIs(kpis config.KPIs, flags config.InputFlags, sampleNumber int, totalSamples int, frequency time.Duration, hadFailures *atomic.Bool) {
+func runKPIs(db *sql.DB, dbImpl database.Database, kpis config.KPIs, flags config.InputFlags,
+	sampleNumber int, totalSamples int, frequency time.Duration, hadFailures *atomic.Bool) {
+
 	if len(kpis.Queries) == 0 {
 		return
 	}
 
 	log.Printf("Running sample %d/%d for %d KPIs with frequency %s", sampleNumber, totalSamples, len(kpis.Queries), frequency)
 
-	if err := prometheus.RunQueries(kpis, flags, sampleNumber, totalSamples, frequency); err != nil {
+	if err := prometheus.RunQueries(db, dbImpl, kpis, flags, sampleNumber, totalSamples, frequency); err != nil {
 		log.Printf("RunQueries failed for frequency %s KPIs: %v", frequency, err)
 		hadFailures.Store(true)
 	}
@@ -208,4 +227,10 @@ func calculateTotalSamples(frequency time.Duration, duration time.Duration) int 
 	frequencySecs := int(frequency.Seconds())
 	durationSecs := int(duration.Seconds())
 	return (durationSecs / frequencySecs) + 1
+}
+
+func closeDB(db *sql.DB) {
+	if err := db.Close(); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to close database: %v\n", err)
+	}
 }

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"database/sql"
 	"sync/atomic"
 	"time"
 
@@ -8,6 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/redhat-best-practices-for-k8s/kpi-collection-tool/internal/config"
+	"github.com/redhat-best-practices-for-k8s/kpi-collection-tool/internal/database"
 )
 
 // Helper function to create a Duration pointer
@@ -187,31 +189,44 @@ var _ = Describe("Collector", func() {
 	})
 
 	Describe("startKPIGoroutines", func() {
-		var flags config.InputFlags
+		var (
+			flags  config.InputFlags
+			db     *sql.DB
+			dbImpl database.Database
+		)
 
 		BeforeEach(func() {
 			flags = config.InputFlags{
 				SamplingFreq: 60 * time.Second,
 				Duration:     1 * time.Second,
 			}
+
+			var err error
+			db, dbImpl, err = database.InitDatabaseWithConfig("sqlite", "")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			if db != nil {
+				Expect(db.Close()).To(Succeed())
+			}
 		})
 
 		Context("when there are KPIs with various frequencies", func() {
 			It("should return cancel function and WaitGroup", func() {
-			kpis := config.KPIs{
-				Queries: []config.Query{
-					{ID: "kpi-1", PromQuery: "query1", SampleFrequency: durationPtr(5 * time.Second)},
-					{ID: "kpi-2", PromQuery: "query2"}, // default frequency
-				},
-			}
+				kpis := config.KPIs{
+					Queries: []config.Query{
+						{ID: "kpi-1", PromQuery: "query1", SampleFrequency: durationPtr(5 * time.Second)},
+						{ID: "kpi-2", PromQuery: "query2"},
+					},
+				}
 
 				var hadFailures atomic.Bool
-				cancel, wg := startKPIGoroutines(kpis, flags, &hadFailures)
+				cancel, wg := startKPIGoroutines(db, dbImpl, kpis, flags, &hadFailures)
 
 				Expect(cancel).NotTo(BeNil())
 				Expect(wg).NotTo(BeNil())
 
-				// Cancel and wait to clean up goroutines
 				cancel()
 				wg.Wait()
 			})
@@ -227,12 +242,11 @@ var _ = Describe("Collector", func() {
 				}
 
 				var hadFailures atomic.Bool
-				cancel, wg := startKPIGoroutines(kpis, flags, &hadFailures)
+				cancel, wg := startKPIGoroutines(db, dbImpl, kpis, flags, &hadFailures)
 
 				Expect(cancel).NotTo(BeNil())
 				Expect(wg).NotTo(BeNil())
 
-				// Cancel and wait to clean up goroutines
 				cancel()
 				wg.Wait()
 			})
@@ -243,12 +257,11 @@ var _ = Describe("Collector", func() {
 				kpis := config.KPIs{Queries: []config.Query{}}
 
 				var hadFailures atomic.Bool
-				cancel, wg := startKPIGoroutines(kpis, flags, &hadFailures)
+				cancel, wg := startKPIGoroutines(db, dbImpl, kpis, flags, &hadFailures)
 
 				Expect(cancel).NotTo(BeNil())
 				Expect(wg).NotTo(BeNil())
 
-				// Cancel and wait (should return immediately)
 				cancel()
 				wg.Wait()
 			})

--- a/internal/prometheus/client.go
+++ b/internal/prometheus/client.go
@@ -58,18 +58,10 @@ func setupPromClient(prometheusURL, bearerToken string, insecureTLS bool) (promv
 	return promv1.NewAPI(client), nil
 }
 
-// RunQueries executes all Prometheus queries and stores results in database
-func RunQueries(kpisToRun config.KPIs, flags config.InputFlags, sampleNumber int, totalSamples int, frequency time.Duration) error {
-	// Initialize Database based on configuration
-	db, dbImpl, err := database.InitDatabaseWithConfig(flags.DatabaseType, flags.PostgresURL)
-	if err != nil {
-		return fmt.Errorf("failed to init database: %v", err)
-	}
-	defer func() {
-		if closeErr := db.Close(); closeErr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: failed to close database: %v\n", closeErr)
-		}
-	}()
+// RunQueries executes all Prometheus queries and stores results in the given database.
+// The caller is responsible for opening and closing the database connection.
+func RunQueries(db *sql.DB, dbImpl database.Database, kpisToRun config.KPIs, flags config.InputFlags,
+	sampleNumber int, totalSamples int, frequency time.Duration) error {
 
 	// Get or create cluster in DB
 	clusterID, err := dbImpl.GetOrCreateCluster(db, flags.ClusterName, flags.ClusterType)


### PR DESCRIPTION
## Summary

- Initialize the database connection once in the collector before spawning
  frequency-group goroutines, instead of opening a new connection on every
  `RunQueries` call. This fixes a `SQLITE_BUSY` race when multiple goroutines
  try to run `PRAGMA` statements on the same file simultaneously at startup.

## Root cause

When KPIs have different `sample-frequency` values, the collector spawns one
goroutine per frequency group. All goroutines fire their first sample
immediately, and each called `database.InitDatabaseWithConfig()` independently.
Two concurrent `InitDB()` calls on the same SQLite file caused the second one
to fail with `SQLITE_BUSY` before `busy_timeout` was even applied — because
the pragma-setting step itself was the one getting blocked.

## What changed

- `collector.Run()` and `collector.RunOnce()` now call `InitDatabaseWithConfig`
  once and pass `*sql.DB` + `Database` down to all goroutines
- `prometheus.RunQueries()` accepts an existing DB connection instead of
  creating its own
- Go's `*sql.DB` is a thread-safe connection pool, so sharing it across
  goroutines is safe and doesn't hold idle connections open between samples