### PR TITLE
Fix task package compile error after KPIsFile rename

### DIFF
--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -44,10 +44,10 @@ func (t *PromKPITask) Run(ctx context.Context) error {
 }
 
 // ResolveFromFlags builds the task list for this run.
-// Today only --kpis-file is supported (one Prom KPI task).
+// Today only --prom-kpis-config is supported (one Prom KPI task).
 func ResolveFromFlags(flags config.InputFlags, kpis config.KPIs) ([]Task, error) {
-	if flags.KPIsFile == "" {
-		return nil, fmt.Errorf("no tasks configured: --kpis-file is required")
+	if flags.PromKPIsConfig == "" {
+		return nil, fmt.Errorf("no tasks configured: --prom-kpis-config is required")
 	}
 	return []Task{NewPromKPITask(kpis, flags)}, nil
 }

--- a/internal/task/task_test.go
+++ b/internal/task/task_test.go
@@ -9,8 +9,8 @@ import (
 )
 
 var _ = Describe("ResolveFromFlags", func() {
-	It("returns one prom-kpis task when --kpis-file is set", func() {
-		flags := config.InputFlags{KPIsFile: "kpis.yaml"}
+	It("returns one prom-kpis task when --prom-kpis-config is set", func() {
+		flags := config.InputFlags{PromKPIsConfig: "kpis.yaml"}
 		kpis := config.KPIs{Queries: []config.Query{{ID: "cpu", PromQuery: "up"}}}
 
 		tasks, err := task.ResolveFromFlags(flags, kpis)
@@ -19,13 +19,13 @@ var _ = Describe("ResolveFromFlags", func() {
 		Expect(tasks[0].Name()).To(Equal("prom-kpis"))
 	})
 
-	It("returns an error when no --kpis-file is set", func() {
+	It("returns an error when no --prom-kpis-config is set", func() {
 		flags := config.InputFlags{}
 		kpis := config.KPIs{}
 
 		tasks, err := task.ResolveFromFlags(flags, kpis)
 		Expect(err).To(HaveOccurred())
 		Expect(tasks).To(BeNil())
-		Expect(err.Error()).To(ContainSubstring("--kpis-file"))
+		Expect(err.Error()).To(ContainSubstring("--prom-kpis-config"))
 	})
 })


### PR DESCRIPTION
Fix merge artifact from PRs #138 and #139: `internal/task/` still referenced the old `KPIsFile` field renamed to `PromKPIsConfig`.
- Update `ResolveFromFlags` and tests to use `PromKPIsConfig`