### PR TITLE
Wire multi-task resolver, and --parallel flag

### DIFF
--- a/internal/commands/run.go
+++ b/internal/commands/run.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/redhat-best-practices-for-k8s/kpi-collection-tool/internal/config"
@@ -110,6 +111,10 @@ func init() {
 	runCmd.Flags().BoolVar(&flags.SingleRun, "once", false,
 		"collect all KPI metrics once and exit (ignores --frequency and --duration)")
 
+	// Multi-task execution mode
+	runCmd.Flags().BoolVar(&flags.Parallel, "parallel", false,
+		"run tasks concurrently instead of sequentially")
+
 	// Skip interactive prompts
 	runCmd.Flags().BoolVarP(&flags.SkipPrompts, "yes", "y", false,
 		"skip interactive prompts (e.g. category advisory)")
@@ -189,7 +194,7 @@ func runTasks(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	failedTasks := runAllTasks(cmd, tasks)
+	failedTasks := runAllTasks(cmd, tasks, flags.Parallel)
 
 	absOutputDir, err := filepath.Abs(database.OutputDir)
 	if err != nil {
@@ -243,20 +248,36 @@ func setupPromKPIs(flags config.InputFlags) (config.KPIs, error) {
 	return kpis, nil
 }
 
-// runAllTasks executes tasks sequentially with continue-on-failure.
+// runAllTasks executes tasks with continue-on-failure.
+// When parallel is true, tasks run concurrently; otherwise sequentially.
 // Returns the names of any tasks that failed.
-func runAllTasks(cmd *cobra.Command, tasks []task.Task) []string {
+func runAllTasks(cmd *cobra.Command, tasks []task.Task, parallel bool) []string {
+	var mu sync.Mutex
 	var failedTasks []string
+	var wg sync.WaitGroup
 
-	for _, t := range tasks {
+	run := func(t task.Task) {
+		defer wg.Done()
 		log.Printf("Running task: %s", t.Name())
 		if err := t.Run(cmd.Context()); err != nil {
 			log.Printf("Task %s failed: %v", t.Name(), err)
 			fmt.Fprintf(os.Stderr, "Task %s failed: %v\n", t.Name(), err)
+			mu.Lock()
 			failedTasks = append(failedTasks, t.Name())
+			mu.Unlock()
 		}
 	}
 
+	for _, t := range tasks {
+		wg.Add(1)
+		if parallel {
+			go run(t)
+		} else {
+			run(t)
+		}
+	}
+
+	wg.Wait()
 	return failedTasks
 }
 

--- a/internal/commands/run.go
+++ b/internal/commands/run.go
@@ -156,42 +156,13 @@ func runTasks(cmd *cobra.Command, args []string) error {
 
 	log.Println("KPI Collector initialized")
 
-	// Load KPI queries
-	kpis, err := config.LoadKPIs(flags.PromKPIsConfig)
-	if err != nil {
-		return fmt.Errorf("failed to load KPI queries: %w", err)
-	}
-	log.Printf("Loaded KPIs from %s", flags.PromKPIsConfig)
-
-	// Validate KPI configurations (syntax, duplicates, etc.)
-	if validationErrors := config.ValidateKPIs(kpis); len(validationErrors) > 0 {
-		fmt.Println("KPI validation errors:")
-		for _, e := range validationErrors {
-			fmt.Printf("  ✗ %v\n", e)
-		}
-		return fmt.Errorf("found %d KPI validation error(s)", len(validationErrors))
-	}
-	fmt.Printf("✓ Validated %d KPI(s)\n", len(kpis.Queries))
-
-	if !flags.SkipPrompts {
-		if abort := promptIfManyUncategorized(kpis); abort {
-			return fmt.Errorf("aborted by user")
-		}
-	}
-
-	kpis, err = substituteCPUsIfNeeded(kpis, flags)
-	if err != nil {
-		return err
-	}
-
-	if !flags.SingleRun {
-		warnFrequencyExceedsDuration(kpis, flags)
-	}
-
-	// Validate range query frequency/range mismatches (only relevant for periodic collection)
-	if !flags.SingleRun {
-		if err := validateRangeFrequency(kpis, flags); err != nil {
-			return err
+	// Prom-specific setup: only when --prom-kpis-config is set
+	var kpis config.KPIs
+	if flags.PromKPIsConfig != "" {
+		var setupErr error
+		kpis, setupErr = setupPromKPIs(flags)
+		if setupErr != nil {
+			return setupErr
 		}
 	}
 
@@ -201,9 +172,10 @@ func runTasks(cmd *cobra.Command, args []string) error {
 
 		tokenDuration := tokenDurationForCollection(flags.SingleRun, flags.Duration)
 
-		flags.ThanosURL, flags.BearerToken, err = kubernetes.SetupKubeconfigAuth(flags.Kubeconfig, tokenDuration)
-		if err != nil {
-			return fmt.Errorf("failed to setup kubeconfig auth: %w", err)
+		var authErr error
+		flags.ThanosURL, flags.BearerToken, authErr = kubernetes.SetupKubeconfigAuth(flags.Kubeconfig, tokenDuration)
+		if authErr != nil {
+			return fmt.Errorf("failed to setup kubeconfig auth: %w", authErr)
 		}
 		fmt.Printf("Discovered Thanos URL: %s\n", flags.ThanosURL)
 		fmt.Printf("Created service account token (sa=%s, ns=%s, expiry=%s)\n",
@@ -217,26 +189,75 @@ func runTasks(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	var taskErr error
-	for _, t := range tasks {
-		log.Printf("Running task: %s", t.Name())
-		if err := t.Run(cmd.Context()); err != nil {
-			taskErr = err
-			break
-		}
-	}
+	failedTasks := runAllTasks(cmd, tasks)
 
 	absOutputDir, err := filepath.Abs(database.OutputDir)
 	if err != nil {
 		absOutputDir = database.OutputDir
 	}
-
 	fmt.Printf("Artifacts stored in: %s\n", absOutputDir)
-	if taskErr != nil {
-		return fmt.Errorf("collection completed with errors: %w", taskErr)
+
+	if len(failedTasks) > 0 {
+		return fmt.Errorf("tasks failed: %s", strings.Join(failedTasks, ", "))
 	}
 
 	return nil
+}
+
+// setupPromKPIs loads, validates, and prepares Prom KPI queries.
+func setupPromKPIs(flags config.InputFlags) (config.KPIs, error) {
+	kpis, err := config.LoadKPIs(flags.PromKPIsConfig)
+	if err != nil {
+		return config.KPIs{}, fmt.Errorf("failed to load KPI queries: %w", err)
+	}
+	log.Printf("Loaded KPIs from %s", flags.PromKPIsConfig)
+
+	if validationErrors := config.ValidateKPIs(kpis); len(validationErrors) > 0 {
+		fmt.Println("KPI validation errors:")
+		for _, e := range validationErrors {
+			fmt.Printf("  ✗ %v\n", e)
+		}
+		return config.KPIs{}, fmt.Errorf("found %d KPI validation error(s)", len(validationErrors))
+	}
+	fmt.Printf("✓ Validated %d KPI(s)\n", len(kpis.Queries))
+
+	if !flags.SkipPrompts {
+		if abort := promptIfManyUncategorized(kpis); abort {
+			return config.KPIs{}, fmt.Errorf("aborted by user")
+		}
+	}
+
+	kpis, err = substituteCPUsIfNeeded(kpis, flags)
+	if err != nil {
+		return config.KPIs{}, err
+	}
+
+	if !flags.SingleRun {
+		warnFrequencyExceedsDuration(kpis, flags)
+
+		if err := validateRangeFrequency(kpis, flags); err != nil {
+			return config.KPIs{}, err
+		}
+	}
+
+	return kpis, nil
+}
+
+// runAllTasks executes tasks sequentially with continue-on-failure.
+// Returns the names of any tasks that failed.
+func runAllTasks(cmd *cobra.Command, tasks []task.Task) []string {
+	var failedTasks []string
+
+	for _, t := range tasks {
+		log.Printf("Running task: %s", t.Name())
+		if err := t.Run(cmd.Context()); err != nil {
+			log.Printf("Task %s failed: %v", t.Name(), err)
+			fmt.Fprintf(os.Stderr, "Task %s failed: %v\n", t.Name(), err)
+			failedTasks = append(failedTasks, t.Name())
+		}
+	}
+
+	return failedTasks
 }
 
 func databaseLocation(flags config.InputFlags) string {

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -136,6 +136,7 @@ type InputFlags struct {
 	PerNodeConfig  string // path to per-node task config file (not yet implemented)
 	RecoveryConfig string // path to recovery task config file (not yet implemented)
 	SingleRun      bool   // collect metrics once and exit
+	Parallel       bool   // run tasks concurrently instead of sequentially
 	SkipPrompts    bool   // skip interactive prompts (--yes/-y)
 }
 

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -43,20 +43,12 @@ func (t *PromKPITask) Run(ctx context.Context) error {
 	return collector.RunKPIs(t.kpis, t.flags)
 }
 
-<<<<<<< HEAD
 // ResolveFromFlags builds the task list from whichever config flags are set.
 func ResolveFromFlags(flags config.InputFlags, kpis config.KPIs) ([]Task, error) {
 	var tasks []Task
 
 	if flags.PromKPIsConfig != "" {
 		tasks = append(tasks, NewPromKPITask(kpis, flags))
-=======
-// ResolveFromFlags builds the task list for this run.
-// Today only --prom-kpis-config is supported (one Prom KPI task).
-func ResolveFromFlags(flags config.InputFlags, kpis config.KPIs) ([]Task, error) {
-	if flags.PromKPIsConfig == "" {
-		return nil, fmt.Errorf("no tasks configured: --prom-kpis-config is required")
->>>>>>> upstream/main
 	}
 
 	// TODO: implement OslatTask and wire here

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -43,11 +43,32 @@ func (t *PromKPITask) Run(ctx context.Context) error {
 	return collector.RunKPIs(t.kpis, t.flags)
 }
 
-// ResolveFromFlags builds the task list for this run.
-// Today only --kpis-file is supported (one Prom KPI task).
+// ResolveFromFlags builds the task list from whichever config flags are set.
 func ResolveFromFlags(flags config.InputFlags, kpis config.KPIs) ([]Task, error) {
-	if flags.KPIsFile == "" {
-		return nil, fmt.Errorf("no tasks configured: --kpis-file is required")
+	var tasks []Task
+
+	if flags.PromKPIsConfig != "" {
+		tasks = append(tasks, NewPromKPITask(kpis, flags))
 	}
-	return []Task{NewPromKPITask(kpis, flags)}, nil
+
+	// TODO: implement OslatTask and wire here
+	if flags.OslatConfig != "" {
+		return nil, fmt.Errorf("--oslat-config: task type not yet supported")
+	}
+
+	// TODO: implement PerNodeTask and wire here
+	if flags.PerNodeConfig != "" {
+		return nil, fmt.Errorf("--per-node-config: task type not yet supported")
+	}
+
+	// TODO: implement RecoveryTask and wire here
+	if flags.RecoveryConfig != "" {
+		return nil, fmt.Errorf("--recovery-config: task type not yet supported")
+	}
+
+	if len(tasks) == 0 {
+		return nil, fmt.Errorf("no tasks configured: at least one task config flag is required (e.g. --prom-kpis-config)")
+	}
+
+	return tasks, nil
 }

--- a/internal/task/task_test.go
+++ b/internal/task/task_test.go
@@ -9,8 +9,8 @@ import (
 )
 
 var _ = Describe("ResolveFromFlags", func() {
-	It("returns one prom-kpis task when --kpis-file is set", func() {
-		flags := config.InputFlags{KPIsFile: "kpis.yaml"}
+	It("returns one prom-kpis task when --prom-kpis-config is set", func() {
+		flags := config.InputFlags{PromKPIsConfig: "kpis.yaml"}
 		kpis := config.KPIs{Queries: []config.Query{{ID: "cpu", PromQuery: "up"}}}
 
 		tasks, err := task.ResolveFromFlags(flags, kpis)
@@ -19,13 +19,56 @@ var _ = Describe("ResolveFromFlags", func() {
 		Expect(tasks[0].Name()).To(Equal("prom-kpis"))
 	})
 
-	It("returns an error when no --kpis-file is set", func() {
+	It("returns an error when no task config flags are set", func() {
 		flags := config.InputFlags{}
 		kpis := config.KPIs{}
 
 		tasks, err := task.ResolveFromFlags(flags, kpis)
 		Expect(err).To(HaveOccurred())
 		Expect(tasks).To(BeNil())
-		Expect(err.Error()).To(ContainSubstring("--kpis-file"))
+		Expect(err.Error()).To(ContainSubstring("no tasks configured"))
+	})
+
+	It("returns not-yet-supported error for --oslat-config", func() {
+		flags := config.InputFlags{OslatConfig: "oslat.yaml"}
+		kpis := config.KPIs{}
+
+		tasks, err := task.ResolveFromFlags(flags, kpis)
+		Expect(err).To(HaveOccurred())
+		Expect(tasks).To(BeNil())
+		Expect(err.Error()).To(ContainSubstring("not yet supported"))
+	})
+
+	It("returns not-yet-supported error for --per-node-config", func() {
+		flags := config.InputFlags{PerNodeConfig: "per-node.yaml"}
+		kpis := config.KPIs{}
+
+		tasks, err := task.ResolveFromFlags(flags, kpis)
+		Expect(err).To(HaveOccurred())
+		Expect(tasks).To(BeNil())
+		Expect(err.Error()).To(ContainSubstring("not yet supported"))
+	})
+
+	It("returns not-yet-supported error for --recovery-config", func() {
+		flags := config.InputFlags{RecoveryConfig: "recovery.yaml"}
+		kpis := config.KPIs{}
+
+		tasks, err := task.ResolveFromFlags(flags, kpis)
+		Expect(err).To(HaveOccurred())
+		Expect(tasks).To(BeNil())
+		Expect(err.Error()).To(ContainSubstring("not yet supported"))
+	})
+
+	It("returns not-yet-supported error even when prom is also set", func() {
+		flags := config.InputFlags{
+			PromKPIsConfig: "kpis.yaml",
+			OslatConfig:    "oslat.yaml",
+		}
+		kpis := config.KPIs{}
+
+		tasks, err := task.ResolveFromFlags(flags, kpis)
+		Expect(err).To(HaveOccurred())
+		Expect(tasks).To(BeNil())
+		Expect(err.Error()).To(ContainSubstring("not yet supported"))
 	})
 })


### PR DESCRIPTION
- Update `ResolveFromFlags` to check all task config flags and build a task list
- Extract Prom-specific setup (load, validate, CPU substitution) into `setupPromKPIs` — only runs when `--prom-kpis-config` is set.
- Replace fail-fast task loop with continue-on-failure: runs all tasks, reports failures at the end
- Non-prom flags (`--oslat-config`, `--per-node-config`, `--recovery-config`) return "not yet supported" with TODO placeholders
- Add `--parallel` flag to run tasks concurrently instead of sequentially
