### PR TITLE
add --bundle flag for playlist-based task execution

### DIFF
--- a/internal/commands/run.go
+++ b/internal/commands/run.go
@@ -58,7 +58,11 @@ Use --artifacts-dir to override.`,
   # With PostgreSQL backend
   kpi-collector run --cluster-name prod --cluster-type hub \
     --kubeconfig ~/.kube/config --prom-kpis-config kpis.yaml \
-    --db-type postgres --postgres-url "postgresql://user:pass@localhost:5432/kpi"`,
+    --db-type postgres --postgres-url "postgresql://user:pass@localhost:5432/kpi"
+
+  # Run a bundle (directory with bundle.yaml + task files)
+  kpi-collector run --cluster-name prod --cluster-type ran \
+    --kubeconfig ~/.kube/config --bundle nokia-ran-bundle/`,
 	RunE: runTasks,
 }
 
@@ -111,6 +115,10 @@ func init() {
 	runCmd.Flags().BoolVar(&flags.SingleRun, "once", false,
 		"collect all KPI metrics once and exit (ignores --frequency and --duration)")
 
+	// Bundle mode
+	runCmd.Flags().StringVar(&flags.BundleConfig, "bundle", "",
+		"path to bundle file or directory containing bundle.yaml and task files")
+
 	// Multi-task execution mode
 	runCmd.Flags().BoolVar(&flags.Parallel, "parallel", false,
 		"run tasks concurrently instead of sequentially")
@@ -127,6 +135,12 @@ func init() {
 	// --once is mutually exclusive with --frequency and --duration
 	runCmd.MarkFlagsMutuallyExclusive("once", "frequency")
 	runCmd.MarkFlagsMutuallyExclusive("once", "duration")
+
+	// --bundle is mutually exclusive with typed config flags
+	runCmd.MarkFlagsMutuallyExclusive("bundle", "prom-kpis-config")
+	runCmd.MarkFlagsMutuallyExclusive("bundle", "oslat-config")
+	runCmd.MarkFlagsMutuallyExclusive("bundle", "per-node-config")
+	runCmd.MarkFlagsMutuallyExclusive("bundle", "recovery-config")
 
 }
 
@@ -189,12 +203,40 @@ func runTasks(cmd *cobra.Command, args []string) error {
 			tokenDuration)
 	}
 
-	tasks, err := task.ResolveFromFlags(flags, kpis)
+	// Resolve tasks: either from a bundle or from individual flags
+	var tasks []task.Task
+	var bundleSpec *task.BundleSpec
+
+	if flags.BundleConfig != "" {
+		var spec task.BundleSpec
+		spec, err = task.LoadBundle(flags.BundleConfig)
+		if err != nil {
+			return fmt.Errorf("failed to load bundle: %w", err)
+		}
+		bundleSpec = &spec
+		log.Printf("Loaded bundle from %s (%d task(s), mode=%s, on-failure=%s)",
+			flags.BundleConfig, len(spec.Tasks), spec.Mode, spec.OnFailure)
+
+		tasks, err = task.ResolveBundleTasks(spec, flags, kpis)
+	} else {
+		tasks, err = task.ResolveFromFlags(flags, kpis)
+	}
 	if err != nil {
 		return err
 	}
 
-	failedTasks := runAllTasks(cmd, tasks, flags.Parallel)
+	parallel := flags.Parallel
+	failFast := false
+	if bundleSpec != nil {
+		if bundleSpec.Mode == task.ModeParallel {
+			parallel = true
+		}
+		if bundleSpec.OnFailure == task.OnFailureFailFast {
+			failFast = true
+		}
+	}
+
+	failedTasks := runAllTasks(cmd, tasks, parallel, failFast)
 
 	absOutputDir, err := filepath.Abs(database.OutputDir)
 	if err != nil {
@@ -248,10 +290,10 @@ func setupPromKPIs(flags config.InputFlags) (config.KPIs, error) {
 	return kpis, nil
 }
 
-// runAllTasks executes tasks with continue-on-failure.
-// When parallel is true, tasks run concurrently; otherwise sequentially.
-// Returns the names of any tasks that failed.
-func runAllTasks(cmd *cobra.Command, tasks []task.Task, parallel bool) []string {
+// runAllTasks executes tasks and returns the names of any that failed.
+// parallel: run concurrently instead of sequentially.
+// failFast: stop on first failure (sequential only; ignored when parallel).
+func runAllTasks(cmd *cobra.Command, tasks []task.Task, parallel, failFast bool) []string {
 	var mu sync.Mutex
 	var failedTasks []string
 	var wg sync.WaitGroup
@@ -274,6 +316,9 @@ func runAllTasks(cmd *cobra.Command, tasks []task.Task, parallel bool) []string 
 			go run(t)
 		} else {
 			run(t)
+			if failFast && len(failedTasks) > 0 {
+				break
+			}
 		}
 	}
 

--- a/internal/config/cli_flags.go
+++ b/internal/config/cli_flags.go
@@ -29,8 +29,8 @@ func ValidateFlags(flags InputFlags) error {
 		return fmt.Errorf("invalid flag combination: either provide --token and --thanos-url, or provide --kubeconfig")
 	}
 
-	if !flags.HasAnyTaskConfig() {
-		return fmt.Errorf("at least one task config flag is required (--prom-kpis-config, --oslat-config, --per-node-config, or --recovery-config)")
+	if !flags.HasAnyTaskConfig() && flags.BundleConfig == "" {
+		return fmt.Errorf("at least one task config flag or --bundle is required")
 	}
 
 	if flags.SamplingFreq <= 0 {

--- a/internal/config/cli_flags_test.go
+++ b/internal/config/cli_flags_test.go
@@ -26,7 +26,7 @@ const (
 	errDurationMsg            = "duration must be greater than 0"
 	errInvalidDBTypeMsg       = "invalid db-type: must be 'sqlite' or 'postgres'"
 	errPostgresURLRequiredMsg = "postgres-url is required when db-type=postgres"
-	errNoTaskConfigMsg = "at least one task config flag is required (--prom-kpis-config, --oslat-config, --per-node-config, or --recovery-config)"
+	errNoTaskConfigMsg = "at least one task config flag or --bundle is required"
 )
 
 var _ = Describe("validateFlags test", func() {

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -135,6 +135,7 @@ type InputFlags struct {
 	OslatConfig    string // path to oslat task config file (not yet implemented)
 	PerNodeConfig  string // path to per-node task config file (not yet implemented)
 	RecoveryConfig string // path to recovery task config file (not yet implemented)
+	BundleConfig   string // path to bundle file or directory (--bundle)
 	SingleRun      bool   // collect metrics once and exit
 	Parallel       bool   // run tasks concurrently instead of sequentially
 	SkipPrompts    bool   // skip interactive prompts (--yes/-y)

--- a/internal/task/bundle.go
+++ b/internal/task/bundle.go
@@ -1,0 +1,145 @@
+package task
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/redhat-best-practices-for-k8s/kpi-collection-tool/internal/config"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	ModeSequential = "sequential"
+	ModeParallel   = "parallel"
+
+	OnFailureContinue = "continue"
+	OnFailureFailFast = "fail-fast"
+
+	bundleFileName = "bundle.yaml"
+)
+
+// BundleSpec describes a playlist of tasks and how to execute them.
+type BundleSpec struct {
+	Tasks     []BundleTaskRef `yaml:"tasks"`
+	Mode      string          `yaml:"mode"`
+	OnFailure string          `yaml:"on-failure"`
+
+	// baseDir is the directory containing the bundle file, used to resolve
+	// relative task file paths.
+	baseDir string
+}
+
+// BundleTaskRef is a reference to a single task file inside a bundle.
+type BundleTaskRef struct {
+	File string `yaml:"file"`
+	Type string `yaml:"type"`
+}
+
+// LoadBundle reads a bundle from a file path or a directory containing bundle.yaml.
+func LoadBundle(path string) (BundleSpec, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return BundleSpec{}, fmt.Errorf("cannot access bundle path %q: %w", path, err)
+	}
+
+	bundlePath := path
+	if info.IsDir() {
+		bundlePath = filepath.Join(path, bundleFileName)
+	}
+
+	data, err := os.ReadFile(bundlePath) //#nosec G304 -- path is user-provided CLI input
+	if err != nil {
+		return BundleSpec{}, fmt.Errorf("failed to read bundle file %q: %w", bundlePath, err)
+	}
+
+	var spec BundleSpec
+	if err := yaml.Unmarshal(data, &spec); err != nil {
+		return BundleSpec{}, fmt.Errorf("failed to parse bundle file %q: %w", bundlePath, err)
+	}
+
+	spec.baseDir = filepath.Dir(bundlePath)
+
+	if err := validateBundleSpec(&spec); err != nil {
+		return BundleSpec{}, err
+	}
+
+	return spec, nil
+}
+
+func validateBundleSpec(spec *BundleSpec) error {
+	if len(spec.Tasks) == 0 {
+		return fmt.Errorf("bundle has no tasks defined")
+	}
+
+	if spec.Mode == "" {
+		spec.Mode = ModeSequential
+	}
+	if spec.Mode != ModeSequential && spec.Mode != ModeParallel {
+		return fmt.Errorf("invalid bundle mode %q: must be %q or %q", spec.Mode, ModeSequential, ModeParallel)
+	}
+
+	if spec.OnFailure == "" {
+		spec.OnFailure = OnFailureContinue
+	}
+	if spec.OnFailure != OnFailureContinue && spec.OnFailure != OnFailureFailFast {
+		return fmt.Errorf("invalid bundle on-failure %q: must be %q or %q", spec.OnFailure, OnFailureContinue, OnFailureFailFast)
+	}
+
+	for i, ref := range spec.Tasks {
+		if ref.File == "" {
+			return fmt.Errorf("bundle task #%d has no file specified", i+1)
+		}
+	}
+
+	return nil
+}
+
+// ResolveBundleTasks turns a BundleSpec into a list of executable Tasks.
+// Only prom-kpis is supported today; other types return an error.
+func ResolveBundleTasks(spec BundleSpec, flags config.InputFlags, kpis config.KPIs) ([]Task, error) {
+	var tasks []Task
+
+	for _, ref := range spec.Tasks {
+		taskType := ref.Type
+		if taskType == "" {
+			taskType = inferTypeFromFilename(ref.File)
+		}
+
+		taskFile := ref.File
+		if !filepath.IsAbs(taskFile) {
+			taskFile = filepath.Join(spec.baseDir, taskFile)
+		}
+
+		switch taskType {
+		case "prom-kpis":
+			promKPIs, err := config.LoadKPIs(taskFile)
+			if err != nil {
+				return nil, fmt.Errorf("bundle task %q: failed to load KPIs: %w", ref.File, err)
+			}
+			tasks = append(tasks, NewPromKPITask(promKPIs, flags))
+
+		// TODO: implement oslat, per-node, recovery task types
+		default:
+			return nil, fmt.Errorf("bundle task %q: task type %q is not yet supported", ref.File, taskType)
+		}
+	}
+
+	return tasks, nil
+}
+
+func inferTypeFromFilename(filename string) string {
+	switch base := filepath.Base(filename); base {
+	case "kpis.yaml", "kpis.yml":
+		return "prom-kpis"
+	case "oslat.yaml", "oslat.yml":
+		return "oslat"
+	case "per-node.yaml", "per-node.yml":
+		return "per-node"
+	case "recovery.yaml", "recovery.yml":
+		return "recovery"
+	default:
+		return ""
+	}
+}

--- a/internal/task/bundle_test.go
+++ b/internal/task/bundle_test.go
@@ -1,0 +1,162 @@
+package task_test
+
+import (
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/redhat-best-practices-for-k8s/kpi-collection-tool/internal/config"
+	"github.com/redhat-best-practices-for-k8s/kpi-collection-tool/internal/task"
+)
+
+func defaultFlags() config.InputFlags {
+	return config.InputFlags{}
+}
+
+func defaultKPIs() config.KPIs {
+	return config.KPIs{}
+}
+
+var _ = Describe("Bundle", func() {
+
+	var tmpDir string
+
+	BeforeEach(func() {
+		var err error
+		tmpDir, err = os.MkdirTemp("", "bundle-test-*")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		Expect(os.RemoveAll(tmpDir)).To(Succeed())
+	})
+
+	writeFile := func(name, content string) string {
+		path := filepath.Join(tmpDir, name)
+		Expect(os.WriteFile(path, []byte(content), 0644)).To(Succeed())
+		return path
+	}
+
+	Describe("LoadBundle", func() {
+		It("loads a valid bundle file", func() {
+			writeFile("bundle.yaml", `
+tasks:
+  - file: kpis.yaml
+    type: prom-kpis
+mode: sequential
+on-failure: continue
+`)
+			spec, err := task.LoadBundle(filepath.Join(tmpDir, "bundle.yaml"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(spec.Tasks).To(HaveLen(1))
+			Expect(spec.Tasks[0].File).To(Equal("kpis.yaml"))
+			Expect(spec.Tasks[0].Type).To(Equal("prom-kpis"))
+			Expect(spec.Mode).To(Equal("sequential"))
+			Expect(spec.OnFailure).To(Equal("continue"))
+		})
+
+		It("loads from a directory containing bundle.yaml", func() {
+			writeFile("bundle.yaml", `
+tasks:
+  - file: kpis.yaml
+    type: prom-kpis
+`)
+			spec, err := task.LoadBundle(tmpDir)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(spec.Tasks).To(HaveLen(1))
+		})
+
+		It("defaults mode to sequential and on-failure to continue", func() {
+			writeFile("bundle.yaml", `
+tasks:
+  - file: kpis.yaml
+    type: prom-kpis
+`)
+			spec, err := task.LoadBundle(filepath.Join(tmpDir, "bundle.yaml"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(spec.Mode).To(Equal("sequential"))
+			Expect(spec.OnFailure).To(Equal("continue"))
+		})
+
+		It("accepts parallel mode", func() {
+			writeFile("bundle.yaml", `
+tasks:
+  - file: kpis.yaml
+    type: prom-kpis
+mode: parallel
+on-failure: fail-fast
+`)
+			spec, err := task.LoadBundle(filepath.Join(tmpDir, "bundle.yaml"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(spec.Mode).To(Equal("parallel"))
+			Expect(spec.OnFailure).To(Equal("fail-fast"))
+		})
+
+		It("rejects an empty task list", func() {
+			writeFile("bundle.yaml", `
+tasks: []
+`)
+			_, err := task.LoadBundle(filepath.Join(tmpDir, "bundle.yaml"))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("no tasks defined"))
+		})
+
+		It("rejects an invalid mode", func() {
+			writeFile("bundle.yaml", `
+tasks:
+  - file: kpis.yaml
+mode: banana
+`)
+			_, err := task.LoadBundle(filepath.Join(tmpDir, "bundle.yaml"))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("invalid bundle mode"))
+		})
+
+		It("rejects an invalid on-failure policy", func() {
+			writeFile("bundle.yaml", `
+tasks:
+  - file: kpis.yaml
+on-failure: maybe
+`)
+			_, err := task.LoadBundle(filepath.Join(tmpDir, "bundle.yaml"))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("invalid bundle on-failure"))
+		})
+
+		It("rejects a task with no file", func() {
+			writeFile("bundle.yaml", `
+tasks:
+  - type: prom-kpis
+`)
+			_, err := task.LoadBundle(filepath.Join(tmpDir, "bundle.yaml"))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("no file specified"))
+		})
+
+		It("returns error for missing path", func() {
+			_, err := task.LoadBundle("/nonexistent/path")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("cannot access"))
+		})
+	})
+
+	Describe("inferTypeFromFilename", func() {
+		It("handles unsupported task type in bundle", func() {
+			writeFile("bundle.yaml", `
+tasks:
+  - file: custom.yaml
+    type: custom-thing
+`)
+			writeFile("custom.yaml", "data: true")
+
+			spec, err := task.LoadBundle(filepath.Join(tmpDir, "bundle.yaml"))
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = task.ResolveBundleTasks(spec, defaultFlags(), defaultKPIs())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("not yet supported"))
+		})
+	})
+})


### PR DESCRIPTION
### Summary

- Add `--bundle` flag to `run` - accepts a `bundle.yaml` file or a directory containing one
- Bundle spec defines: task file references, execution mode (sequential/parallel), and on-failure policy (continue/fail-fast)
- `--bundle` is mutually exclusive with typed config flags (`--prom-kpis-config`, `--oslat-config`, etc.)
- Type inference from filename convention as fallback when `type:` is not set in the bundle

### Caveats

This is part of an incremental refactoring toward multi-task/bundle support. Known limitations in the current state:

1. **Only `prom-kpis` task type is wired** - oslat, per-node, and recovery return "not yet supported" errors (both via typed flags and inside bundles)
2. **Prom-specific flags (`--frequency`, `--duration`, `--once`) are still global CLI flags** - they are not yet configurable per-task inside the YAML. This is a known dilemma documented. End-goal: YAML carries all config, CLI flags remain as overrides for backward compatibility
3. **No task-level validation inside bundles** - bundle loading validates structure (mode, on-failure, file refs), but does not validate individual task YAML contents until execution
4. **Fail-fast only applies to sequential mode** - when `mode: parallel`, all tasks run regardless of failures
5. **No example bundle YAMLs in the repo yet** - reference bundle/task YAML files will be added in a future PR

### Backward Compatibility

Existing `run --kpis-file` / `run --prom-kpis-config` usage is unchanged. `--bundle` is opt-in.