### PR TITLE
Fix OCP nightly e2e: wait for Prometheus scrape data before collecting

### DIFF
--- a/.github/scripts/wait-for-scrape-data.sh
+++ b/.github/scripts/wait-for-scrape-data.sh
@@ -4,6 +4,10 @@
 #
 # Usage: .github/scripts/wait-for-scrape-data.sh [thanos-url]
 #   thanos-url  Thanos query endpoint (default: http://localhost:9090)
+#
+# Environment variables (optional, for authenticated endpoints):
+#   BEARER_TOKEN   - Bearer token for Authorization header
+#   INSECURE_TLS   - Set to "true" to skip TLS verification (-k)
 
 set -euo pipefail
 
@@ -12,10 +16,18 @@ MAX_ATTEMPTS=60
 POLL_INTERVAL=5
 HISTORY_WAIT=180
 
+CURL_OPTS=(-sf)
+if [ "${INSECURE_TLS:-}" = "true" ]; then
+  CURL_OPTS+=(-k)
+fi
+if [ -n "${BEARER_TOKEN:-}" ]; then
+  CURL_OPTS+=(-H "Authorization: Bearer ${BEARER_TOKEN}")
+fi
+
 echo "Waiting for scrape data at $THANOS_URL ..."
 
 for i in $(seq 1 "$MAX_ATTEMPTS"); do
-  count=$(curl -sf "${THANOS_URL}/api/v1/query?query=up" \
+  count=$(curl "${CURL_OPTS[@]}" "${THANOS_URL}/api/v1/query?query=up" \
     | jq '.data.result | length' 2>/dev/null || echo 0)
   if [ "$count" -gt 0 ]; then
     echo "Thanos has data ($count series)"

--- a/.github/workflows/qe-ocp.yaml
+++ b/.github/workflows/qe-ocp.yaml
@@ -57,10 +57,17 @@ jobs:
       - name: Extract token and Thanos URL
         id: ocp-auth
         run: |
-          TOKEN=$(oc create token prometheus-k8s -n openshift-monitoring --duration=10m)
+          TOKEN=$(oc create token prometheus-k8s -n openshift-monitoring --duration=20m)
           THANOS_URL=$(oc get route thanos-querier -n openshift-monitoring -o jsonpath='{.spec.host}')
           echo "token=$TOKEN" >> "$GITHUB_OUTPUT"
           echo "thanos_url=$THANOS_URL" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for scrape data
+        timeout-minutes: 10
+        env:
+          BEARER_TOKEN: ${{ steps.ocp-auth.outputs.token }}
+          INSECURE_TLS: 'true'
+        run: .github/scripts/wait-for-scrape-data.sh "https://${{ steps.ocp-auth.outputs.thanos_url }}"
 
       - name: Collect once (range queries, token auth)
         run: |


### PR DESCRIPTION
The "Wait for scrape data" step was added for the K8s PR tests (`pre-main.yaml`) but was forgotten in the OCP nightly workflow (`qe-ocp.yaml`).
Without it, range queries (`since: 3m`) run before Prometheus has accumulated enough history, returning empty results and failing verification.
Added the same wait step to the OCP workflow, reusing `wait-for-scrape-data.sh` with new support for authenticated endpoints (`BEARER_TOKEN` and `INSECURE_TLS` env vars).
Bump token duration from 10m to 20m to account for the added wait time.
