### PR TITLE
Extend Prom KPI YAML with execution config

### DIFF
--- a/internal/commands/run.go
+++ b/internal/commands/run.go
@@ -165,7 +165,7 @@ func runTasks(cmd *cobra.Command, args []string) error {
 	var kpis config.KPIs
 	if flags.PromKPIsConfig != "" {
 		var setupErr error
-		kpis, setupErr = setupPromKPIs(flags)
+		kpis, setupErr = setupPromKPIs(cmd, &flags)
 		if setupErr != nil {
 			return setupErr
 		}
@@ -210,12 +210,27 @@ func runTasks(cmd *cobra.Command, args []string) error {
 }
 
 // setupPromKPIs loads, validates, and prepares Prom KPI queries.
-func setupPromKPIs(flags config.InputFlags) (config.KPIs, error) {
+// It also merges any YAML-level config into the flags (YAML values
+// are only applied when the corresponding CLI flag was not explicitly set).
+func setupPromKPIs(cmd *cobra.Command, flags *config.InputFlags) (config.KPIs, error) {
 	kpis, err := config.LoadKPIs(flags.PromKPIsConfig)
 	if err != nil {
 		return config.KPIs{}, fmt.Errorf("failed to load KPI queries: %w", err)
 	}
 	log.Printf("Loaded KPIs from %s", flags.PromKPIsConfig)
+
+	// Merge YAML config into flags (explicit CLI > YAML > default)
+	if cfg := kpis.Config; cfg != nil {
+		if cfg.Frequency != nil && !cmd.Flags().Changed("frequency") {
+			flags.SamplingFreq = cfg.Frequency.Duration
+		}
+		if cfg.Duration != nil && !cmd.Flags().Changed("duration") {
+			flags.Duration = cfg.Duration.Duration
+		}
+		if cfg.Once != nil && !cmd.Flags().Changed("once") {
+			flags.SingleRun = *cfg.Once
+		}
+	}
 
 	if validationErrors := config.ValidateKPIs(kpis); len(validationErrors) > 0 {
 		fmt.Println("KPI validation errors:")
@@ -232,15 +247,15 @@ func setupPromKPIs(flags config.InputFlags) (config.KPIs, error) {
 		}
 	}
 
-	kpis, err = substituteCPUsIfNeeded(kpis, flags)
+	kpis, err = substituteCPUsIfNeeded(kpis, *flags)
 	if err != nil {
 		return config.KPIs{}, err
 	}
 
 	if !flags.SingleRun {
-		warnFrequencyExceedsDuration(kpis, flags)
+		warnFrequencyExceedsDuration(kpis, *flags)
 
-		if err := validateRangeFrequency(kpis, flags); err != nil {
+		if err := validateRangeFrequency(kpis, *flags); err != nil {
 			return config.KPIs{}, err
 		}
 	}

--- a/internal/config/kpis_loader_test.go
+++ b/internal/config/kpis_loader_test.go
@@ -1094,3 +1094,78 @@ var _ = Describe("KPIs Loader", func() {
 		})
 	})
 })
+
+var _ = Describe("KPIs YAML with type and config", func() {
+	var tmpDir string
+
+	BeforeEach(func() {
+		var err error
+		tmpDir, err = os.MkdirTemp("", "kpis-config-test-*")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		err := os.RemoveAll(tmpDir)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("loads YAML with type and config block", func() {
+		yaml := `type: prom-kpis
+config:
+  frequency: 30s
+  duration: 2h
+  once: true
+kpis:
+  - id: test
+    promquery: up
+`
+		path := filepath.Join(tmpDir, "kpis.yaml")
+		Expect(os.WriteFile(path, []byte(yaml), 0644)).To(Succeed())
+
+		kpis, err := LoadKPIs(path)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(kpis.Type).To(Equal("prom-kpis"))
+		Expect(kpis.Config).NotTo(BeNil())
+		Expect(kpis.Config.Frequency.Duration).To(Equal(30 * time.Second))
+		Expect(kpis.Config.Duration.Duration).To(Equal(2 * time.Hour))
+		Expect(*kpis.Config.Once).To(BeTrue())
+		Expect(kpis.Queries).To(HaveLen(1))
+	})
+
+	It("loads YAML without type or config (backward compatible)", func() {
+		yaml := `kpis:
+  - id: test
+    promquery: up
+`
+		path := filepath.Join(tmpDir, "kpis.yaml")
+		Expect(os.WriteFile(path, []byte(yaml), 0644)).To(Succeed())
+
+		kpis, err := LoadKPIs(path)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(kpis.Type).To(BeEmpty())
+		Expect(kpis.Config).To(BeNil())
+		Expect(kpis.Queries).To(HaveLen(1))
+	})
+
+	It("loads YAML with partial config", func() {
+		yaml := `config:
+  once: true
+kpis:
+  - id: test
+    promquery: up
+`
+		path := filepath.Join(tmpDir, "kpis.yaml")
+		Expect(os.WriteFile(path, []byte(yaml), 0644)).To(Succeed())
+
+		kpis, err := LoadKPIs(path)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(kpis.Config).NotTo(BeNil())
+		Expect(kpis.Config.Frequency).To(BeNil())
+		Expect(kpis.Config.Duration).To(BeNil())
+		Expect(*kpis.Config.Once).To(BeTrue())
+	})
+})
+

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -161,10 +161,20 @@ func (q *Query) IsRunOnce() bool {
 	return q.RunOnce != nil && *q.RunOnce
 }
 
+// PromConfig holds optional execution settings that can be specified
+// in the KPI YAML file instead of (or in addition to) CLI flags.
+type PromConfig struct {
+	Frequency *Duration `yaml:"frequency,omitempty"`
+	Duration  *Duration `yaml:"duration,omitempty"`
+	Once      *bool     `yaml:"once,omitempty"`
+}
+
 // KPIs represents the structure of the KPI configuration file containing
 // the list of KPI queries to be executed against Prometheus/Thanos
 type KPIs struct {
-	Queries []Query `yaml:"kpis"`
+	Type    string      `yaml:"type,omitempty"`
+	Config  *PromConfig `yaml:"config,omitempty"`
+	Queries []Query     `yaml:"kpis"`
 }
 
 // GetEffectiveFrequency returns the sample frequency for this query,


### PR DESCRIPTION
### Summary

Part of the multi-task runner refactoring. Adds optional `type` and `config` block to the Prom KPI YAML file, allowing execution settings (frequency, duration, once) to be specified in the YAML instead of CLI flags. This is a step toward making task YAMLs self-contained, so a bundle run doesn't require task-specific CLI flags.

```yaml
type: prom-kpis  # optional, defaults to prom-kpis

config:          # optional
  frequency: 30s
  duration: 2h
  once: true

kpis:
  - id: test-up
    promquery: up
```

**Precedence:** explicit CLI flag > YAML config > built-in default.

A YAML value is only used when the user did not explicitly pass the corresponding flag.

### Backward Compatibility

Existing YAML files without `type:` or `config:` work unchanged. All CLI flags remain fully supported.