### PR TITLE
support offline/disconnected Grafana usage

### DIFF
--- a/docs/grafana.md
+++ b/docs/grafana.md
@@ -48,6 +48,8 @@ Flags:
 | `--datasource` | Yes | Database type: `sqlite` or `postgres` | `--datasource=postgres` |
 | `--postgres-url` | If postgres | PostgreSQL connection string | `--postgres-url="postgresql://user:pass@host:5432/db"` |
 | `--port` | No | Grafana port (default: `3000`) | `--port=3001` |
+| `--image` | No | Override the default Grafana container image | `--image=my-registry/grafana:11.4.0` |
+| `--plugins-dir` | No | Path to local directory with pre-extracted plugins (skips online install) | `--plugins-dir=./plugins` |
 
 ### `grafana stop`
 
@@ -105,6 +107,90 @@ kpi-collector grafana start --datasource=postgres \
 kpi-collector grafana start --datasource=postgres \
   --postgres-url "postgresql://user:pass@db.example.com:5432/kpi_metrics"
 ```
+
+## Disconnected / Air-Gapped Environments
+
+By default, `grafana start` requires internet access for two operations:
+
+1. **Pulling the container image** (`docker.io/grafana/grafana:11.4.0`) — fails with
+   `short-name resolution enforced but cannot prompt without a TTY` on restricted hosts.
+2. **Downloading the SQLite plugin** (`frser-sqlite-datasource`) from
+   `https://grafana.com/api/plugins/frser-sqlite-datasource` — fails with a timeout on
+   air-gapped networks.
+
+Use the `--image` and `--plugins-dir` flags to bypass these network dependencies.
+
+### Step 1: Prepare Artifacts (on a connected machine)
+
+#### Container Image
+
+```bash
+# Pull the full image reference (use docker.io prefix to avoid short-name issues)
+podman pull docker.io/grafana/grafana:11.4.0
+
+# Save to a tar file for transfer to the disconnected host
+podman save docker.io/grafana/grafana:11.4.0 -o grafana-11.4.0.tar
+```
+
+#### SQLite Datasource Plugin
+
+Download the plugin ZIP from <https://grafana.com/grafana/plugins/frser-sqlite-datasource/>
+(select the version compatible with Grafana 11.x), then extract it:
+
+```bash
+mkdir -p grafana-plugins
+unzip frser-sqlite-datasource-*.zip -d grafana-plugins/
+```
+
+The resulting directory structure should look like:
+
+```
+grafana-plugins/
+└── frser-sqlite-datasource/
+    ├── plugin.json
+    ├── module.js
+    └── ...
+```
+
+### Step 2: Transfer to the Disconnected Host
+
+Copy both artifacts to the disconnected host (via USB, scp to a jump-host, etc.):
+
+- `grafana-11.4.0.tar`
+- `grafana-plugins/` directory
+
+### Step 3: Load the Image
+
+```bash
+podman load -i grafana-11.4.0.tar
+```
+
+Verify the image is available locally:
+
+```bash
+podman image inspect docker.io/grafana/grafana:11.4.0
+```
+
+### Step 4: Run Grafana Offline
+
+```bash
+kpi-collector grafana start --datasource=sqlite \
+  --image docker.io/grafana/grafana:11.4.0 \
+  --plugins-dir ./grafana-plugins
+```
+
+When `--image` is provided, the tool verifies the image exists locally before
+launching — if it is missing you will get a clear error with a `pull` or `load` hint.
+When `--plugins-dir` is provided, the directory is mounted into the container at
+`/var/lib/grafana/plugins` and the online plugin download (`GF_INSTALL_PLUGINS`) is skipped.
+
+### Alternative Workflow
+
+If Grafana is not needed on the disconnected host itself:
+
+1. Collect data on the disconnected host with `kpi-collector run`
+2. Copy the artifacts directory (containing the SQLite database) to a connected host
+3. Run `kpi-collector grafana start --datasource=sqlite --artifacts-dir <path>` on the connected host
 
 ## Accessing Grafana
 

--- a/internal/commands/grafana_start.go
+++ b/internal/commands/grafana_start.go
@@ -14,9 +14,11 @@ import (
 )
 
 var grafanaStartFlags struct {
-	datasource  string
-	postgresURL string
-	port        int
+	datasource   string
+	postgresURL  string
+	port         int
+	pluginsDir   string
+	image string
 }
 
 var grafanaStartCmd = &cobra.Command{
@@ -33,7 +35,11 @@ or use --artifacts-dir to point to the artifacts directory.`,
   # Using PostgreSQL
   kpi-collector grafana start --datasource=postgres --postgres-url "postgresql://user:pass@host:5432/dbname"
   # Custom port
-  kpi-collector grafana start --datasource=sqlite --port 3001`,
+  kpi-collector grafana start --datasource=sqlite --port 3001
+  # Offline/disconnected usage (pre-loaded image + local plugins)
+  kpi-collector grafana start --datasource=sqlite \
+    --image my-registry/grafana:11.4.0 \
+    --plugins-dir ./plugins/`,
 	RunE: runGrafanaStart,
 }
 
@@ -46,6 +52,10 @@ func init() {
 		"PostgreSQL connection string (required if datasource=postgres)")
 	grafanaStartCmd.Flags().IntVar(&grafanaStartFlags.port, "port", 3000,
 		"Grafana port (default: 3000)")
+	grafanaStartCmd.Flags().StringVar(&grafanaStartFlags.pluginsDir, "plugins-dir", "",
+		"path to a local directory containing pre-extracted Grafana plugins (skips online install)")
+	grafanaStartCmd.Flags().StringVar(&grafanaStartFlags.image, "image", "",
+		"override the default Grafana container image (default: grafana/grafana:11.4.0)")
 
 	if err := grafanaStartCmd.MarkFlagRequired("datasource"); err != nil {
 		panic(fmt.Sprintf("failed to mark datasource as required: %v", err))
@@ -59,6 +69,12 @@ func runGrafanaStart(cmd *cobra.Command, args []string) error {
 
 	if grafanaStartFlags.datasource == "postgres" && grafanaStartFlags.postgresURL == "" {
 		return fmt.Errorf("--postgres-url is required when datasource is 'postgres'")
+	}
+
+	if grafanaStartFlags.pluginsDir != "" {
+		if info, err := os.Stat(grafanaStartFlags.pluginsDir); err != nil || !info.IsDir() {
+			return fmt.Errorf("--plugins-dir %q is not a valid directory", grafanaStartFlags.pluginsDir)
+		}
 	}
 
 	fmt.Printf("Starting Grafana with %s datasource...\n", grafanaStartFlags.datasource)
@@ -221,6 +237,12 @@ func runGrafanaContainer(grafanaDir string) error {
 	}
 	fmt.Printf("Container Runtime found: %s\n", runtime)
 
+	if grafanaStartFlags.image != "" {
+		if err := verifyImageAvailable(runtime, grafanaStartFlags.image); err != nil {
+			return err
+		}
+	}
+
 	// Stop and remove existing container if it exists
 	stopCmd := exec.Command(runtime, "rm", "-f", grafanaContainerName)
 	_ = stopCmd.Run() // Ignore error if container doesn't exist
@@ -273,12 +295,26 @@ func runGrafanaContainer(grafanaDir string) error {
 
 		args = append(args,
 			"-v", fmt.Sprintf("%s:/var/lib/grafana/kpi_metrics.db:ro", absDBPath),
-			"-e", "GF_INSTALL_PLUGINS=frser-sqlite-datasource",
 		)
+
+		if grafanaStartFlags.pluginsDir != "" {
+			absPluginsDir, err := filepath.Abs(grafanaStartFlags.pluginsDir)
+			if err != nil {
+				return fmt.Errorf("failed to resolve plugins-dir path: %w", err)
+			}
+			args = append(args,
+				"-v", fmt.Sprintf("%s:/var/lib/grafana/plugins:ro", absPluginsDir),
+			)
+		} else {
+			args = append(args, "-e", "GF_INSTALL_PLUGINS=frser-sqlite-datasource")
+		}
 	}
 
-	// Add the image name
-	args = append(args, "grafana/grafana:11.4.0")
+	image := "grafana/grafana:11.4.0"
+	if grafanaStartFlags.image != "" {
+		image = grafanaStartFlags.image
+	}
+	args = append(args, image)
 
 	containerRuntimeCmd := exec.Command(runtime, args...)
 	output, err := containerRuntimeCmd.CombinedOutput()
@@ -286,6 +322,17 @@ func runGrafanaContainer(grafanaDir string) error {
 		return fmt.Errorf("%s run failed: %w\nOutput: %s", runtime, err, string(output))
 	}
 
+	return nil
+}
+
+func verifyImageAvailable(runtime, image string) error {
+	cmd := exec.Command(runtime, "image", "inspect", image)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf(
+			"image %q not found locally; pull or load it first (%s pull %s)\nOutput: %s",
+			image, runtime, image, string(output),
+		)
+	}
 	return nil
 }
 


### PR DESCRIPTION
Add `--grafana-image` and `--plugins-dir` flags to `grafana start` for air-gapped environments where internet access is unavailable.
### Changes
- `--grafana-image <image>`: override the default container image (`grafana/grafana:11.4.0`), verified locally via `image inspect` before launch
- `--plugins-dir <path>`: mount a local directory with pre-extracted plugins, skipping online `GF_INSTALL_PLUGINS` download
- Existing behavior preserved when neither flag is provided
- Added step-by-step disconnected usage guide to `docs/grafana.md`