### PR TITLE
Refactor run to execute Prom KPIs as a task

### DIFF
--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -26,10 +26,10 @@ import (
 // collection completes before the timer expires.
 const durationBuffer = 100 * time.Millisecond
 
-// RunOnce executes every KPI query exactly once and returns.
+// RunKPIsOnce executes every KPI query exactly once and returns.
 // It ignores frequency and duration settings entirely.
 // Returns an error if any queries failed.
-func RunOnce(kpis config.KPIs, flags config.InputFlags) error {
+func RunKPIsOnce(kpis config.KPIs, flags config.InputFlags) error {
 	db, dbImpl, err := database.InitDatabaseWithConfig(flags.DatabaseType, flags.PostgresURL)
 	if err != nil {
 		return fmt.Errorf("failed to init database: %v", err)
@@ -48,9 +48,9 @@ func RunOnce(kpis config.KPIs, flags config.InputFlags) error {
 	return err
 }
 
-// Run executes the KPI collection loop until duration expires or interrupted.
+// RunKPIs executes the KPI collection loop until duration expires or interrupted.
 // Returns an error if any query failures occurred during collection.
-func Run(kpis config.KPIs, flags config.InputFlags) error {
+func RunKPIs(kpis config.KPIs, flags config.InputFlags) error {
 	db, dbImpl, err := database.InitDatabaseWithConfig(flags.DatabaseType, flags.PostgresURL)
 	if err != nil {
 		return fmt.Errorf("failed to init database: %v", err)

--- a/internal/commands/run.go
+++ b/internal/commands/run.go
@@ -9,11 +9,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/redhat-best-practices-for-k8s/kpi-collection-tool/internal/collector"
 	"github.com/redhat-best-practices-for-k8s/kpi-collection-tool/internal/config"
 	"github.com/redhat-best-practices-for-k8s/kpi-collection-tool/internal/database"
 	"github.com/redhat-best-practices-for-k8s/kpi-collection-tool/internal/kubernetes"
 	"github.com/redhat-best-practices-for-k8s/kpi-collection-tool/internal/logger"
+	"github.com/redhat-best-practices-for-k8s/kpi-collection-tool/internal/task"
 
 	"github.com/spf13/cobra"
 )
@@ -58,7 +58,7 @@ Use --artifacts-dir to override.`,
   kpi-collector run --cluster-name prod --cluster-type hub \
     --kubeconfig ~/.kube/config --kpis-file kpis.yaml \
     --db-type postgres --postgres-url "postgresql://user:pass@localhost:5432/kpi"`,
-	RunE: runCollect,
+	RunE: runTasks,
 }
 
 func init() {
@@ -115,7 +115,7 @@ func init() {
 
 }
 
-func runCollect(cmd *cobra.Command, args []string) error {
+func runTasks(cmd *cobra.Command, args []string) error {
 	fmt.Println("KPI Collector starting...")
 
 	// Validate all flags (including cluster type)
@@ -202,12 +202,18 @@ func runCollect(cmd *cobra.Command, args []string) error {
 			tokenDuration)
 	}
 
-	// Run collection
-	var collectionErr error
-	if flags.SingleRun {
-		collectionErr = collector.RunOnce(kpis, flags)
-	} else {
-		collectionErr = collector.Run(kpis, flags)
+	tasks, err := task.ResolveFromFlags(flags, kpis)
+	if err != nil {
+		return err
+	}
+
+	var taskErr error
+	for _, t := range tasks {
+		log.Printf("Running task: %s", t.Name())
+		if err := t.Run(cmd.Context()); err != nil {
+			taskErr = err
+			break
+		}
 	}
 
 	absOutputDir, err := filepath.Abs(database.OutputDir)
@@ -216,8 +222,8 @@ func runCollect(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Printf("Artifacts stored in: %s\n", absOutputDir)
-	if collectionErr != nil {
-		return fmt.Errorf("collection completed with errors: %w", collectionErr)
+	if taskErr != nil {
+		return fmt.Errorf("collection completed with errors: %w", taskErr)
 	}
 
 	return nil

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -1,0 +1,53 @@
+// Package task defines runnable units executed by `kpi-collector run`.
+// Today only the Prometheus KPI task is supported; more task types can be
+// added later without rewriting the run command.
+package task
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/redhat-best-practices-for-k8s/kpi-collection-tool/internal/collector"
+	"github.com/redhat-best-practices-for-k8s/kpi-collection-tool/internal/config"
+)
+
+// Task is a single unit of work that `run` can execute.
+type Task interface {
+	Name() string
+	Run(ctx context.Context) error
+}
+
+// PromKPITask collects Prometheus/Thanos KPI metrics.
+type PromKPITask struct {
+	kpis  config.KPIs
+	flags config.InputFlags
+}
+
+// NewPromKPITask creates a Prom KPI collection task.
+func NewPromKPITask(kpis config.KPIs, flags config.InputFlags) *PromKPITask {
+	return &PromKPITask{kpis: kpis, flags: flags}
+}
+
+// Name returns the task identifier.
+func (t *PromKPITask) Name() string {
+	return "prom-kpis"
+}
+
+// Run executes Prom KPI collection (once or periodic based on flags).
+func (t *PromKPITask) Run(ctx context.Context) error {
+	_ = ctx // reserved for cancellation in later task types
+
+	if t.flags.SingleRun {
+		return collector.RunKPIsOnce(t.kpis, t.flags)
+	}
+	return collector.RunKPIs(t.kpis, t.flags)
+}
+
+// ResolveFromFlags builds the task list for this run.
+// Today only --kpis-file is supported (one Prom KPI task).
+func ResolveFromFlags(flags config.InputFlags, kpis config.KPIs) ([]Task, error) {
+	if flags.KPIsFile == "" {
+		return nil, fmt.Errorf("no tasks configured: --kpis-file is required")
+	}
+	return []Task{NewPromKPITask(kpis, flags)}, nil
+}

--- a/internal/task/task_suite_test.go
+++ b/internal/task/task_suite_test.go
@@ -1,0 +1,13 @@
+package task_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestTask(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Task Suite")
+}

--- a/internal/task/task_test.go
+++ b/internal/task/task_test.go
@@ -1,0 +1,31 @@
+package task_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/redhat-best-practices-for-k8s/kpi-collection-tool/internal/config"
+	"github.com/redhat-best-practices-for-k8s/kpi-collection-tool/internal/task"
+)
+
+var _ = Describe("ResolveFromFlags", func() {
+	It("returns one prom-kpis task when --kpis-file is set", func() {
+		flags := config.InputFlags{KPIsFile: "kpis.yaml"}
+		kpis := config.KPIs{Queries: []config.Query{{ID: "cpu", PromQuery: "up"}}}
+
+		tasks, err := task.ResolveFromFlags(flags, kpis)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(tasks).To(HaveLen(1))
+		Expect(tasks[0].Name()).To(Equal("prom-kpis"))
+	})
+
+	It("returns an error when no --kpis-file is set", func() {
+		flags := config.InputFlags{}
+		kpis := config.KPIs{}
+
+		tasks, err := task.ResolveFromFlags(flags, kpis)
+		Expect(err).To(HaveOccurred())
+		Expect(tasks).To(BeNil())
+		Expect(err.Error()).To(ContainSubstring("--kpis-file"))
+	})
+})


### PR DESCRIPTION
- Introduce a `Task` abstraction and run Prom KPI collection as `PromKPITask`
- Rename `runCollect` → `runTasks`, `collector.Run` → `RunKPIs`, `RunOnce` → `RunKPIsOnce`
- No CLI or behavior changes (`--kpis-file` path unchanged)