### PR TITLE
Rename --kpis-file flag and add multi-task config skeleton

### DIFF
--- a/internal/commands/run.go
+++ b/internal/commands/run.go
@@ -39,24 +39,24 @@ All artifacts (database, logs, output) are stored in ./kpi-collector-artifacts/ 
 Use --artifacts-dir to override.`,
 	Example: `  # Using kubeconfig (auto-discovery of Thanos URL and token)
   kpi-collector run --cluster-name prod --cluster-type ran \
-    --kubeconfig ~/.kube/config --kpis-file kpis.yaml
+    --kubeconfig ~/.kube/config --prom-kpis-config kpis.yaml
 
   # Using manual credentials
   kpi-collector run --cluster-name prod --cluster-type core \
-    --token $TOKEN --thanos-url thanos.example.com --kpis-file kpis.yaml
+    --token $TOKEN --thanos-url thanos.example.com --prom-kpis-config kpis.yaml
 
   # Collect all KPIs once and exit
   kpi-collector run --cluster-name prod --cluster-type ran \
-    --kubeconfig ~/.kube/config --kpis-file kpis.yaml --once
+    --kubeconfig ~/.kube/config --prom-kpis-config kpis.yaml --once
 
   # Custom sampling: every 30s for 2 hours
   kpi-collector run --cluster-name prod --cluster-type ran \
-    --kubeconfig ~/.kube/config --kpis-file kpis.yaml \
+    --kubeconfig ~/.kube/config --prom-kpis-config kpis.yaml \
     --frequency 30s --duration 2h
 
   # With PostgreSQL backend
   kpi-collector run --cluster-name prod --cluster-type hub \
-    --kubeconfig ~/.kube/config --kpis-file kpis.yaml \
+    --kubeconfig ~/.kube/config --prom-kpis-config kpis.yaml \
     --db-type postgres --postgres-url "postgresql://user:pass@localhost:5432/kpi"`,
 	RunE: runCollect,
 }
@@ -90,8 +90,21 @@ func init() {
 	runCmd.Flags().StringVar(&flags.PostgresURL, "postgres-url", "",
 		"PostgreSQL connection string (required if db-type=postgres)")
 
-	runCmd.Flags().StringVar(&flags.KPIsFile, "kpis-file", "",
-		"path to KPIs configuration file (required)")
+	// Task config flags
+	runCmd.Flags().StringVar(&flags.PromKPIsConfig, "prom-kpis-config", "",
+		"path to Prometheus KPI configuration file")
+	runCmd.Flags().StringVar(&flags.PromKPIsConfig, "kpis-file", "",
+		"[deprecated: use --prom-kpis-config] path to Prometheus KPI configuration file")
+	runCmd.Flags().StringVar(&flags.OslatConfig, "oslat-config", "",
+		"path to oslat task configuration file (not yet implemented)")
+	runCmd.Flags().StringVar(&flags.PerNodeConfig, "per-node-config", "",
+		"path to per-node task configuration file (not yet implemented)")
+	runCmd.Flags().StringVar(&flags.RecoveryConfig, "recovery-config", "",
+		"path to recovery task configuration file (not yet implemented)")
+
+	if err := runCmd.Flags().MarkDeprecated("kpis-file", "use --prom-kpis-config instead"); err != nil {
+		panic(fmt.Sprintf("failed to mark kpis-file as deprecated: %v", err))
+	}
 
 	// Single-run mode
 	runCmd.Flags().BoolVar(&flags.SingleRun, "once", false,
@@ -104,9 +117,6 @@ func init() {
 	// Mark required flags
 	if err := runCmd.MarkFlagRequired("cluster-name"); err != nil {
 		panic(fmt.Sprintf("failed to mark cluster-name as required: %v", err))
-	}
-	if err := runCmd.MarkFlagRequired("kpis-file"); err != nil {
-		panic(fmt.Sprintf("failed to mark kpis-file as required: %v", err))
 	}
 
 	// --once is mutually exclusive with --frequency and --duration
@@ -147,11 +157,11 @@ func runCollect(cmd *cobra.Command, args []string) error {
 	log.Println("KPI Collector initialized")
 
 	// Load KPI queries
-	kpis, err := config.LoadKPIs(flags.KPIsFile)
+	kpis, err := config.LoadKPIs(flags.PromKPIsConfig)
 	if err != nil {
 		return fmt.Errorf("failed to load KPI queries: %w", err)
 	}
-	log.Printf("Loaded KPIs from %s", flags.KPIsFile)
+	log.Printf("Loaded KPIs from %s", flags.PromKPIsConfig)
 
 	// Validate KPI configurations (syntax, duplicates, etc.)
 	if validationErrors := config.ValidateKPIs(kpis); len(validationErrors) > 0 {

--- a/internal/config/cli_flags.go
+++ b/internal/config/cli_flags.go
@@ -4,13 +4,12 @@ import (
 	"fmt"
 )
 
-// validateFlags ensures the correct combination of flags is provided
+// ValidateFlags ensures the correct combination of flags is provided
 func ValidateFlags(flags InputFlags) error {
 	if flags.ClusterName == "" {
 		return fmt.Errorf("cluster name is required: use --cluster-name flag")
 	}
 
-	// Validate cluster type is provided and valid
 	validClusterTypes := map[string]bool{"ran": true, "core": true, "hub": true}
 	if flags.ClusterType == "" {
 		return fmt.Errorf("cluster-type is required: must be 'ran', 'core', or 'hub'")
@@ -23,12 +22,15 @@ func ValidateFlags(flags InputFlags) error {
 		fmt.Println("WARNING: TLS certificate verification is disabled. Use only in development environments.")
 	}
 
-	// Validate flag combinations for authentication
 	validAuthCombo := (flags.BearerToken != "" && flags.ThanosURL != "" && flags.Kubeconfig == "") ||
 		(flags.BearerToken == "" && flags.ThanosURL == "" && flags.Kubeconfig != "")
 
 	if !validAuthCombo {
 		return fmt.Errorf("invalid flag combination: either provide --token and --thanos-url, or provide --kubeconfig")
+	}
+
+	if !flags.HasAnyTaskConfig() {
+		return fmt.Errorf("at least one task config flag is required (--prom-kpis-config, --oslat-config, --per-node-config, or --recovery-config)")
 	}
 
 	if flags.SamplingFreq <= 0 {
@@ -45,10 +47,6 @@ func ValidateFlags(flags InputFlags) error {
 
 	if flags.DatabaseType == "postgres" && flags.PostgresURL == "" {
 		return fmt.Errorf("postgres-url is required when db-type=postgres")
-	}
-
-	if flags.KPIsFile == "" {
-		return fmt.Errorf("kpis-file must be specified")
 	}
 
 	return nil

--- a/internal/config/cli_flags_test.go
+++ b/internal/config/cli_flags_test.go
@@ -16,7 +16,7 @@ const (
 	validSamplingFreq = 60 * time.Second
 	validDuration     = 45 * time.Minute
 	validDatabaseType = "sqlite"
-	validKPIsFile     = "/path/to/kpis.yaml"
+	validPromKPIsConfig = "/path/to/kpis.yaml"
 
 	errClusterNameRequiredMsg = "cluster name is required: use --cluster-name flag"
 	errClusterTypeRequiredMsg = "cluster-type is required: must be 'ran', 'core', or 'hub'"
@@ -26,7 +26,7 @@ const (
 	errDurationMsg            = "duration must be greater than 0"
 	errInvalidDBTypeMsg       = "invalid db-type: must be 'sqlite' or 'postgres'"
 	errPostgresURLRequiredMsg = "postgres-url is required when db-type=postgres"
-	errKPIsFileMsg            = "kpis-file must be specified"
+	errNoTaskConfigMsg = "at least one task config flag is required (--prom-kpis-config, --oslat-config, --per-node-config, or --recovery-config)"
 )
 
 var _ = Describe("validateFlags test", func() {
@@ -53,7 +53,7 @@ var _ = Describe("validateFlags test", func() {
 				SamplingFreq: validSamplingFreq,
 				Duration:     validDuration,
 				DatabaseType: validDatabaseType,
-				KPIsFile:     validKPIsFile,
+				PromKPIsConfig: validPromKPIsConfig,
 			},
 			"", // no error expected
 		),
@@ -65,7 +65,7 @@ var _ = Describe("validateFlags test", func() {
 				SamplingFreq: validSamplingFreq,
 				Duration:     validDuration,
 				DatabaseType: validDatabaseType,
-				KPIsFile:     validKPIsFile,
+				PromKPIsConfig: validPromKPIsConfig,
 			},
 			"",
 		),
@@ -87,7 +87,7 @@ var _ = Describe("validateFlags test", func() {
 				SamplingFreq: validSamplingFreq,
 				Duration:     validDuration,
 				DatabaseType: validDatabaseType,
-				KPIsFile:     validKPIsFile,
+				PromKPIsConfig: validPromKPIsConfig,
 			},
 			errClusterTypeRequiredMsg,
 		),
@@ -100,7 +100,7 @@ var _ = Describe("validateFlags test", func() {
 				SamplingFreq: validSamplingFreq,
 				Duration:     validDuration,
 				DatabaseType: validDatabaseType,
-				KPIsFile:     validKPIsFile,
+				PromKPIsConfig: validPromKPIsConfig,
 			},
 			errInvalidClusterTypeMsg,
 		),
@@ -166,7 +166,7 @@ var _ = Describe("validateFlags test", func() {
 				SamplingFreq: 0,
 				Duration:     validDuration,
 				DatabaseType: validDatabaseType,
-				KPIsFile:     validKPIsFile,
+				PromKPIsConfig: validPromKPIsConfig,
 			},
 			errSamplingFreqMsg,
 		),
@@ -179,7 +179,7 @@ var _ = Describe("validateFlags test", func() {
 				SamplingFreq: -10,
 				Duration:     validDuration,
 				DatabaseType: validDatabaseType,
-				KPIsFile:     validKPIsFile,
+				PromKPIsConfig: validPromKPIsConfig,
 			},
 			errSamplingFreqMsg,
 		),
@@ -193,7 +193,7 @@ var _ = Describe("validateFlags test", func() {
 				SamplingFreq: validSamplingFreq,
 				Duration:     0,
 				DatabaseType: validDatabaseType,
-				KPIsFile:     validKPIsFile,
+				PromKPIsConfig: validPromKPIsConfig,
 			},
 			errDurationMsg,
 		),
@@ -206,7 +206,7 @@ var _ = Describe("validateFlags test", func() {
 				SamplingFreq: validSamplingFreq,
 				Duration:     -10 * time.Minute,
 				DatabaseType: validDatabaseType,
-				KPIsFile:     validKPIsFile,
+				PromKPIsConfig: validPromKPIsConfig,
 			},
 			errDurationMsg,
 		),
@@ -220,7 +220,7 @@ var _ = Describe("validateFlags test", func() {
 				SamplingFreq: validSamplingFreq,
 				Duration:     validDuration,
 				DatabaseType: "mysql",
-				KPIsFile:     validKPIsFile,
+				PromKPIsConfig: validPromKPIsConfig,
 			},
 			errInvalidDBTypeMsg,
 		),
@@ -233,7 +233,7 @@ var _ = Describe("validateFlags test", func() {
 				SamplingFreq: validSamplingFreq,
 				Duration:     validDuration,
 				DatabaseType: "",
-				KPIsFile:     validKPIsFile,
+				PromKPIsConfig: validPromKPIsConfig,
 			},
 			errInvalidDBTypeMsg,
 		),
@@ -248,7 +248,7 @@ var _ = Describe("validateFlags test", func() {
 				Duration:     validDuration,
 				DatabaseType: "postgres",
 				PostgresURL:  "",
-				KPIsFile:     validKPIsFile,
+				PromKPIsConfig: validPromKPIsConfig,
 			},
 			errPostgresURLRequiredMsg,
 		),
@@ -263,7 +263,7 @@ var _ = Describe("validateFlags test", func() {
 				Duration:     validDuration,
 				DatabaseType: "postgres",
 				PostgresURL:  "postgresql://user:pass@localhost:5432/dbname",
-				KPIsFile:     validKPIsFile,
+				PromKPIsConfig: validPromKPIsConfig,
 			},
 			"",
 		),
@@ -278,12 +278,12 @@ var _ = Describe("validateFlags test", func() {
 				SamplingFreq: validSamplingFreq,
 				Duration:     validDuration,
 				DatabaseType: validDatabaseType,
-				KPIsFile:     validKPIsFile,
+				PromKPIsConfig: validPromKPIsConfig,
 			},
 			"",
 		),
-		// Error cases - missing KPIs file
-		Entry("empty kpis-file",
+		// Error cases - no task config flag set
+		Entry("no task config flags",
 			InputFlags{
 				ClusterName:  validClusterName,
 				ClusterType:  validClusterType,
@@ -292,9 +292,9 @@ var _ = Describe("validateFlags test", func() {
 				SamplingFreq: validSamplingFreq,
 				Duration:     validDuration,
 				DatabaseType: validDatabaseType,
-				KPIsFile:     "",
+				PromKPIsConfig: "",
 			},
-			errKPIsFileMsg,
+			errNoTaskConfigMsg,
 		),
 	)
 })

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -121,19 +121,27 @@ type RangeWindow struct {
 
 // InputFlags holds all command line flag values
 type InputFlags struct {
-	BearerToken  string
-	ThanosURL    string
-	Kubeconfig   string
-	ClusterName  string
-	ClusterType  string
-	InsecureTLS  bool
-	SamplingFreq time.Duration
-	Duration     time.Duration
-	DatabaseType string // "sqlite" or "postgres"
-	PostgresURL  string // PostgreSQL connection string
-	KPIsFile     string
-	SingleRun    bool // collect metrics once and exit
-	SkipPrompts  bool // skip interactive prompts (--yes/-y)
+	BearerToken    string
+	ThanosURL      string
+	Kubeconfig     string
+	ClusterName    string
+	ClusterType    string
+	InsecureTLS    bool
+	SamplingFreq   time.Duration
+	Duration       time.Duration
+	DatabaseType   string // "sqlite" or "postgres"
+	PostgresURL    string // PostgreSQL connection string
+	PromKPIsConfig string // path to Prom KPI config file (--prom-kpis-config / --kpis-file)
+	OslatConfig    string // path to oslat task config file (not yet implemented)
+	PerNodeConfig  string // path to per-node task config file (not yet implemented)
+	RecoveryConfig string // path to recovery task config file (not yet implemented)
+	SingleRun      bool   // collect metrics once and exit
+	SkipPrompts    bool   // skip interactive prompts (--yes/-y)
+}
+
+// HasAnyTaskConfig returns true if at least one task config flag is set.
+func (f InputFlags) HasAnyTaskConfig() bool {
+	return f.PromKPIsConfig != "" || f.OslatConfig != "" || f.PerNodeConfig != "" || f.RecoveryConfig != ""
 }
 
 // Query represents a single KPI query configuration


### PR DESCRIPTION
### Summary
- Rename `--kpis-file` to `--prom-kpis-config` (old flag kept as deprecated alias)
- Add placeholder CLI flags: `--oslat-config`, `--per-node-config`, `--recovery-config`
- Relax validation to require at least one task config flag instead of mandating `--kpis-file`

#### Backward Compatibility
Existing scripts using `--kpis-file` continue to work unchanged. Users see a deprecation notice suggesting `--prom-kpis-config`.