### PR TITLE
reduce QE nightly flakiness from slow metrics startup

### DIFF
--- a/.github/scripts/wait-for-scrape-data.sh
+++ b/.github/scripts/wait-for-scrape-data.sh
@@ -2,8 +2,12 @@
 # Wait for Thanos/Prometheus to have scrape data, then wait for enough
 # history to satisfy range queries with since=3m.
 #
-# Usage: .github/scripts/wait-for-scrape-data.sh [thanos-url]
-#   thanos-url  Thanos query endpoint (default: http://localhost:9090)
+# Usage: .github/scripts/wait-for-scrape-data.sh <thanos-url> [metric-query...]
+#   thanos-url    Thanos query endpoint (default: http://localhost:9090)
+#   metric-query  Additional PromQL queries that must return data before the
+#                 history wait begins (e.g. "kube_pod_info" or "up{job='foo'}").
+#                 This prevents starting the timer before slower exporters
+#                 (like kube-state-metrics) are scraped.
 #
 # Environment variables (optional, for authenticated endpoints):
 #   BEARER_TOKEN   - Bearer token for Authorization header
@@ -12,9 +16,12 @@
 set -euo pipefail
 
 THANOS_URL="${1:-http://localhost:9090}"
-MAX_ATTEMPTS=60
+shift || true
+EXTRA_METRICS=("$@")
+
+MAX_ATTEMPTS=80
 POLL_INTERVAL=5
-HISTORY_WAIT=180
+HISTORY_WAIT=210
 
 CURL_OPTS=(-sf)
 if [ "${INSECURE_TLS:-}" = "true" ]; then
@@ -24,24 +31,38 @@ if [ -n "${BEARER_TOKEN:-}" ]; then
   CURL_OPTS+=(-H "Authorization: Bearer ${BEARER_TOKEN}")
 fi
 
-echo "Waiting for scrape data at $THANOS_URL ..."
+query_result_count() {
+  local query="$1"
+  curl "${CURL_OPTS[@]}" -G --data-urlencode "query=${query}" \
+    "${THANOS_URL}/api/v1/query" \
+    | jq '.data.result | length' 2>/dev/null || echo 0
+}
 
-for i in $(seq 1 "$MAX_ATTEMPTS"); do
-  count=$(curl "${CURL_OPTS[@]}" "${THANOS_URL}/api/v1/query?query=up" \
-    | jq '.data.result | length' 2>/dev/null || echo 0)
-  if [ "$count" -gt 0 ]; then
-    echo "Thanos has data ($count series)"
-    break
-  fi
-  echo "  attempt $i/$MAX_ATTEMPTS: waiting for scrape data..."
-  sleep "$POLL_INTERVAL"
+wait_for_metric() {
+  local query="$1" label="$2"
+  echo "Waiting for $label ($query) ..."
+  for i in $(seq 1 "$MAX_ATTEMPTS"); do
+    count=$(query_result_count "$query")
+    if [ "$count" -gt 0 ]; then
+      echo "  $label: $count series available"
+      return 0
+    fi
+    echo "  attempt $i/$MAX_ATTEMPTS: waiting for $label ..."
+    sleep "$POLL_INTERVAL"
+  done
+  echo "FAIL: $label returned no data after $((MAX_ATTEMPTS * POLL_INTERVAL))s"
+  return 1
+}
+
+# Phase 1: wait for any scrape data via the generic "up" metric.
+wait_for_metric "up" "scrape data"
+
+# Phase 2: wait for each additional metric the caller requires.
+for metric in "${EXTRA_METRICS[@]+"${EXTRA_METRICS[@]}"}"; do
+  wait_for_metric "$metric" "$metric"
 done
 
-if [ "$count" -eq 0 ] 2>/dev/null || [ -z "$count" ]; then
-  echo "FAIL: no metric data after $((MAX_ATTEMPTS * POLL_INTERVAL)) seconds"
-  exit 1
-fi
-
-echo "Waiting ${HISTORY_WAIT}s for range query coverage (since: 3m)..."
+# Phase 3: accumulate enough history for range queries (since: 3m + buffer).
+echo "Waiting ${HISTORY_WAIT}s for range query coverage (since: 3m + buffer)..."
 sleep "$HISTORY_WAIT"
 echo "Scrape history ready"

--- a/.github/workflows/qe-ocp.yaml
+++ b/.github/workflows/qe-ocp.yaml
@@ -67,7 +67,7 @@ jobs:
         env:
           BEARER_TOKEN: ${{ steps.ocp-auth.outputs.token }}
           INSECURE_TLS: 'true'
-        run: .github/scripts/wait-for-scrape-data.sh "https://${{ steps.ocp-auth.outputs.thanos_url }}"
+        run: .github/scripts/wait-for-scrape-data.sh "https://${{ steps.ocp-auth.outputs.thanos_url }}" kube_pod_info
 
       - name: Collect once (range queries, token auth)
         run: |


### PR DESCRIPTION
The QE nightly fails intermittently because `kube_pod_info` (from kube-state-metrics) isn't scraped
long enough when range queries execute. The wait script only checked for the generic `up` metric
before starting a fixed 180s timer — not enough for slower exporters.
- Accept extra metric queries in `wait-for-scrape-data.sh`; poll each until data appears before
  starting the history timer
- Pass `kube_pod_info` as a required metric in the workflow
- Increase polling limit (60→80 attempts) and history wait (180→210s) for CRC startup variance